### PR TITLE
hack: Add very basic debug info

### DIFF
--- a/guppylang/compiler/func_compiler.py
+++ b/guppylang/compiler/func_compiler.py
@@ -47,7 +47,7 @@ def compile_local_func_def(
         [v.name for v, _ in captured] + list(func.ty.input_names),
     )
 
-    def_node = graph.add_def(closure_ty, dfg.node, func.name)
+    def_node = graph.add_def(closure_ty, dfg.node, func.name, func)
     def_input, input_ports = graph.add_input_with_ports(
         list(closure_ty.inputs), def_node
     )

--- a/guppylang/definition/custom.py
+++ b/guppylang/definition/custom.py
@@ -157,7 +157,7 @@ class CustomFunctionDef(CompiledCallableDef):
         # we explicitly monomorphise here and invoke the call compiler with the
         # inferred type args.
         fun_ty = self.ty.instantiate(type_args)
-        def_node = graph.add_def(fun_ty, dfg.node, self.name)
+        def_node = graph.add_def(fun_ty, dfg.node, self.name, self.defined_at)
         with graph.parent(def_node):
             _, inp_ports = graph.add_input_with_ports(list(fun_ty.inputs))
             returns = self.compile_call(
@@ -279,7 +279,10 @@ class OpCompiler(CustomCallCompiler):
 
     def compile(self, args: list[OutPortV]) -> list[OutPortV]:
         node = self.graph.add_node(
-            self.op.model_copy(deep=True), inputs=args, parent=self.dfg.node
+            self.op.model_copy(deep=True),
+            inputs=args,
+            parent=self.dfg.node,
+            debug=self.node,
         )
         return_ty = get_type(self.node)
         return [node.add_out_port(ty) for ty in type_to_row(return_ty)]

--- a/guppylang/definition/function.py
+++ b/guppylang/definition/function.py
@@ -112,7 +112,7 @@ class CheckedFunctionDef(ParsedFunctionDef, CompilableDef):
         access to the other compiled functions yet. The body is compiled later in
         `CompiledFunctionDef.compile_inner()`.
         """
-        def_node = graph.add_def(self.ty, parent, self.name)
+        def_node = graph.add_def(self.ty, parent, self.name, self.defined_at)
         return CompiledFunctionDef(
             self.id,
             self.name,

--- a/guppylang/module.py
+++ b/guppylang/module.py
@@ -33,6 +33,7 @@ class GuppyModule:
     """A Guppy module that may contain function and type definitions."""
 
     name: str
+    file: str | None
 
     # Whether the module has already been compiled
     _compiled: bool
@@ -59,8 +60,11 @@ class GuppyModule:
     # `_register_buffered_instance_funcs` is called. This way, we can associate
     _instance_func_buffer: dict[str, RawDef] | None
 
-    def __init__(self, name: str, import_builtins: bool = True):
+    def __init__(
+        self, name: str, file: str | None = None, import_builtins: bool = True
+    ):
         self.name = name
+        self.file = file
         self._globals = Globals({}, {}, {}, {})
         self._compiled_globals = {}
         self._imported_globals = Globals.default()
@@ -197,7 +201,7 @@ class GuppyModule:
         self._globals = self._globals.update_defs(other_defs)
 
         # Prepare Hugr for this module
-        graph = Hugr(self.name)
+        graph = Hugr(self.name, self.file)
         module_node = graph.set_root_name(self.name)
 
         # Compile definitions to Hugr


### PR DESCRIPTION
This branch is for testing of lowering of DWARF info in hugr-llvm. This implementation is quite hacky; we should wait until #257 is done to properly implement this.

This branch adds debug info to the following nodes:
* Module (requires passing an explict `file` parameter when constructing a `GuppyModule`)
* FuncDefn
* Most ExtensionOps

