### PR TITLE
fix:  Pass strict parameter to zip function call, as recommended per the B905 linting rule

### DIFF
--- a/guppylang/cfg/builder.py
+++ b/guppylang/cfg/builder.py
@@ -440,7 +440,7 @@ class BranchBuilder(AstVisitor[None]):
                     end_lineno=right.end_lineno,
                     end_col_offset=right.end_col_offset,
                 )
-                for left, op, right in zip(comparators[:-1], node.ops, comparators[1:])
+                for left, op, right in zip(comparators[:-1], node.ops, comparators[1:], strict=True)
             ]
             conj = ast.BoolOp(op=ast.And(), values=values)
             set_location_from(conj, node)

--- a/guppylang/cfg/builder.py
+++ b/guppylang/cfg/builder.py
@@ -440,7 +440,9 @@ class BranchBuilder(AstVisitor[None]):
                     end_lineno=right.end_lineno,
                     end_col_offset=right.end_col_offset,
                 )
-                for left, op, right in zip(comparators[:-1], node.ops, comparators[1:], strict=True)
+                for left, op, right in zip(
+                    comparators[:-1], node.ops, comparators[1:], strict=True
+                )
             ]
             conj = ast.BoolOp(op=ast.And(), values=values)
             set_location_from(conj, node)

--- a/guppylang/checker/expr_checker.py
+++ b/guppylang/checker/expr_checker.py
@@ -687,7 +687,7 @@ def type_check_args(
     check_num_args(len(func_ty.inputs), len(inputs), node)
 
     new_args: list[ast.expr] = []
-    for inp, ty in zip(inputs, func_ty.inputs):
+    for inp, ty in zip(inputs, func_ty.inputs, strict=True):
         a, s = ExprChecker(ctx).check(inp, ty.substitute(subst), "argument")
         new_args.append(a)
         subst |= s

--- a/guppylang/checker/func_checker.py
+++ b/guppylang/checker/func_checker.py
@@ -88,7 +88,9 @@ def check_nested_func_def(
     # Construct inputs for checking the body CFG
     inputs = list(captured.values()) + [
         Variable(x, ty, func_def.args.args[i], None)
-        for i, (x, ty) in enumerate(zip(func_ty.input_names, func_ty.inputs, strict=True))
+        for i, (x, ty) in enumerate(
+            zip(func_ty.input_names, func_ty.inputs, strict=True)
+        )
     ]
     def_id = DefId.fresh()
     globals = ctx.globals

--- a/guppylang/checker/func_checker.py
+++ b/guppylang/checker/func_checker.py
@@ -34,7 +34,7 @@ def check_global_func_def(
     cfg = CFGBuilder().build(func_def.body, returns_none, globals)
     inputs = [
         Variable(x, ty, loc, None)
-        for x, ty, loc in zip(ty.input_names, ty.inputs, args)
+        for x, ty, loc in zip(ty.input_names, ty.inputs, args, strict=True)
     ]
     return check_cfg(cfg, inputs, ty.output, globals)
 
@@ -88,7 +88,7 @@ def check_nested_func_def(
     # Construct inputs for checking the body CFG
     inputs = list(captured.values()) + [
         Variable(x, ty, func_def.args.args[i], None)
-        for i, (x, ty) in enumerate(zip(func_ty.input_names, func_ty.inputs))
+        for i, (x, ty) in enumerate(zip(func_ty.input_names, func_ty.inputs, strict=True))
     ]
     def_id = DefId.fresh()
     globals = ctx.globals

--- a/guppylang/checker/stmt_checker.py
+++ b/guppylang/checker/stmt_checker.py
@@ -71,7 +71,7 @@ class StmtChecker(AstVisitor[BBStatement]):
                         f"(expected {n}, got {m})",
                         node,
                     )
-                for pat, el_ty in zip(elts, tys):
+                for pat, el_ty in zip(elts, tys, strict=True):
                     self._check_assign(pat, el_ty, node)
 
             # TODO: Python also supports assignments like `[a, b] = [1, 2]` or

--- a/guppylang/compiler/expr_compiler.py
+++ b/guppylang/compiler/expr_compiler.py
@@ -389,7 +389,7 @@ def python_value_to_hugr(v: Any, exp_ty: Type) -> ops.Value | None:
             assert isinstance(exp_ty, TupleType)
             vs = [
                 python_value_to_hugr(elt, ty)
-                for elt, ty in zip(elts, exp_ty.element_types)
+                for elt, ty in zip(elts, exp_ty.element_types, strict=True)
             ]
             if doesnt_contain_none(vs):
                 return ops.Value(ops.TupleValue(vs=vs))

--- a/guppylang/error.py
+++ b/guppylang/error.py
@@ -116,7 +116,9 @@ def format_source_location(
     ]
     longest = max(len(ln) for ln in line_numbers)
     prefixes = [ln + " " * (longest - len(ln) + indent) for ln in line_numbers]
-    res = "".join(prefix + line + "\n" for prefix, line in zip(prefixes, s[:-1], strict=False))
+    res = "".join(
+        prefix + line + "\n" for prefix, line in zip(prefixes, s[:-1], strict=False)
+    )
     res += (longest + indent) * " " + s[-1]
     return res
 

--- a/guppylang/error.py
+++ b/guppylang/error.py
@@ -116,7 +116,7 @@ def format_source_location(
     ]
     longest = max(len(ln) for ln in line_numbers)
     prefixes = [ln + " " * (longest - len(ln) + indent) for ln in line_numbers]
-    res = "".join(prefix + line + "\n" for prefix, line in zip(prefixes, s[:-1]))
+    res = "".join(prefix + line + "\n" for prefix, line in zip(prefixes, s[:-1], strict=True))
     res += (longest + indent) * " " + s[-1]
     return res
 

--- a/guppylang/error.py
+++ b/guppylang/error.py
@@ -116,7 +116,7 @@ def format_source_location(
     ]
     longest = max(len(ln) for ln in line_numbers)
     prefixes = [ln + " " * (longest - len(ln) + indent) for ln in line_numbers]
-    res = "".join(prefix + line + "\n" for prefix, line in zip(prefixes, s[:-1], strict=True))
+    res = "".join(prefix + line + "\n" for prefix, line in zip(prefixes, s[:-1], strict=False))
     res += (longest + indent) * " " + s[-1]
     return res
 

--- a/guppylang/hugr_builder/hugr.py
+++ b/guppylang/hugr_builder/hugr.py
@@ -518,7 +518,7 @@ class Hugr:
         parent: Node | None = None,
     ) -> VNode:
         """Adds a `Tag` node to the graph."""
-        assert all(inp.ty == ty for inp, ty in zip(inputs, variants[tag]))
+        assert all(inp.ty == ty for inp, ty in zip(inputs, variants[tag], strict=True))
         hugr_variants = rows_to_hugr(variants)
         out_ty = SumType([row_to_type(row) for row in variants])
         return self.add_node(

--- a/guppylang/module.py
+++ b/guppylang/module.py
@@ -237,7 +237,7 @@ def get_py_scope(f: PyFunc) -> PyScope:
 
     nonlocals: PyScope = {}
     if f.__closure__ is not None:
-        for var, cell in zip(code.co_freevars, f.__closure__):
+        for var, cell in zip(code.co_freevars, f.__closure__, strict=True):
             try:
                 value = cell.cell_contents
             except ValueError:

--- a/ruff.toml
+++ b/ruff.toml
@@ -71,7 +71,6 @@ ignore = [
   "EM102",  # Exception must not use a string (an f-string) literal, assign to variable first
   "S101",   # Use of `assert` detected
   "TRY003", # Avoid specifying long messages outside the exception class
-  "B905",   # `zip()` without an explicit `strict=` parameter
 ]
 
 [lint.per-file-ignores]

--- a/tests/integration/test_extern.py
+++ b/tests/integration/test_extern.py
@@ -37,6 +37,7 @@ def test_extern_alt_symbol(validate):
     assert isinstance(c.v.root, ops.ExtensionValue)
     assert c.v.root.value.v["symbol"] == "foo"
 
+
 def test_extern_tuple(validate):
     module = GuppyModule("module")
 


### PR DESCRIPTION
Solves https://github.com/CQCL/guppylang/issues/65

When adding `strict=True` to all mentions of `zip`, some tests started to fail:

```bash
===================================================================================================== short test summary info =====================================================================================================
FAILED tests/error/test_linear_errors.py::test_linear_errors[/guppylang/tests/error/linear_errors/reassign_unused_tuple.py] - ValueError: zip() argument 2 is shorter than argument 1
FAILED tests/error/test_linear_errors.py::test_linear_errors[/guppylang/tests/error/linear_errors/reassign_unused.py] - ValueError: zip() argument 2 is shorter than argument 1
FAILED tests/error/test_misc_errors.py::test_misc_errors[/guppylang/tests/error/misc_errors/return_not_annotated_none2.py] - ValueError: zip() argument 2 is shorter than argument 1
FAILED tests/error/test_misc_errors.py::test_misc_errors[/guppylang/tests/error/misc_errors/return_not_annotated.py] - ValueError: zip() argument 2 is shorter than argument 1
FAILED tests/error/test_misc_errors.py::test_misc_errors[/guppylang/tests/error/misc_errors/arg_not_annotated.py] - ValueError: zip() argument 2 is shorter than argument 1
FAILED tests/error/test_misc_errors.py::test_misc_errors[/guppylang/tests/error/misc_errors/return_not_annotated_none1.py] - ValueError: zip() argument 2 is shorter than argument 1
FAILED tests/error/test_misc_errors.py::test_misc_errors[/guppylang/tests/error/misc_errors/list_linear.py] - ValueError: zip() argument 2 is shorter than argument 1
FAILED tests/error/test_poly_errors.py::test_type_errors[/guppylang/tests/error/poly_errors/define.py] - ValueError: zip() argument 2 is shorter than argument 1
FAILED tests/error/test_struct_errors.py::test_struct_errors[/guppylang/tests/error/struct_errors/inheritance.py] - ValueError: zip() argument 2 is shorter than argument 1
FAILED tests/error/test_struct_errors.py::test_struct_errors[/guppylang/tests/error/struct_errors/invalid_instantiate2.py] - ValueError: zip() argument 2 is shorter than argument 1
FAILED tests/error/test_struct_errors.py::test_struct_errors[/guppylang/tests/error/struct_errors/keywords.py] - ValueError: zip() argument 2 is shorter than argument 1
FAILED tests/error/test_struct_errors.py::test_struct_errors[/guppylang/tests/error/struct_errors/invalid_generic.py] - ValueError: zip() argument 2 is shorter than argument 1
FAILED tests/error/test_struct_errors.py::test_struct_errors[/guppylang/tests/error/struct_errors/invalid_instantiate1.py] - ValueError: zip() argument 2 is shorter than argument 1
==================================================================================== 13 failed, 305 passed, 13 skipped, 316 warnings in 3.48s =====================================================================================
```

As such we need to set `strict=False` to one occurrence of `zip`, namely on the line
```python
res = "".join(prefix + line + "\n" for prefix, line in zip(prefixes, s[:-1], strict=False))
```

_Note: This is my 1st PR, done to familiarize myself with the PR process for `guppylang`_