### PR TITLE
fix: Use places in BB signatures for Hugr generation

### DIFF
--- a/guppylang/checker/cfg_checker.py
+++ b/guppylang/checker/cfg_checker.py
@@ -63,7 +63,8 @@ def check_cfg(
     """Type checks a control-flow graph.
 
     Annotates the basic blocks with input and output type signatures and removes
-    unreachable blocks.
+    unreachable blocks. Note that the inputs/outputs are annotated in the form of
+    *places* rather than just variables.
     """
     # First, we need to run program analysis
     ass_before = {v.name for v in inputs}

--- a/guppylang/checker/cfg_checker.py
+++ b/guppylang/checker/cfg_checker.py
@@ -6,45 +6,48 @@ Operates on CFGs produced by the `CFGBuilder`. Produces a `CheckedCFG` consistin
 
 import collections
 from collections.abc import Iterator, Sequence
-from dataclasses import dataclass
-from typing import TypeVar
+from dataclasses import dataclass, field
+from typing import Generic, TypeVar
 
 from guppylang.ast_util import line_col
 from guppylang.cfg.bb import BB
 from guppylang.cfg.cfg import CFG, BaseCFG
-from guppylang.checker.core import Context, Globals, Locals, Variable
+from guppylang.checker.core import Context, Globals, Locals, Place, V, Variable
 from guppylang.checker.expr_checker import ExprSynthesizer, to_bool
-from guppylang.checker.linearity_checker import check_cfg_linearity
 from guppylang.checker.stmt_checker import StmtChecker
 from guppylang.error import GuppyError
 from guppylang.tys.ty import Type
 
-VarRow = Sequence[Variable]
+Row = Sequence[V]
 
 
 @dataclass(frozen=True)
-class Signature:
+class Signature(Generic[V]):
     """The signature of a basic block.
 
-    Stores the input/output variables with their types.
+    Stores the input/output variables with their types. Generic over the representation
+    of program variables.
     """
 
-    input_row: VarRow
-    output_rows: Sequence[VarRow]  # One for each successor
+    input_row: Row[V]
+    output_rows: Sequence[Row[V]]  # One for each successor
 
     @staticmethod
-    def empty() -> "Signature":
+    def empty() -> "Signature[V]":
         return Signature([], [])
 
 
 @dataclass(eq=False)  # Disable equality to recover hash from `object`
-class CheckedBB(BB):
-    """Basic block annotated with an input and output type signature."""
+class CheckedBB(BB, Generic[V]):
+    """Basic block annotated with an input and output type signature.
 
-    sig: Signature = Signature.empty()  # noqa: RUF009
+    The signature is generic over the representation of program variables.
+    """
+
+    sig: Signature[V] = field(default_factory=Signature.empty)
 
 
-class CheckedCFG(BaseCFG[CheckedBB]):
+class CheckedCFG(BaseCFG[CheckedBB[V]], Generic[V]):
     input_tys: list[Type]
     output_ty: Type
 
@@ -55,8 +58,8 @@ class CheckedCFG(BaseCFG[CheckedBB]):
 
 
 def check_cfg(
-    cfg: CFG, inputs: VarRow, return_ty: Type, globals: Globals
-) -> CheckedCFG:
+    cfg: CFG, inputs: Row[Variable], return_ty: Type, globals: Globals
+) -> CheckedCFG[Place]:
     """Type checks a control-flow graph.
 
     Annotates the basic blocks with input and output type signatures and removes
@@ -67,7 +70,7 @@ def check_cfg(
     cfg.analyze(ass_before, ass_before)
 
     # We start by compiling the entry BB
-    checked_cfg = CheckedCFG([v.ty for v in inputs], return_ty)
+    checked_cfg: CheckedCFG[Variable] = CheckedCFG([v.ty for v in inputs], return_ty)
     checked_cfg.entry_bb = check_bb(
         cfg.entry_bb, checked_cfg, inputs, return_ty, globals
     )
@@ -117,18 +120,20 @@ def check_cfg(
     }
 
     # Finally, run the linearity check
-    check_cfg_linearity(checked_cfg)
+    from guppylang.checker.linearity_checker import check_cfg_linearity
 
-    return checked_cfg
+    linearity_checked_cfg = check_cfg_linearity(checked_cfg)
+
+    return linearity_checked_cfg
 
 
 def check_bb(
     bb: BB,
-    checked_cfg: CheckedCFG,
-    inputs: VarRow,
+    checked_cfg: CheckedCFG[Variable],
+    inputs: Row[Variable],
     return_ty: Type,
     globals: Globals,
-) -> CheckedBB:
+) -> CheckedBB[Variable]:
     cfg = bb.containing_cfg
 
     # For the entry BB we have to separately check that all used variables are
@@ -180,7 +185,7 @@ def check_bb(
     return checked_bb
 
 
-def check_rows_match(row1: VarRow, row2: VarRow, bb: BB) -> None:
+def check_rows_match(row1: Row[Variable], row2: Row[Variable], bb: BB) -> None:
     """Checks that the types of two rows match up.
 
     Otherwise, an error is thrown, alerting the user that a variable has different

--- a/guppylang/checker/func_checker.py
+++ b/guppylang/checker/func_checker.py
@@ -12,7 +12,7 @@ from guppylang.ast_util import return_nodes_in_ast, with_loc
 from guppylang.cfg.bb import BB
 from guppylang.cfg.builder import CFGBuilder
 from guppylang.checker.cfg_checker import CheckedCFG, check_cfg
-from guppylang.checker.core import Context, Globals, Variable
+from guppylang.checker.core import Context, Globals, Place, Variable
 from guppylang.definition.common import DefId
 from guppylang.error import GuppyError
 from guppylang.nodes import CheckedNestedFunctionDef, NestedFunctionDef
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
 def check_global_func_def(
     func_def: ast.FunctionDef, ty: FunctionType, globals: Globals
-) -> CheckedCFG:
+) -> CheckedCFG[Place]:
     """Type checks a top-level function definition."""
     args = func_def.args.args
     returns_none = isinstance(ty.output, NoneType)

--- a/guppylang/checker/linearity_checker.py
+++ b/guppylang/checker/linearity_checker.py
@@ -281,6 +281,9 @@ def check_cfg_linearity(cfg: "CheckedCFG[Variable]") -> "CheckedCFG[Place]":
     """Checks whether a CFG satisfies the linearity requirements.
 
     Raises a user-error if linearity violations are found.
+
+    Returns a new CFG with refined basic block signatures in terms of *places* rather
+    than just variables.
     """
     bb_checker = BBLinearityChecker()
     scopes: dict[BB, Scope] = {

--- a/guppylang/definition/function.py
+++ b/guppylang/definition/function.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from guppylang.ast_util import AstNode, annotate_location, with_loc
 from guppylang.checker.cfg_checker import CheckedCFG
-from guppylang.checker.core import Context, Globals, PyScope
+from guppylang.checker.core import Context, Globals, Place, PyScope
 from guppylang.checker.expr_checker import check_call, synthesize_call
 from guppylang.checker.func_checker import check_global_func_def, check_signature
 from guppylang.compiler.core import CompiledGlobals, DFContainer
@@ -103,7 +103,7 @@ class CheckedFunctionDef(ParsedFunctionDef, CompilableDef):
     graph for the function body.
     """
 
-    cfg: CheckedCFG
+    cfg: CheckedCFG[Place]
 
     def compile_outer(self, graph: Hugr, parent: Node) -> "CompiledFunctionDef":
         """Adds a Hugr `FuncDefn` node for this function to the Hugr.

--- a/guppylang/nodes.py
+++ b/guppylang/nodes.py
@@ -200,7 +200,7 @@ class NestedFunctionDef(ast.FunctionDef):
 
 class CheckedNestedFunctionDef(ast.FunctionDef):
     def_id: "DefId"
-    cfg: "CheckedCFG"
+    cfg: "CheckedCFG[Place]"
     ty: FunctionType
 
     #: Mapping from names to variables captured by this function, together with an AST
@@ -210,7 +210,7 @@ class CheckedNestedFunctionDef(ast.FunctionDef):
     def __init__(
         self,
         def_id: "DefId",
-        cfg: "CheckedCFG",
+        cfg: "CheckedCFG[Place]",
         ty: FunctionType,
         captured: Mapping[str, tuple["Variable", AstNode]],
         *args: Any,

--- a/tests/error/comprehension_errors/pattern_override2.err
+++ b/tests/error/comprehension_errors/pattern_override2.err
@@ -4,4 +4,4 @@ Guppy compilation failed. Error in file $FILE:13
 12:    def foo(qs: linst[qubit], xs: list[int]) -> list[int]:
 13:        return [q for q in qs for q in xs]
                          ^
-GuppyError: Variable `q` with linear type `qubit` is not used
+GuppyTypeError: Variable `q` with linear type `qubit` is not used

--- a/tests/error/linear_errors/if_both_unused_reassign_field.err
+++ b/tests/error/linear_errors/if_both_unused_reassign_field.err
@@ -3,4 +3,4 @@ Guppy compilation failed. Error in file $FILE:17
 15:    @guppy(module)
 16:    def foo(b: bool, s: MyStruct) -> MyStruct:
                         ^^^^^^^^^^^
-GuppyError: Field `s.q` with linear type `qubit` is not used
+GuppyError: Field `s.q` with linear type `qubit` is not used on all control-flow paths

--- a/tests/integration/test_linear.py
+++ b/tests/integration/test_linear.py
@@ -219,6 +219,30 @@ def test_struct_reassign(validate):
         return s.x
 
 
+def test_struct_reassign2(validate):
+    module = GuppyModule("test")
+    module.load(quantum)
+
+    @guppy.struct(module)
+    class MyStruct:
+        q1: qubit
+        q2: qubit
+
+    @guppy.declare(module)
+    def use(q: qubit) -> None:
+        ...
+
+    @guppy(module)
+    def test(s: MyStruct, b: bool) -> MyStruct:
+        use(s.q1)
+        if b:
+            s.q1 = qubit()
+        else:
+            s.q1 = qubit()
+        s.q2 = qubit()
+        return s
+
+
 def test_measure(validate):
     module = GuppyModule("test")
     module.load(quantum)


### PR DESCRIPTION
Fixes  #337.

The fix for the linearity checker is easy: When checking assignments, only complain if a *local* unused linear variable is shadowed.

However, correctly lowering the program in #337 to Hugr requires some additional changes to Hugr codegen. Namely, we need to consider if a BB uses a *whole* struct `s` or only some of its fields. In the latter case, we should only feed those used values into the BB. This requires specifying the signature of BBs in the form of `Place`s rather than `Variable`s.

Concretely, this PR does the following:

* Make `Signature` generic over the representation of program variables so it can capture both `Variable` and `Place`
* Similarly, make `CheckedBB` and `CheckedCFG` generic
* During checking, we first construct a `CheckedCFG[Variable]` which then gets turned into a `CheckedCFG[Place]` during linearity checking
* Add a test case