### PR TITLE
[new] Add option to export integration test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ Run tests using
 pytest -v
 ```
 
+Integration test cases can be exported to a directory using
+
+```sh
+pytest --export-test-cases=guppy-exports
+
+```
+which will create a directory `./guppy-exports` populated with hugr modules serialised in msgpack.
+
 ## Packaging
 
 ```sh

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+from pathlib import Path
+import argparse
+
+def pytest_addoption(parser):
+    def dir_path(s):
+        path = Path(s)
+        if not path.exists() or path.is_dir():
+            return path
+        raise argparse.ArgumentTypeError(f"export-test-cases dir:{path} exists and is not a directory")
+
+    parser.addoption("--export-test-cases", action="store", type=dir_path, help="A directory to which to export test cases")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,21 @@
+import pytest
+
+from . import util
+
+@pytest.fixture
+def export_test_cases_dir(request):
+    r = request.config.getoption('--export-test-cases')
+    if r and not r.exists():
+        r.mkdir(parents=True)
+    return r
+
+
+@pytest.fixture
+def validate(request, export_test_cases_dir):
+    def validate_impl(hugr):
+        bs = hugr.serialize()
+        util.validate_bytes(bs)
+        if export_test_cases_dir:
+            export_file = export_test_cases_dir / f"{request.node.name}.msgpack"
+            export_file.write_bytes(bs)
+    return validate_impl

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -1,8 +1,7 @@
 from guppy.compiler import guppy
-from tests.integration.util import validate
 
 
-def test_id():
+def test_id(validate):
     @guppy
     def identity(x: int) -> int:
         return x
@@ -10,7 +9,7 @@ def test_id():
     validate(identity)
 
 
-def test_void():
+def test_void(validate):
     @guppy
     def void() -> None:
         return
@@ -18,7 +17,7 @@ def test_void():
     validate(void)
 
 
-def test_copy():
+def test_copy(validate):
     @guppy
     def copy(x: int) -> (int, int):
         return x, x
@@ -26,7 +25,7 @@ def test_copy():
     validate(copy)
 
 
-def test_discard():
+def test_discard(validate):
     @guppy
     def discard(x: int) -> None:
         return
@@ -34,7 +33,7 @@ def test_discard():
     validate(discard)
 
 
-def test_implicit_return():
+def test_implicit_return(validate):
     @guppy
     def ret() -> None:
         pass
@@ -42,7 +41,7 @@ def test_implicit_return():
     validate(ret)
 
 
-def test_assign():
+def test_assign(validate):
     @guppy
     def foo(x: bool) -> bool:
         y = x
@@ -51,7 +50,7 @@ def test_assign():
     validate(foo)
 
 
-def test_assign_expr():
+def test_assign_expr(validate):
     @guppy
     def foo(x: bool) -> bool:
         (y := x)

--- a/tests/integration/util.py
+++ b/tests/integration/util.py
@@ -5,8 +5,10 @@ from guppy.hugr.hugr import Hugr
 
 
 def validate(hugr: Hugr):
-    validator.validate(hugr.serialize())
+    validate_bytes(hugr.serialize())
 
+def validate_bytes(hugr: bytes):
+    validator.validate(hugr)
 
 class Decorator:
     def __matmul__(self, other):


### PR DESCRIPTION
pytest_addoption only seems to work in the root of the test suite.

If you agree with this path forward I'll do the rest of the tests.