### PR TITLE
chore: Bump Hugr version and add dummy extension reqs

### DIFF
--- a/validator/Cargo.lock
+++ b/validator/Cargo.lock
@@ -82,13 +82,24 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "delegate"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee5df75c70b95bd3aacc8e2fd098797692fb1d54121019c4de481e42f04c8a1"
+checksum = "b4801d755ab05b6e25cbbf1afc342993aafa00e572409f9ee21633a19e609d9f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
+]
+
+[[package]]
+name = "delegate"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e018fccbeeb50ff26562ece792ed06659b9c2dae79ece77c4456bb10d9bf79b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -165,6 +176,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "html-escape"
@@ -342,13 +359,13 @@ dependencies = [
 
 [[package]]
 name = "portgraph"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be897a76c32073a098999883efd53f5520c188e77192136ce2628ecedf74386"
+checksum = "e79e1dbdf59146cb0941cbab3af7ecfe028c0976d96dc110964d770b88783b3b"
 dependencies = [
  "bitvec",
  "context-iterators",
- "delegate",
+ "delegate 0.11.0",
  "petgraph",
  "serde",
  "thiserror",
@@ -426,12 +443,12 @@ dependencies = [
 [[package]]
 name = "quantinuum-hugr"
 version = "0.1.0"
-source = "git+https://github.com/CQCL-DEV/hugr.git?rev=d00dc3f1d6000349404f01a6bfc6bf94a32b9956#d00dc3f1d6000349404f01a6bfc6bf94a32b9956"
+source = "git+https://github.com/CQCL-DEV/hugr.git?rev=4607d64151072ae453a31f49c7cf72a4002e1ca0#4607d64151072ae453a31f49c7cf72a4002e1ca0"
 dependencies = [
  "bitvec",
  "cgmath",
  "context-iterators",
- "delegate",
+ "delegate 0.12.0",
  "derive_more",
  "downcast-rs",
  "enum_dispatch",
@@ -448,6 +465,8 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "smol_str",
+ "strum",
+ "strum_macros",
  "thiserror",
  "typetag",
 ]
@@ -617,6 +636,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74212e6bbe9a4352329b2f68ba3130c15a3f26fe88ff22dbdc6cdd58fa85e99c"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.18",
 ]
 
 [[package]]

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -10,6 +10,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = "0.19.0"
-quantinuum-hugr = { git = "https://github.com/CQCL-DEV/hugr.git", rev = "d00dc3f1d6000349404f01a6bfc6bf94a32b9956" }
+quantinuum-hugr = { git = "https://github.com/CQCL-DEV/hugr.git", rev = "4607d64151072ae453a31f49c7cf72a4002e1ca0" }
 rmp-serde = "1.1.1"
 lazy_static = "1.4.0"

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -10,8 +10,8 @@ lazy_static! {
         logic::EXTENSION.to_owned(),
         int_types::extension(),
         int_ops::EXTENSION.to_owned(),
-        float_types::extension(),
-        float_ops::extension()
+        float_types::EXTENSION.to_owned(),
+        float_ops::EXTENSION.to_owned()
     ])
     .unwrap();
 }


### PR DESCRIPTION
Some recent changes from https://github.com/CQCL/hugr/pull/733 introduce implicit extension requirements into Hugrs that would need to be propagated through the graph in order to satisfy the validator.

The hope is that we can use Hugr's extension inference mechanism to resolve this, but unfortunately there are still some places where requirements cannot be inferred (see https://github.com/CQCL/hugr/issues/640).

Therefore, we over-approximate for now and set *all* Hugr standard extensions as being required for every node. This is a temporary fix until inference can handle all cases.