### PR TITLE
chore: Make locals and analysis generic over key type

### DIFF
--- a/guppylang/cfg/analysis.py
+++ b/guppylang/cfg/analysis.py
@@ -135,9 +135,9 @@ AssignmentDomain = tuple[DefAssignmentDomain[V], MaybeAssignmentDomain[V]]
 class AssignmentAnalysis(Generic[V], ForwardAnalysis[AssignmentDomain[V]]):
     """Assigned variable analysis pass.
 
-    Computes the set of variable that are definitely assigned at the start of a BB.
-    Additionally, we compute the set of variables that are assigned on (at least) some
-    paths to a BB (the definitely assigned variables are a subset of this).
+    Computes the set of variables (i.e. `V`s) that are definitely assigned at the start
+    of a BB. Additionally, we compute the set of variables that are assigned on (at
+    least) some paths to a BB (the definitely assigned variables are a subset of this).
     """
 
     stats: dict[BB, VariableStats[V]]

--- a/guppylang/cfg/analysis.py
+++ b/guppylang/cfg/analysis.py
@@ -11,7 +11,7 @@ T = TypeVar("T")
 Result = dict[BB, T]
 
 
-class Analysis(ABC, Generic[T]):
+class Analysis(Generic[T], ABC):
     """Abstract base class for a program analysis pass over the lattice `T`"""
 
     def eq(self, t1: T, t2: T, /) -> bool:
@@ -34,7 +34,7 @@ class Analysis(ABC, Generic[T]):
         """
 
 
-class ForwardAnalysis(Analysis[T], ABC, Generic[T]):
+class ForwardAnalysis(Generic[T], Analysis[T], ABC):
     """Abstract base class for a program analysis pass running in forward direction."""
 
     @abstractmethod
@@ -59,7 +59,7 @@ class ForwardAnalysis(Analysis[T], ABC, Generic[T]):
         return vals_before
 
 
-class BackwardAnalysis(Analysis[T], ABC, Generic[T]):
+class BackwardAnalysis(Generic[T], Analysis[T], ABC):
     """Abstract base class for a program analysis pass running in backward direction."""
 
     @abstractmethod
@@ -88,7 +88,7 @@ class BackwardAnalysis(Analysis[T], ABC, Generic[T]):
 LivenessDomain = dict[V, BB]
 
 
-class LivenessAnalysis(BackwardAnalysis[LivenessDomain[V]], Generic[V]):
+class LivenessAnalysis(Generic[V], BackwardAnalysis[LivenessDomain[V]]):
     """Live variable analysis pass.
 
     Computes the variables that are live before the execution of each BB. The analysis
@@ -132,7 +132,7 @@ MaybeAssignmentDomain = set[V]
 AssignmentDomain = tuple[DefAssignmentDomain[V], MaybeAssignmentDomain[V]]
 
 
-class AssignmentAnalysis(ForwardAnalysis[AssignmentDomain[V]], Generic[V]):
+class AssignmentAnalysis(Generic[V], ForwardAnalysis[AssignmentDomain[V]]):
     """Assigned variable analysis pass.
 
     Computes the set of variable that are definitely assigned at the start of a BB.

--- a/guppylang/cfg/analysis.py
+++ b/guppylang/cfg/analysis.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from typing import Generic, TypeVar
 
-from guppylang.cfg.bb import BB
+from guppylang.cfg.bb import BB, P, VariableStats
 
 # Type variable for the lattice domain
 T = TypeVar("T")
@@ -85,48 +85,54 @@ class BackwardAnalysis(Analysis[T], ABC, Generic[T]):
 
 # For live variable analysis, we also store a BB in which a use occurs as evidence of
 # liveness.
-LivenessDomain = dict[str, BB]
+LivenessDomain = dict[P, BB]
 
 
-class LivenessAnalysis(BackwardAnalysis[LivenessDomain]):
+class LivenessAnalysis(BackwardAnalysis[LivenessDomain[P]], Generic[P]):
     """Live variable analysis pass.
 
     Computes the variables that are live before the execution of each BB. The analysis
     runs over the lattice of mappings from variable names to BBs containing a use.
     """
 
-    def eq(self, live1: LivenessDomain, live2: LivenessDomain) -> bool:
+    stats: dict[BB, VariableStats[P]]
+
+    def __init__(self, stats: dict[BB, VariableStats[P]]) -> None:
+        self.stats = stats
+
+    def eq(self, live1: LivenessDomain[P], live2: LivenessDomain[P]) -> bool:
         # Only check that both contain the same variables. We don't care about the BB
         # in which the use occurs, we just need any one, to report to the user.
         return live1.keys() == live2.keys()
 
-    def initial(self) -> LivenessDomain:
+    def initial(self) -> LivenessDomain[P]:
         return {}
 
-    def join(self, *ts: LivenessDomain) -> LivenessDomain:
-        res: LivenessDomain = {}
+    def join(self, *ts: LivenessDomain[P]) -> LivenessDomain[P]:
+        res: LivenessDomain[P] = {}
         for t in ts:
             res |= t
         return res
 
-    def apply_bb(self, live_after: LivenessDomain, bb: BB) -> LivenessDomain:
-        return {x: bb for x in bb.vars.used} | {
-            x: b for x, b in live_after.items() if x not in bb.vars.assigned
+    def apply_bb(self, live_after: LivenessDomain[P], bb: BB) -> LivenessDomain[P]:
+        stats = self.stats[bb]
+        return {x: bb for x in stats.used} | {
+            x: b for x, b in live_after.items() if x not in stats.assigned
         }
 
 
 # Set of variables that are definitely assigned at the start of a BB
-DefAssignmentDomain = set[str]
+DefAssignmentDomain = set[P]
 
 # Set of variables that are assigned on (at least) some paths to a BB. Definitely
 # assigned variables are a subset of this
-MaybeAssignmentDomain = set[str]
+MaybeAssignmentDomain = set[P]
 
 # For assignment analysis, we do definite- and maybe-assignment in one pass
-AssignmentDomain = tuple[DefAssignmentDomain, MaybeAssignmentDomain]
+AssignmentDomain = tuple[DefAssignmentDomain[P], MaybeAssignmentDomain[P]]
 
 
-class AssignmentAnalysis(ForwardAnalysis[AssignmentDomain]):
+class AssignmentAnalysis(ForwardAnalysis[AssignmentDomain[P]], Generic[P]):
     """Assigned variable analysis pass.
 
     Computes the set of variable that are definitely assigned at the start of a BB.
@@ -134,15 +140,16 @@ class AssignmentAnalysis(ForwardAnalysis[AssignmentDomain]):
     paths to a BB (the definitely assigned variables are a subset of this).
     """
 
-    all_vars: set[str]
-    ass_before_entry: set[str]
-    maybe_ass_before_entry: set[str]
+    stats: dict[BB, VariableStats[P]]
+    all_vars: set[P]
+    ass_before_entry: set[P]
+    maybe_ass_before_entry: set[P]
 
     def __init__(
         self,
-        bbs: Iterable[BB],
-        ass_before_entry: set[str],
-        maybe_ass_before_entry: set[str],
+        stats: dict[BB, VariableStats[P]],
+        ass_before_entry: set[P],
+        maybe_ass_before_entry: set[P],
     ) -> None:
         """Constructs an `AssignmentAnalysis` pass for a CFG.
 
@@ -150,18 +157,20 @@ class AssignmentAnalysis(ForwardAnalysis[AssignmentDomain]):
         CFG (for example function arguments).
         """
         assert ass_before_entry.issubset(maybe_ass_before_entry)
+        self.stats = stats
         self.ass_before_entry = ass_before_entry
         self.maybe_ass_before_entry = maybe_ass_before_entry
         self.all_vars = (
-            set.union(*(set(bb.vars.assigned.keys()) for bb in bbs)) | ass_before_entry
+            set.union(*(set(stat.assigned.keys()) for stat in stats.values()))
+            | ass_before_entry
         )
 
-    def initial(self) -> AssignmentDomain:
+    def initial(self) -> AssignmentDomain[P]:
         # Note that definite assignment must start with `all_vars` instead of only
         # `ass_before_entry` since we want to compute the *greatest* fixpoint.
         return self.all_vars, self.maybe_ass_before_entry
 
-    def join(self, *ts: AssignmentDomain) -> AssignmentDomain:
+    def join(self, *ts: AssignmentDomain[P]) -> AssignmentDomain[P]:
         # We always include the variables that are definitely assigned before the entry,
         # even if the join is empty
         if len(ts) == 0:
@@ -171,16 +180,17 @@ class AssignmentAnalysis(ForwardAnalysis[AssignmentDomain]):
         maybe_ass = set.union(*(maybe_ass for _, maybe_ass in ts))
         return def_ass, maybe_ass
 
-    def apply_bb(self, val_before: AssignmentDomain, bb: BB) -> AssignmentDomain:
+    def apply_bb(self, val_before: AssignmentDomain[P], bb: BB) -> AssignmentDomain[P]:
+        stats = self.stats[bb]
         def_ass_before, maybe_ass_before = val_before
         return (
-            def_ass_before | bb.vars.assigned.keys(),
-            maybe_ass_before | bb.vars.assigned.keys(),
+            def_ass_before | stats.assigned.keys(),
+            maybe_ass_before | stats.assigned.keys(),
         )
 
     def run_unpacked(
         self, bbs: Iterable[BB]
-    ) -> tuple[Result[DefAssignmentDomain], Result[MaybeAssignmentDomain]]:
+    ) -> tuple[Result[DefAssignmentDomain[P]], Result[MaybeAssignmentDomain[P]]]:
         """Runs the analysis and unpacks the definite- and maybe-assignment results."""
         res = self.run(bbs)
         return {bb: res[bb][0] for bb in res}, {bb: res[bb][1] for bb in res}

--- a/guppylang/cfg/analysis.py
+++ b/guppylang/cfg/analysis.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from typing import Generic, TypeVar
 
-from guppylang.cfg.bb import BB, V, VariableStats
+from guppylang.cfg.bb import BB, VId, VariableStats
 
 # Type variable for the lattice domain
 T = TypeVar("T")
@@ -85,36 +85,36 @@ class BackwardAnalysis(Generic[T], Analysis[T], ABC):
 
 # For live variable analysis, we also store a BB in which a use occurs as evidence of
 # liveness.
-LivenessDomain = dict[V, BB]
+LivenessDomain = dict[VId, BB]
 
 
-class LivenessAnalysis(Generic[V], BackwardAnalysis[LivenessDomain[V]]):
+class LivenessAnalysis(Generic[VId], BackwardAnalysis[LivenessDomain[VId]]):
     """Live variable analysis pass.
 
     Computes the variables that are live before the execution of each BB. The analysis
     runs over the lattice of mappings from variable names to BBs containing a use.
     """
 
-    stats: dict[BB, VariableStats[V]]
+    stats: dict[BB, VariableStats[VId]]
 
-    def __init__(self, stats: dict[BB, VariableStats[V]]) -> None:
+    def __init__(self, stats: dict[BB, VariableStats[VId]]) -> None:
         self.stats = stats
 
-    def eq(self, live1: LivenessDomain[V], live2: LivenessDomain[V]) -> bool:
+    def eq(self, live1: LivenessDomain[VId], live2: LivenessDomain[VId]) -> bool:
         # Only check that both contain the same variables. We don't care about the BB
         # in which the use occurs, we just need any one, to report to the user.
         return live1.keys() == live2.keys()
 
-    def initial(self) -> LivenessDomain[V]:
+    def initial(self) -> LivenessDomain[VId]:
         return {}
 
-    def join(self, *ts: LivenessDomain[V]) -> LivenessDomain[V]:
-        res: LivenessDomain[V] = {}
+    def join(self, *ts: LivenessDomain[VId]) -> LivenessDomain[VId]:
+        res: LivenessDomain[VId] = {}
         for t in ts:
             res |= t
         return res
 
-    def apply_bb(self, live_after: LivenessDomain[V], bb: BB) -> LivenessDomain[V]:
+    def apply_bb(self, live_after: LivenessDomain[VId], bb: BB) -> LivenessDomain[VId]:
         stats = self.stats[bb]
         return {x: bb for x in stats.used} | {
             x: b for x, b in live_after.items() if x not in stats.assigned
@@ -122,17 +122,17 @@ class LivenessAnalysis(Generic[V], BackwardAnalysis[LivenessDomain[V]]):
 
 
 # Set of variables that are definitely assigned at the start of a BB
-DefAssignmentDomain = set[V]
+DefAssignmentDomain = set[VId]
 
 # Set of variables that are assigned on (at least) some paths to a BB. Definitely
 # assigned variables are a subset of this
-MaybeAssignmentDomain = set[V]
+MaybeAssignmentDomain = set[VId]
 
 # For assignment analysis, we do definite- and maybe-assignment in one pass
-AssignmentDomain = tuple[DefAssignmentDomain[V], MaybeAssignmentDomain[V]]
+AssignmentDomain = tuple[DefAssignmentDomain[VId], MaybeAssignmentDomain[VId]]
 
 
-class AssignmentAnalysis(Generic[V], ForwardAnalysis[AssignmentDomain[V]]):
+class AssignmentAnalysis(Generic[VId], ForwardAnalysis[AssignmentDomain[VId]]):
     """Assigned variable analysis pass.
 
     Computes the set of variables (i.e. `V`s) that are definitely assigned at the start
@@ -140,16 +140,16 @@ class AssignmentAnalysis(Generic[V], ForwardAnalysis[AssignmentDomain[V]]):
     least) some paths to a BB (the definitely assigned variables are a subset of this).
     """
 
-    stats: dict[BB, VariableStats[V]]
-    all_vars: set[V]
-    ass_before_entry: set[V]
-    maybe_ass_before_entry: set[V]
+    stats: dict[BB, VariableStats[VId]]
+    all_vars: set[VId]
+    ass_before_entry: set[VId]
+    maybe_ass_before_entry: set[VId]
 
     def __init__(
         self,
-        stats: dict[BB, VariableStats[V]],
-        ass_before_entry: set[V],
-        maybe_ass_before_entry: set[V],
+        stats: dict[BB, VariableStats[VId]],
+        ass_before_entry: set[VId],
+        maybe_ass_before_entry: set[VId],
     ) -> None:
         """Constructs an `AssignmentAnalysis` pass for a CFG.
 
@@ -165,12 +165,12 @@ class AssignmentAnalysis(Generic[V], ForwardAnalysis[AssignmentDomain[V]]):
             | ass_before_entry
         )
 
-    def initial(self) -> AssignmentDomain[V]:
+    def initial(self) -> AssignmentDomain[VId]:
         # Note that definite assignment must start with `all_vars` instead of only
         # `ass_before_entry` since we want to compute the *greatest* fixpoint.
         return self.all_vars, self.maybe_ass_before_entry
 
-    def join(self, *ts: AssignmentDomain[V]) -> AssignmentDomain[V]:
+    def join(self, *ts: AssignmentDomain[VId]) -> AssignmentDomain[VId]:
         # We always include the variables that are definitely assigned before the entry,
         # even if the join is empty
         if len(ts) == 0:
@@ -180,7 +180,7 @@ class AssignmentAnalysis(Generic[V], ForwardAnalysis[AssignmentDomain[V]]):
         maybe_ass = set.union(*(maybe_ass for _, maybe_ass in ts))
         return def_ass, maybe_ass
 
-    def apply_bb(self, val_before: AssignmentDomain[V], bb: BB) -> AssignmentDomain[V]:
+    def apply_bb(self, val_before: AssignmentDomain[VId], bb: BB) -> AssignmentDomain[VId]:
         stats = self.stats[bb]
         def_ass_before, maybe_ass_before = val_before
         return (
@@ -190,7 +190,7 @@ class AssignmentAnalysis(Generic[V], ForwardAnalysis[AssignmentDomain[V]]):
 
     def run_unpacked(
         self, bbs: Iterable[BB]
-    ) -> tuple[Result[DefAssignmentDomain[V]], Result[MaybeAssignmentDomain[V]]]:
+    ) -> tuple[Result[DefAssignmentDomain[VId]], Result[MaybeAssignmentDomain[VId]]]:
         """Runs the analysis and unpacks the definite- and maybe-assignment results."""
         res = self.run(bbs)
         return {bb: res[bb][0] for bb in res}, {bb: res[bb][1] for bb in res}

--- a/guppylang/cfg/analysis.py
+++ b/guppylang/cfg/analysis.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from typing import Generic, TypeVar
 
-from guppylang.cfg.bb import BB, VId, VariableStats
+from guppylang.cfg.bb import BB, VariableStats, VId
 
 # Type variable for the lattice domain
 T = TypeVar("T")
@@ -180,7 +180,9 @@ class AssignmentAnalysis(Generic[VId], ForwardAnalysis[AssignmentDomain[VId]]):
         maybe_ass = set.union(*(maybe_ass for _, maybe_ass in ts))
         return def_ass, maybe_ass
 
-    def apply_bb(self, val_before: AssignmentDomain[VId], bb: BB) -> AssignmentDomain[VId]:
+    def apply_bb(
+        self, val_before: AssignmentDomain[VId], bb: BB
+    ) -> AssignmentDomain[VId]:
         stats = self.stats[bb]
         def_ass_before, maybe_ass_before = val_before
         return (

--- a/guppylang/cfg/bb.py
+++ b/guppylang/cfg/bb.py
@@ -13,21 +13,21 @@ if TYPE_CHECKING:
     from guppylang.cfg.cfg import BaseCFG
 
 
-# Type variable for entities which we may wish to track during program analysis
-# (generally program variables or parts thereof)
-V = TypeVar("V", bound=Hashable)
+# Type variable for ids of entities which we may wish to track during program analysis
+# (generally ids for program variables or parts thereof)
+VId = TypeVar("VId", bound=Hashable)
 
 
 @dataclass
-class VariableStats(Generic[V]):
+class VariableStats(Generic[VId]):
     """Stores variable usage information for a basic block."""
 
     # Variables that are assigned in the BB
-    assigned: dict[V, AstNode] = field(default_factory=dict)
+    assigned: dict[VId, AstNode] = field(default_factory=dict)
 
     # The (external) variables used in the BB, i.e. usages of variables that are
     # created in the BB are not included here.
-    used: dict[V, ast.Name] = field(default_factory=dict)
+    used: dict[VId, ast.Name] = field(default_factory=dict)
 
 
 BBStatement = (

--- a/guppylang/cfg/bb.py
+++ b/guppylang/cfg/bb.py
@@ -14,19 +14,19 @@ if TYPE_CHECKING:
 
 
 # Type variable for the program variable identifiers
-P = TypeVar("P", bound=Hashable)
+V = TypeVar("P", bound=Hashable)
 
 
 @dataclass
-class VariableStats(Generic[P]):
+class VariableStats(Generic[V]):
     """Stores variable usage information for a basic block."""
 
     # Variables that are assigned in the BB
-    assigned: dict[P, AstNode] = field(default_factory=dict)
+    assigned: dict[V, AstNode] = field(default_factory=dict)
 
     # The (external) variables used in the BB, i.e. usages of variables that are
     # assigned in the BB are not included here.
-    used: dict[P, ast.Name] = field(default_factory=dict)
+    used: dict[V, ast.Name] = field(default_factory=dict)
 
 
 BBStatement = (

--- a/guppylang/cfg/bb.py
+++ b/guppylang/cfg/bb.py
@@ -26,7 +26,7 @@ class VariableStats(Generic[V]):
     assigned: dict[V, AstNode] = field(default_factory=dict)
 
     # The (external) variables used in the BB, i.e. usages of variables that are
-    # assigned in the BB are not included here.
+    # created in the BB are not included here.
     used: dict[V, ast.Name] = field(default_factory=dict)
 
 

--- a/guppylang/cfg/bb.py
+++ b/guppylang/cfg/bb.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 
 # Type variable for the program variable identifiers
-V = TypeVar("P", bound=Hashable)
+V = TypeVar("V", bound=Hashable)
 
 
 @dataclass

--- a/guppylang/cfg/bb.py
+++ b/guppylang/cfg/bb.py
@@ -13,7 +13,8 @@ if TYPE_CHECKING:
     from guppylang.cfg.cfg import BaseCFG
 
 
-# Type variable for the program variable identifiers
+# Type variable for entities which we may wish to track during program analysis
+# (generally program variables or parts thereof)
 V = TypeVar("V", bound=Hashable)
 
 

--- a/guppylang/checker/core.py
+++ b/guppylang/checker/core.py
@@ -8,6 +8,7 @@ from typing import Any, Generic, NamedTuple, TypeVar
 from typing_extensions import assert_never
 
 from guppylang.ast_util import AstNode, name_nodes_in_ast
+from guppylang.cfg.bb import VId
 from guppylang.definition.common import DefId, Definition
 from guppylang.definition.ty import TypeDef
 from guppylang.definition.value import CallableDef
@@ -162,45 +163,44 @@ class Globals:
                 return assert_never(x)
 
 
-K = TypeVar("K")
 V = TypeVar("V")
 
 
 @dataclass
-class Locals(Generic[K, V]):
+class Locals(Generic[VId, V]):
     """Scoped mapping from names to variables"""
 
-    vars: dict[K, V]
-    parent_scope: "Locals[K, V] | None" = None
+    vars: dict[VId, V]
+    parent_scope: "Locals[VId, V] | None" = None
 
-    def __getitem__(self, item: K) -> V:
+    def __getitem__(self, item: VId) -> V:
         if item not in self.vars and self.parent_scope:
             return self.parent_scope[item]
 
         return self.vars[item]
 
-    def __setitem__(self, key: K, value: V) -> None:
+    def __setitem__(self, key: VId, value: V) -> None:
         self.vars[key] = value
 
-    def __iter__(self) -> Iterator[K]:
+    def __iter__(self) -> Iterator[VId]:
         parent_iter = iter(self.parent_scope) if self.parent_scope else iter(())
         return itertools.chain(iter(self.vars), parent_iter)
 
-    def __contains__(self, item: K) -> bool:
+    def __contains__(self, item: VId) -> bool:
         return (item in self.vars) or (
             self.parent_scope is not None and item in self.parent_scope
         )
 
-    def __copy__(self) -> "Locals[K, V]":
+    def __copy__(self) -> "Locals[VId, V]":
         # Make a copy of the var map so that mutating the copy doesn't
         # mutate our variable mapping
         return Locals(self.vars.copy(), copy.copy(self.parent_scope))
 
-    def keys(self) -> set[K]:
+    def keys(self) -> set[VId]:
         parent_keys = self.parent_scope.keys() if self.parent_scope else set()
         return parent_keys | self.vars.keys()
 
-    def items(self) -> Iterable[tuple[K, V]]:
+    def items(self) -> Iterable[tuple[VId, V]]:
         parent_items = (
             iter(self.parent_scope.items()) if self.parent_scope else iter(())
         )

--- a/guppylang/checker/core.py
+++ b/guppylang/checker/core.py
@@ -168,7 +168,12 @@ V = TypeVar("V")
 
 @dataclass
 class Locals(Generic[VId, V]):
-    """Scoped mapping from names to variables"""
+    """Scoped mapping from program variable ids to the corresponding program variable.
+
+    Depending on which checking phase we are in (type checking or linearity checking),
+    we use this either as a mapping from strings to `Variable`s or as a mapping from
+    `PlaceId`s to `Place`s.
+    """
 
     vars: dict[VId, V]
     parent_scope: "Locals[VId, V] | None" = None

--- a/guppylang/checker/expr_checker.py
+++ b/guppylang/checker/expr_checker.py
@@ -40,6 +40,7 @@ from guppylang.checker.core import (
     DummyEvalDict,
     Globals,
     Locals,
+    Variable,
 )
 from guppylang.definition.ty import TypeDef
 from guppylang.definition.value import CallableDef, ValueDef
@@ -876,7 +877,7 @@ def synthesize_comprehension(
 
     # The rest is checked in a new nested context to ensure that variables don't escape
     # their scope
-    inner_locals = Locals({}, parent_scope=ctx.locals)
+    inner_locals: Locals[str, Variable] = Locals({}, parent_scope=ctx.locals)
     inner_ctx = Context(ctx.globals, inner_locals)
     expr_sth, stmt_chk = ExprSynthesizer(inner_ctx), StmtChecker(inner_ctx)
     gen.hasnext_assign = stmt_chk.visit_Assign(gen.hasnext_assign)

--- a/guppylang/checker/linearity_checker.py
+++ b/guppylang/checker/linearity_checker.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from guppylang.checker.cfg_checker import CheckedBB, CheckedCFG
 
 
-class Scope(Locals):
+class Scope(Locals[str, Variable]):
     """Scoped collection of assigned variables indexed by name.
 
     Keeps track of which variables have already been used.

--- a/guppylang/hugr_builder/visualise.py
+++ b/guppylang/hugr_builder/visualise.py
@@ -11,7 +11,7 @@ from guppylang.cfg.analysis import (
     LivenessDomain,
     MaybeAssignmentDomain,
 )
-from guppylang.cfg.bb import BB, V
+from guppylang.cfg.bb import BB, VId
 from guppylang.hugr_builder.hugr import DummyOp, Hugr, InPort, Node, OutPort, OutPortV
 
 if TYPE_CHECKING:
@@ -249,9 +249,9 @@ def commas(*args: str) -> str:
 
 def cfg_to_graphviz(
     cfg: "CFG",
-    live_before: dict[BB, LivenessDomain[V]],
-    ass_before: dict[BB, DefAssignmentDomain[V]],
-    maybe_ass_before: dict[BB, MaybeAssignmentDomain[V]],
+    live_before: dict[BB, LivenessDomain[VId]],
+    ass_before: dict[BB, DefAssignmentDomain[VId]],
+    maybe_ass_before: dict[BB, MaybeAssignmentDomain[VId]],
 ) -> gv.Digraph:
     graph = gv.Digraph("CFG", strict=False)
     for bb in cfg.bbs:
@@ -273,9 +273,9 @@ live_before: {commas(*(str(x) for x in live_before[bb]))}
 
 def render_cfg(
     cfg: "CFG",
-    live_before: dict[BB, LivenessDomain[V]],
-    ass_before: dict[BB, DefAssignmentDomain[V]],
-    maybe_ass_before: dict[BB, MaybeAssignmentDomain[V]],
+    live_before: dict[BB, LivenessDomain[VId]],
+    ass_before: dict[BB, DefAssignmentDomain[VId]],
+    maybe_ass_before: dict[BB, MaybeAssignmentDomain[VId]],
     filename: str,
     format_st: str = "svg",
 ) -> None:

--- a/guppylang/hugr_builder/visualise.py
+++ b/guppylang/hugr_builder/visualise.py
@@ -11,7 +11,7 @@ from guppylang.cfg.analysis import (
     LivenessDomain,
     MaybeAssignmentDomain,
 )
-from guppylang.cfg.bb import BB, P
+from guppylang.cfg.bb import BB, V
 from guppylang.hugr_builder.hugr import DummyOp, Hugr, InPort, Node, OutPort, OutPortV
 
 if TYPE_CHECKING:
@@ -249,9 +249,9 @@ def commas(*args: str) -> str:
 
 def cfg_to_graphviz(
     cfg: "CFG",
-    live_before: dict[BB, LivenessDomain[P]],
-    ass_before: dict[BB, DefAssignmentDomain[P]],
-    maybe_ass_before: dict[BB, MaybeAssignmentDomain[P]],
+    live_before: dict[BB, LivenessDomain[V]],
+    ass_before: dict[BB, DefAssignmentDomain[V]],
+    maybe_ass_before: dict[BB, MaybeAssignmentDomain[V]],
 ) -> gv.Digraph:
     graph = gv.Digraph("CFG", strict=False)
     for bb in cfg.bbs:
@@ -273,9 +273,9 @@ live_before: {commas(*(str(x) for x in live_before[bb]))}
 
 def render_cfg(
     cfg: "CFG",
-    live_before: dict[BB, LivenessDomain[P]],
-    ass_before: dict[BB, DefAssignmentDomain[P]],
-    maybe_ass_before: dict[BB, MaybeAssignmentDomain[P]],
+    live_before: dict[BB, LivenessDomain[V]],
+    ass_before: dict[BB, DefAssignmentDomain[V]],
+    maybe_ass_before: dict[BB, MaybeAssignmentDomain[V]],
     filename: str,
     format_st: str = "svg",
 ) -> None:

--- a/guppylang/hugr_builder/visualise.py
+++ b/guppylang/hugr_builder/visualise.py
@@ -11,7 +11,7 @@ from guppylang.cfg.analysis import (
     LivenessDomain,
     MaybeAssignmentDomain,
 )
-from guppylang.cfg.bb import BB
+from guppylang.cfg.bb import BB, P
 from guppylang.hugr_builder.hugr import DummyOp, Hugr, InPort, Node, OutPort, OutPortV
 
 if TYPE_CHECKING:
@@ -249,18 +249,18 @@ def commas(*args: str) -> str:
 
 def cfg_to_graphviz(
     cfg: "CFG",
-    live_before: dict[BB, LivenessDomain],
-    ass_before: dict[BB, DefAssignmentDomain],
-    maybe_ass_before: dict[BB, MaybeAssignmentDomain],
+    live_before: dict[BB, LivenessDomain[P]],
+    ass_before: dict[BB, DefAssignmentDomain[P]],
+    maybe_ass_before: dict[BB, MaybeAssignmentDomain[P]],
 ) -> gv.Digraph:
     graph = gv.Digraph("CFG", strict=False)
     for bb in cfg.bbs:
         label = f"""
-assigned: {commas(*bb.vars.assigned)}
-used: {commas(*bb.vars.used)}
-maybe_ass_before: {commas(*maybe_ass_before[bb])}
-ass_before: {commas(*ass_before[bb])}
-live_before: {commas(*live_before[bb])}
+assigned: {commas(*(str(x) for x in bb.vars.assigned))}
+used: {commas(*(str(x) for x in bb.vars.used))}
+maybe_ass_before: {commas(*(str(x) for x in maybe_ass_before[bb]))}
+ass_before: {commas(*(str(x) for x in ass_before[bb]))}
+live_before: {commas(*(str(x) for x in live_before[bb]))}
 --------
 """ + "\n".join(ast.unparse(s) for s in bb.statements)
         if bb.branch_pred is not None:
@@ -273,9 +273,9 @@ live_before: {commas(*live_before[bb])}
 
 def render_cfg(
     cfg: "CFG",
-    live_before: dict[BB, LivenessDomain],
-    ass_before: dict[BB, DefAssignmentDomain],
-    maybe_ass_before: dict[BB, MaybeAssignmentDomain],
+    live_before: dict[BB, LivenessDomain[P]],
+    ass_before: dict[BB, DefAssignmentDomain[P]],
+    maybe_ass_before: dict[BB, MaybeAssignmentDomain[P]],
     filename: str,
     format_st: str = "svg",
 ) -> None:


### PR DESCRIPTION
Makes the dataflow analysis and local variable map generic over the type used to index into them.

This is a precursor for making the analysis track struct fields separately. See #295 for context.