### PR TITLE
fix: Mypy tket2 error

### DIFF
--- a/guppylang/compiler/expr_compiler.py
+++ b/guppylang/compiler/expr_compiler.py
@@ -408,7 +408,7 @@ def python_value_to_hugr(v: Any, exp_ty: Type) -> ops.Value | None:
                         Tk2Circuit,
                     )
 
-                    hugr = json.loads(Tk2Circuit(v).to_hugr_json())
+                    hugr = json.loads(Tk2Circuit(v).to_hugr_json())  # type: ignore[attr-defined]
                     return ops.Value(ops.FunctionValue(hugr=hugr))
             except ImportError:
                 pass


### PR DESCRIPTION
For some reason, mypy started complaining that it can no longer find `Tk2Circuit.to_hugr_json`.

I believe this was introduced in #201 but not flagged because of CI caching?