### PR TITLE
feat: Store inout flags in FunctionType

### DIFF
--- a/guppylang/checker/func_checker.py
+++ b/guppylang/checker/func_checker.py
@@ -17,7 +17,7 @@ from guppylang.definition.common import DefId
 from guppylang.error import GuppyError
 from guppylang.nodes import CheckedNestedFunctionDef, NestedFunctionDef
 from guppylang.tys.parsing import type_from_ast
-from guppylang.tys.ty import FunctionType, InputFlags, NoneType
+from guppylang.tys.ty import FuncInput, FunctionType, InputFlags, NoneType
 
 if TYPE_CHECKING:
     from guppylang.tys.param import Parameter
@@ -33,8 +33,8 @@ def check_global_func_def(
 
     cfg = CFGBuilder().build(func_def.body, returns_none, globals)
     inputs = [
-        Variable(x, ty, loc)
-        for x, (ty, _), loc in zip(ty.input_names, ty.inputs, args, strict=True)
+        Variable(x, inp.ty, loc)
+        for x, inp, loc in zip(ty.input_names, ty.inputs, args, strict=True)
     ]
     return check_cfg(cfg, inputs, ty.output, globals)
 
@@ -75,8 +75,8 @@ def check_nested_func_def(
 
     # Construct inputs for checking the body CFG
     inputs = [v for v, _ in captured.values()] + [
-        Variable(x, ty, func_def.args.args[i])
-        for i, (x, (ty, _)) in enumerate(
+        Variable(x, inp.ty, func_def.args.args[i])
+        for i, (x, inp) in enumerate(
             zip(func_ty.input_names, func_ty.inputs, strict=True)
         )
     ]
@@ -149,7 +149,7 @@ def check_signature(func_def: ast.FunctionDef, globals: Globals) -> FunctionType
         if inp.annotation is None:
             raise GuppyError("Argument type must be annotated", inp)
         ty = type_from_ast(inp.annotation, globals, param_var_mapping)
-        inputs.append((ty, InputFlags.NoFlags))
+        inputs.append(FuncInput(ty, InputFlags.NoFlags))
         input_names.append(inp.arg)
     ret_type = type_from_ast(func_def.returns, globals, param_var_mapping)
 

--- a/guppylang/definition/custom.py
+++ b/guppylang/definition/custom.py
@@ -159,7 +159,7 @@ class CustomFunctionDef(CompiledCallableDef):
         fun_ty = self.ty.instantiate(type_args)
         def_node = graph.add_def(fun_ty, dfg.node, self.name)
         with graph.parent(def_node):
-            input_tys = [ty for ty, _ in fun_ty.inputs]
+            input_tys = [inp.ty for inp in fun_ty.inputs]
             _, inp_ports = graph.add_input_with_ports(input_tys)
             returns = self.compile_call(
                 inp_ports,

--- a/guppylang/definition/struct.py
+++ b/guppylang/definition/struct.py
@@ -27,7 +27,7 @@ from guppylang.hugr_builder.hugr import OutPortV
 from guppylang.tys.arg import Argument
 from guppylang.tys.param import Parameter, check_all_args
 from guppylang.tys.parsing import type_from_ast
-from guppylang.tys.ty import FunctionType, InputFlags, StructType, Type
+from guppylang.tys.ty import FuncInput, FunctionType, InputFlags, StructType, Type
 
 
 @dataclass(frozen=True)
@@ -204,7 +204,7 @@ class CheckedStructDef(TypeDef, CompiledDef):
                 return [self.graph.add_make_tuple(args).out_port(0)]
 
         constructor_sig = FunctionType(
-            inputs=[(f.ty, InputFlags.NoFlags) for f in self.fields],
+            inputs=[FuncInput(f.ty, InputFlags.NoFlags) for f in self.fields],
             output=StructType(
                 defn=self, args=[p.to_bound(i) for i, p in enumerate(self.params)]
             ),

--- a/guppylang/hugr_builder/hugr.py
+++ b/guppylang/hugr_builder/hugr.py
@@ -12,6 +12,7 @@ from hugr.serialization.ops import OpType
 
 from guppylang.tys.subst import Inst
 from guppylang.tys.ty import (
+    FuncInput,
     FunctionType,
     InputFlags,
     StructType,
@@ -611,7 +612,7 @@ class Hugr:
         assert isinstance(def_port.ty, FunctionType)
         assert len(def_port.ty.inputs) >= len(inputs)
         assert [p.ty.to_hugr() for p in inputs] == [
-            ty.to_hugr() for ty, _ in def_port.ty.inputs[: len(inputs)]
+            inp.ty.to_hugr() for inp in def_port.ty.inputs[: len(inputs)]
         ]
         new_ty = FunctionType(
             def_port.ty.inputs[len(inputs) :],
@@ -740,9 +741,14 @@ class Hugr:
         for n in list(self.nodes()):
             if isinstance(n, VNode) and isinstance(n.op, DummyOp):
                 name = n.op.name
-                inputs = zip(
-                    n.in_port_types, itertools.repeat(InputFlags.NoFlags), strict=False
-                )
+                inputs = [
+                    FuncInput(ty, flags)
+                    for ty, flags in zip(
+                        n.in_port_types,
+                        itertools.repeat(InputFlags.NoFlags),
+                        strict=False,
+                    )
+                ]
                 fun_ty = FunctionType(list(inputs), row_to_type(n.out_port_types))
                 if name in used_names:
                     used_names[name] += 1

--- a/guppylang/tys/builtin.py
+++ b/guppylang/tys/builtin.py
@@ -12,6 +12,7 @@ from guppylang.error import GuppyError
 from guppylang.tys.arg import Argument, ConstArg, TypeArg
 from guppylang.tys.param import ConstParam, TypeParam
 from guppylang.tys.ty import (
+    FuncInput,
     FunctionType,
     InputFlags,
     NoneType,
@@ -46,7 +47,10 @@ class _CallableTypeDef(TypeDef):
             for i, arg in enumerate(args)
         ]
         *input_tys, output = args
-        inputs = zip(input_tys, repeat(InputFlags.NoFlags), strict=False)
+        inputs = [
+            FuncInput(ty, flags)
+            for ty, flags in zip(input_tys, repeat(InputFlags.NoFlags), strict=False)
+        ]
         return FunctionType(list(inputs), output)
 
 

--- a/guppylang/tys/printing.py
+++ b/guppylang/tys/printing.py
@@ -74,7 +74,7 @@ class TypePrinter:
         if ty.parametrized:
             for p in ty.params:
                 self.bound_names.append(self._fresh_name(p.name))
-        inputs = ", ".join([self._visit(inp, True) for inp, _ in ty.inputs])
+        inputs = ", ".join([self._visit(inp.ty, True) for inp in ty.inputs])
         if len(ty.inputs) != 1:
             inputs = f"({inputs})"
         output = self._visit(ty.output, True)

--- a/tests/hugr/test_dummy_nodes.py
+++ b/tests/hugr/test_dummy_nodes.py
@@ -1,14 +1,16 @@
 from hugr.serialization import ops
 
 from guppylang.tys.builtin import bool_type
-from guppylang.tys.ty import FunctionType, TupleType, InputFlags
+from guppylang.tys.ty import FunctionType, TupleType, InputFlags, FuncInput
 from guppylang.hugr_builder.hugr import Hugr, DummyOp
 
 
 def test_single_dummy():
     g = Hugr()
     defn = g.add_def(
-        FunctionType([(bool_type(), InputFlags.NoFlags)], bool_type()), g.root, "test"
+        FunctionType([FuncInput(bool_type(), InputFlags.NoFlags)], bool_type()),
+        g.root,
+        "test",
     )
     dfg = g.add_dfg(defn)
     inp = g.add_input([bool_type()], dfg).out_port(0)
@@ -26,7 +28,8 @@ def test_unique_names():
     g = Hugr()
     defn = g.add_def(
         FunctionType(
-            [(bool_type(), InputFlags.NoFlags)], TupleType([bool_type(), bool_type()])
+            [FuncInput(bool_type(), InputFlags.NoFlags)],
+            TupleType([bool_type(), bool_type()]),
         ),
         g.root,
         "test",


### PR DESCRIPTION
Adds a new `InputFlags` enum that is paired up with each input in `FunctionType`.  See #311 for context.

Closes #313