### PR TITLE
fix: Return `in_port`/`out_port` for order edges

### DIFF
--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -33,7 +33,6 @@ def test_discard(validate):
         return
 
     validate(discard)
-    validate(discard)
 
 
 def test_implicit_return(validate):


### PR DESCRIPTION
The code crashed instead with an index-out-of-bounds error when trying to the get `out/in_port` of an order edge (which has `key=-1`). Fixes #82.

This is an attempt for a fix;
I'm not sure if we should assign `NoneType` as the type of order edges. Should the type field be `Optional` instead?