### PR TITLE
test: update tests to use the built-in `py` export

### DIFF
--- a/tests/integration/test_py.py
+++ b/tests/integration/test_py.py
@@ -4,8 +4,8 @@ import pytest
 
 from guppylang.decorator import guppy
 from guppylang.module import GuppyModule
+from guppylang.prelude.builtins import py
 from guppylang.prelude.quantum import qubit, quantum
-from tests.integration.util import py
 from tests.util import compile_guppy
 
 tket2_installed = find_spec("tket2") is not None

--- a/tests/integration/util.py
+++ b/tests/integration/util.py
@@ -1,6 +1,3 @@
-from typing import Any
-
-
 class Decorator:
     def __matmul__(self, other):
         return None
@@ -9,8 +6,3 @@ class Decorator:
 # Dummy names to import to avoid errors for `_@functional` pseudo-decorator:
 functional = Decorator()
 _ = Decorator()
-
-
-def py(*args: Any) -> Any:
-    """Dummy function to import to avoid errors for `py(...)` expressions"""
-    raise NotImplementedError


### PR DESCRIPTION
It was introduced recently in #229