### PR TITLE
feat: Add extern symbols

### DIFF
--- a/guppylang/decorator.py
+++ b/guppylang/decorator.py
@@ -231,9 +231,9 @@ class _Guppy:
     def extern(
         self,
         module: GuppyModule,
-        name: str,
+        symbol: str,
         ty: str,
-        symbol: str | None = None,
+        name: str | None = None,
         constant: bool = True,
     ) -> RawExternDef:
         """Adds an extern symbol to a module."""
@@ -260,7 +260,7 @@ class _Guppy:
                         node.end_col_offset = len(source_lines[info.lineno - 1])
 
         defn = RawExternDef(
-            DefId.fresh(module), name, None, symbol or name, constant, type_ast
+            DefId.fresh(module), name or symbol, None, symbol, constant, type_ast
         )
         module.register_def(defn)
         return defn

--- a/guppylang/decorator.py
+++ b/guppylang/decorator.py
@@ -231,9 +231,9 @@ class _Guppy:
     def extern(
         self,
         module: GuppyModule,
-        symbol: str,
+        name: str,
         ty: str,
-        name: str | None = None,
+        symbol: str | None = None,
         constant: bool = True,
     ) -> RawExternDef:
         """Adds an extern symbol to a module."""
@@ -260,7 +260,7 @@ class _Guppy:
                         node.end_col_offset = len(source_lines[info.lineno - 1])
 
         defn = RawExternDef(
-            DefId.fresh(module), name or symbol, None, symbol, constant, type_ast
+            DefId.fresh(module), name, None, symbol or name, constant, type_ast
         )
         module.register_def(defn)
         return defn

--- a/guppylang/definition/extern.py
+++ b/guppylang/definition/extern.py
@@ -1,0 +1,77 @@
+import ast
+from dataclasses import dataclass, field
+
+from hugr.serialization import ops
+
+from guppylang.ast_util import AstNode
+from guppylang.checker.core import Globals
+from guppylang.compiler.core import CompiledGlobals, DFContainer
+from guppylang.definition.common import CompilableDef, ParsableDef
+from guppylang.definition.value import CompiledValueDef, ValueDef
+from guppylang.hugr_builder.hugr import Hugr, Node, OutPortV, VNode
+from guppylang.tys.parsing import type_from_ast
+
+
+@dataclass(frozen=True)
+class RawExternDef(ParsableDef):
+    """A raw extern symbol definition provided by the user."""
+
+    symbol: str
+    constant: bool
+    type_ast: ast.expr
+
+    description: str = field(default="extern", init=False)
+
+    def parse(self, globals: Globals) -> "ExternDef":
+        """Parses and checks the user-provided signature of the function."""
+        return ExternDef(
+            self.id,
+            self.name,
+            self.defined_at,
+            type_from_ast(self.type_ast, globals, None),
+            self.symbol,
+            self.constant,
+            self.type_ast,
+        )
+
+
+@dataclass(frozen=True)
+class ExternDef(RawExternDef, ValueDef, CompilableDef):
+    """An extern symbol definition."""
+
+    def compile_outer(self, graph: Hugr, parent: Node) -> "CompiledExternDef":
+        """Adds a Hugr constant node for the extern definition to the provided graph."""
+        custom_const = {
+            "symbol": self.symbol,
+            "typ": self.ty.to_hugr(),
+            "constant": self.constant,
+        }
+        value = ops.ExtensionValue(
+            extensions=["prelude"],
+            typ=self.ty.to_hugr(),
+            value=ops.CustomConst(c="ConstExternalSymbol", v=custom_const),
+        )
+        const_node = graph.add_constant(ops.Value(value), self.ty, parent)
+        return CompiledExternDef(
+            self.id,
+            self.name,
+            self.defined_at,
+            self.ty,
+            self.symbol,
+            self.constant,
+            self.type_ast,
+            const_node,
+        )
+
+
+@dataclass(frozen=True)
+class CompiledExternDef(ExternDef, CompiledValueDef):
+    """An extern symbol definition that has been compiled to a Hugr constant."""
+
+    const_node: VNode
+
+    def load(
+        self, dfg: DFContainer, graph: Hugr, globals: CompiledGlobals, node: AstNode
+    ) -> OutPortV:
+        """Loads the extern value into a local Hugr dataflow graph."""
+        return graph.add_load_constant(self.const_node.out_port(0)).out_port(0)

--- a/tests/error/misc_errors/extern_bad_type.err
+++ b/tests/error/misc_errors/extern_bad_type.err
@@ -1,0 +1,7 @@
+Guppy compilation failed. Error in file $FILE:9
+
+7:    module = GuppyModule("test")
+8:    
+9:    x = guppy.extern(module, "x", ty="float[int]")
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+GuppyError: Type `float` is not parameterized

--- a/tests/error/misc_errors/extern_bad_type.err
+++ b/tests/error/misc_errors/extern_bad_type.err
@@ -2,6 +2,6 @@ Guppy compilation failed. Error in file $FILE:9
 
 7:    module = GuppyModule("test")
 8:    
-9:    x = guppy.extern(module, "x", ty="float[int]")
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+9:    guppy.extern(module, "x", ty="float[int]")
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 GuppyError: Type `float` is not parameterized

--- a/tests/error/misc_errors/extern_bad_type.py
+++ b/tests/error/misc_errors/extern_bad_type.py
@@ -1,0 +1,12 @@
+from guppylang.decorator import guppy
+from guppylang.module import GuppyModule
+from guppylang.prelude.quantum import qubit
+
+import guppylang.prelude.quantum as quantum
+
+
+module = GuppyModule("test")
+
+x = guppy.extern(module, "x", ty="float[int]")
+
+module.compile()

--- a/tests/error/misc_errors/extern_bad_type.py
+++ b/tests/error/misc_errors/extern_bad_type.py
@@ -7,6 +7,6 @@ import guppylang.prelude.quantum as quantum
 
 module = GuppyModule("test")
 
-x = guppy.extern(module, "x", ty="float[int]")
+guppy.extern(module, "x", ty="float[int]")
 
 module.compile()

--- a/tests/error/test_misc_errors.py
+++ b/tests/error/test_misc_errors.py
@@ -29,4 +29,4 @@ def test_extern_bad_type_syntax():
     module = GuppyModule("test")
 
     with pytest.raises(GuppyError, match="Not a valid Guppy type: `foo bar`"):
-        guppy.extern(module, symbol="x", ty="foo bar")
+        guppy.extern(module, name="x", ty="foo bar")

--- a/tests/error/test_misc_errors.py
+++ b/tests/error/test_misc_errors.py
@@ -29,4 +29,4 @@ def test_extern_bad_type_syntax():
     module = GuppyModule("test")
 
     with pytest.raises(GuppyError, match="Not a valid Guppy type: `foo bar`"):
-        guppy.extern(module, name="x", ty="foo bar")
+        guppy.extern(module, symbol="x", ty="foo bar")

--- a/tests/error/test_misc_errors.py
+++ b/tests/error/test_misc_errors.py
@@ -1,6 +1,8 @@
 import pathlib
 import pytest
 
+from guppylang import GuppyModule, guppy
+from guppylang.error import GuppyError
 from tests.error.util import run_error_test
 
 path = pathlib.Path(__file__).parent.resolve() / "misc_errors"
@@ -19,5 +21,12 @@ files = [str(f) for f in files]
 
 
 @pytest.mark.parametrize("file", files)
-def test_type_errors(file, capsys):
+def test_misc_errors(file, capsys):
     run_error_test(file, capsys)
+
+
+def test_extern_bad_type_syntax():
+    module = GuppyModule("test")
+
+    with pytest.raises(GuppyError, match="Not a valid Guppy type: `foo bar`"):
+        guppy.extern(module, name="x", ty="foo bar")

--- a/tests/integration/test_extern.py
+++ b/tests/integration/test_extern.py
@@ -5,11 +5,11 @@ from guppylang.module import GuppyModule
 def test_extern_float(validate):
     module = GuppyModule("module")
 
-    ext = guppy.extern(module, "ext", ty="float")
+    guppy.extern(module, "ext", ty="float")
 
     @guppy(module)
     def main() -> float:
-        return ext + ext
+        return ext + ext  # noqa: F821
 
     validate(module.compile())
 
@@ -17,11 +17,11 @@ def test_extern_float(validate):
 def test_extern_tuple(validate):
     module = GuppyModule("module")
 
-    ext = guppy.extern(module, "ext", ty="tuple[int, float]")
+    guppy.extern(module, "ext", ty="tuple[int, float]")
 
     @guppy(module)
     def main() -> float:
-        x, y = ext
+        x, y = ext  # noqa: F821
         return x + y
 
     validate(module.compile())

--- a/tests/integration/test_extern.py
+++ b/tests/integration/test_extern.py
@@ -1,0 +1,27 @@
+from guppylang.decorator import guppy
+from guppylang.module import GuppyModule
+
+
+def test_extern_float(validate):
+    module = GuppyModule("module")
+
+    ext = guppy.extern(module, "ext", ty="float")
+
+    @guppy(module)
+    def main() -> float:
+        return ext + ext
+
+    validate(module.compile())
+
+
+def test_extern_tuple(validate):
+    module = GuppyModule("module")
+
+    ext = guppy.extern(module, "ext", ty="tuple[int, float]")
+
+    @guppy(module)
+    def main() -> float:
+        x, y = ext
+        return x + y
+
+    validate(module.compile())

--- a/tests/integration/test_extern.py
+++ b/tests/integration/test_extern.py
@@ -25,3 +25,15 @@ def test_extern_tuple(validate):
         return x + y
 
     validate(module.compile())
+
+
+def test_extern_name(validate):
+    module = GuppyModule("module")
+
+    ext = guppy.extern(module, "1$weird%symbol", ty="int", name="ext")
+
+    @guppy(module)
+    def main() -> int:
+        return ext
+
+    validate(module.compile())

--- a/tests/integration/test_extern.py
+++ b/tests/integration/test_extern.py
@@ -25,15 +25,3 @@ def test_extern_tuple(validate):
         return x + y
 
     validate(module.compile())
-
-
-def test_extern_name(validate):
-    module = GuppyModule("module")
-
-    ext = guppy.extern(module, "1$weird%symbol", ty="int", name="ext")
-
-    @guppy(module)
-    def main() -> int:
-        return ext
-
-    validate(module.compile())


### PR DESCRIPTION
Closes #169

It's a bit annoying that the type has to be provided as a string, but we can't represent Guppy types as Python objects on user-level yet.