### PR TITLE
feat: Parse docstrings for functions

### DIFF
--- a/guppylang/cfg/builder.py
+++ b/guppylang/cfg/builder.py
@@ -211,7 +211,9 @@ class CFGBuilder(AstVisitor[BB | None]):
     def visit_FunctionDef(
         self, node: ast.FunctionDef, bb: BB, jumps: Jumps
     ) -> BB | None:
-        from guppylang.checker.func_checker import check_signature
+        from guppylang.checker.func_checker import check_signature, parse_docstring
+
+        node, docstring = parse_docstring(node)
 
         func_ty = check_signature(node, self.globals)
         returns_none = isinstance(func_ty.output, NoneType)
@@ -220,6 +222,7 @@ class CFGBuilder(AstVisitor[BB | None]):
         new_node = NestedFunctionDef(
             cfg,
             func_ty,
+            docstring=docstring,
             name=node.name,
             args=node.args,
             body=node.body,

--- a/guppylang/compiler/func_compiler.py
+++ b/guppylang/compiler/func_compiler.py
@@ -73,6 +73,7 @@ def compile_local_func_def(
                 func,
                 func.ty,
                 {},
+                None,
                 func.cfg,
                 def_node,
             )

--- a/guppylang/decorator.py
+++ b/guppylang/decorator.py
@@ -199,7 +199,7 @@ class _Guppy:
         """
 
         def dec(f: PyFunc) -> RawCustomFunctionDef:
-            func_ast = parse_py_func(f)
+            func_ast, docstring = parse_py_func(f)
             if not has_empty_body(func_ast):
                 raise GuppyError(
                     "Body of custom function declaration must be empty",

--- a/guppylang/definition/function.py
+++ b/guppylang/definition/function.py
@@ -9,7 +9,11 @@ from guppylang.ast_util import AstNode, annotate_location, with_loc
 from guppylang.checker.cfg_checker import CheckedCFG
 from guppylang.checker.core import Context, Globals, PyScope
 from guppylang.checker.expr_checker import check_call, synthesize_call
-from guppylang.checker.func_checker import check_global_func_def, check_signature
+from guppylang.checker.func_checker import (
+    check_global_func_def,
+    check_signature,
+    parse_docstring,
+)
 from guppylang.compiler.core import CompiledGlobals, DFContainer
 from guppylang.compiler.func_compiler import compile_global_func_def
 from guppylang.definition.common import CheckableDef, CompilableDef, ParsableDef
@@ -39,13 +43,15 @@ class RawFunctionDef(ParsableDef):
 
     def parse(self, globals: Globals) -> "ParsedFunctionDef":
         """Parses and checks the user-provided signature of the function."""
-        func_ast = parse_py_func(self.python_func)
+        func_ast, docstring = parse_py_func(self.python_func)
         ty = check_signature(func_ast, globals)
         if ty.parametrized:
             raise GuppyError(
                 "Generic function definitions are not supported yet", func_ast
             )
-        return ParsedFunctionDef(self.id, self.name, func_ast, ty, self.python_scope)
+        return ParsedFunctionDef(
+            self.id, self.name, func_ast, ty, self.python_scope, docstring
+        )
 
 
 @dataclass(frozen=True)
@@ -59,6 +65,7 @@ class ParsedFunctionDef(CheckableDef, CallableDef):
     python_scope: PyScope
     defined_at: ast.FunctionDef
     ty: FunctionType
+    docstring: str | None
 
     description: str = field(default="function", init=False)
 
@@ -73,6 +80,7 @@ class ParsedFunctionDef(CheckableDef, CallableDef):
             self.defined_at,
             self.ty,
             self.python_scope,
+            self.docstring,
             cfg,
         )
 
@@ -119,6 +127,7 @@ class CheckedFunctionDef(ParsedFunctionDef, CompilableDef):
             self.defined_at,
             self.ty,
             self.python_scope,
+            self.docstring,
             self.cfg,
             def_node,
         )
@@ -161,7 +170,7 @@ class CompiledFunctionDef(CheckedFunctionDef, CompiledCallableDef):
         compile_global_func_def(self, self.hugr_node, graph, globals)
 
 
-def parse_py_func(f: PyFunc) -> ast.FunctionDef:
+def parse_py_func(f: PyFunc) -> tuple[ast.FunctionDef, str | None]:
     source_lines, line_offset = inspect.getsourcelines(f)
     source = "".join(source_lines)  # Lines already have trailing \n's
     source = textwrap.dedent(source)
@@ -172,4 +181,4 @@ def parse_py_func(f: PyFunc) -> ast.FunctionDef:
     annotate_location(func_ast, source, file, line_offset)
     if not isinstance(func_ast, ast.FunctionDef):
         raise GuppyError("Expected a function definition", func_ast)
-    return func_ast
+    return parse_docstring(func_ast)

--- a/guppylang/nodes.py
+++ b/guppylang/nodes.py
@@ -191,6 +191,7 @@ class PyExpr(ast.expr):
 class NestedFunctionDef(ast.FunctionDef):
     cfg: "CFG"
     ty: FunctionType
+    docstring: str | None
 
     def __init__(self, cfg: "CFG", ty: FunctionType, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)

--- a/tests/integration/test_docstring.py
+++ b/tests/integration/test_docstring.py
@@ -1,0 +1,73 @@
+from guppylang.decorator import guppy
+from guppylang.module import GuppyModule
+
+
+def test_docstring(validate):
+    @guppy
+    def f() -> None:
+        "Example docstring"
+
+    @guppy
+    def g() -> None:
+        """Multi
+        line
+        doc
+        string.
+        """
+        f()
+
+    @guppy
+    def nested() -> None:
+        """Test docstrings in nested functions"""
+
+        def f_nested() -> None:
+            "Example docstring"
+            f_nested()
+            g()
+
+        def g_nested() -> None:
+            """Multi
+            line
+            doc
+            string.
+            """
+
+    default_module = guppy.take_module()
+    validate(default_module.compile())
+
+
+def test_docstring_module(validate):
+    module = GuppyModule("")
+
+    @guppy(module)
+    def f() -> None:
+        "Example docstring"
+        f()
+
+    @guppy(module)
+    def g() -> None:
+        """Multi
+        line
+        doc
+        string.
+        """
+
+    @guppy(module)
+    def nested() -> None:
+        """Test docstrings in nested functions"""
+
+        def f_nested() -> None:
+            "Example docstring"
+            f()
+            g()
+
+        def g_nested() -> None:
+            """Multi
+            line
+            doc
+            string.
+            """
+            f()
+            f_nested()
+
+    validate(module.compile())


### PR DESCRIPTION
Parse docstrings for functions, including nested functions. We don't do anything with them for now, but previously we didn't recognise them and threw an "Unsupported constant" error (trying to interpret the statement as a string expression)

Docstrings for structs are TODO, and probably a separate PR