### PR TITLE
chore: Turn result function into an AST node

### DIFF
--- a/guppylang/compiler/expr_compiler.py
+++ b/guppylang/compiler/expr_compiler.py
@@ -27,15 +27,19 @@ from guppylang.nodes import (
     GlobalName,
     LocalCall,
     PlaceNode,
+    ResultExpr,
     TensorCall,
     TypeApply,
 )
+from guppylang.tys.arg import ConstArg, TypeArg
 from guppylang.tys.builtin import bool_type, get_element_type, is_list_type
+from guppylang.tys.const import ConstValue
 from guppylang.tys.subst import Inst
 from guppylang.tys.ty import (
     BoundTypeVar,
     FunctionType,
     NoneType,
+    NumericType,
     TupleType,
     Type,
     type_to_row,
@@ -293,6 +297,20 @@ class ExprCompiler(CompilerBase, AstVisitor[OutPortV]):
         struct_port = self.visit(node.value)
         unpack = self.graph.add_unpack_tuple(struct_port)
         return unpack.out_port(node.struct_ty.fields.index(node.field))
+
+    def visit_ResultExpr(self, node: ResultExpr) -> OutPortV:
+        type_args = [
+            TypeArg(node.ty),
+            ConstArg(ConstValue(value=node.tag, ty=NumericType(NumericType.Kind.Nat))),
+        ]
+        op = ops.CustomOp(
+            extension="tket2.results",
+            op_name="Result",
+            args=[arg.to_hugr() for arg in type_args],
+            parent=UNDEFINED,
+        )
+        self.graph.add_node(ops.OpType(op), inputs=[self.visit(node.value)])
+        return self._pack_returns([], NoneType())
 
     def visit_DesugaredListComp(self, node: DesugaredListComp) -> OutPortV:
         from guppylang.compiler.stmt_compiler import StmtCompiler

--- a/guppylang/nodes.py
+++ b/guppylang/nodes.py
@@ -188,6 +188,16 @@ class PyExpr(ast.expr):
     _fields = ("value",)
 
 
+class ResultExpr(ast.expr):
+    """A `result(tag, value)` expression."""
+
+    value: ast.expr
+    ty: Type
+    tag: int
+
+    _fields = ("value", "ty", "tag")
+
+
 class NestedFunctionDef(ast.FunctionDef):
     cfg: "CFG"
     ty: FunctionType

--- a/guppylang/prelude/_internal.py
+++ b/guppylang/prelude/_internal.py
@@ -21,8 +21,8 @@ from guppylang.definition.custom import (
 from guppylang.definition.value import CallableDef
 from guppylang.error import GuppyError, GuppyTypeError, InternalGuppyError
 from guppylang.hugr_builder.hugr import UNDEFINED, OutPortV
-from guppylang.nodes import GlobalCall
-from guppylang.tys.arg import ConstArg, TypeArg
+from guppylang.nodes import GlobalCall, ResultExpr
+from guppylang.tys.arg import ConstArg
 from guppylang.tys.builtin import bool_type, int_type, list_type
 from guppylang.tys.const import ConstValue
 from guppylang.tys.subst import Inst, Subst
@@ -287,34 +287,12 @@ class ResultChecker(CustomCallChecker):
             raise GuppyTypeError(
                 f"Cannot use value with linear type `{ty}` as a result", value
             )
-        type_args = [
-            TypeArg(ty),
-            ConstArg(ConstValue(value=tag.value, ty=NumericType(NumericType.Kind.Nat))),
-        ]
-        call = GlobalCall(def_id=self.func.id, args=[value], type_args=type_args)
-        return with_loc(self.node, call), NoneType()
+        return with_loc(self.node, ResultExpr(value, ty, tag.value)), NoneType()
 
     def check(self, args: list[ast.expr], ty: Type) -> tuple[ast.expr, Subst]:
         expr, res_ty = self.synthesize(args)
         subst, _ = check_type_against(res_ty, ty, self.node)
         return expr, subst
-
-
-class ResultCompiler(CustomCallCompiler):
-    """Call compiler for the `result` function.
-
-    This is a temporary hack until we have implemented the proper results mechanism.
-    """
-
-    def compile(self, args: list[OutPortV]) -> list[OutPortV]:
-        op = ops.CustomOp(
-            extension="tket2.results",
-            op_name="Result",
-            args=[arg.to_hugr() for arg in self.type_args],
-            parent=UNDEFINED,
-        )
-        self.graph.add_node(ops.OpType(op), inputs=args)
-        return []
 
 
 class NatTruedivCompiler(CustomCallCompiler):

--- a/guppylang/prelude/builtins.py
+++ b/guppylang/prelude/builtins.py
@@ -24,7 +24,6 @@ from guppylang.prelude._internal import (
     IntTruedivCompiler,
     NatTruedivCompiler,
     ResultChecker,
-    ResultCompiler,
     ReversingChecker,
     UnsupportedChecker,
     float_op,
@@ -614,7 +613,7 @@ class Array:
 
 
 # TODO: This is a temporary hack until we have implemented the proper results mechanism.
-@guppy.custom(builtins, ResultCompiler(), ResultChecker(), higher_order_value=False)
+@guppy.custom(builtins, checker=ResultChecker(), higher_order_value=False)
 def result(tag, value): ...
 
 


### PR DESCRIPTION
Fixes #320.

We were relying on a hack where the `CustomCallChecker` for the `result(tag, value)` function inserted an extra type arg for the tag that wasn't declared in the signature of `result`. This now leads to problems in #321

For now, the only way to fix this is to add a new node to the AST that handles compilation of results with tags.

In the future, we could solve this more elegantly by for example adding `Literal` types which would allow us to specify the tag type arg in argument position:

```python
def result[n, T](tag: Literal[n], value: T) -> None: ...
```