### PR TITLE
test: guppy -> pytket lowering with tket2

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -66,8 +66,8 @@ jobs:
       - name: Install tket2 dependencies
         run: poetry install --with pytket
 
-      - name: Rerun `py(...)` expression tests with tket2 installed
-        run: poetry run pytest tests/integration/test_py.py tests/error/test_py_errors.py
+      - name: Rerun `py(...)` expression tests and pytket lowering with tket2 installed
+        run: poetry run pytest tests/integration/test_py.py tests/error/test_py_errors.py tests/integration/test_tket.py
 
   coverage:
     if: github.event_name != 'merge_group'

--- a/poetry.lock
+++ b/poetry.lock
@@ -1048,6 +1048,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -1188,13 +1189,13 @@ test = ["Cython", "array-api-strict", "asv", "gmpy2", "hypothesis (>=6.30)", "me
 
 [[package]]
 name = "setuptools"
-version = "71.1.0"
+version = "72.1.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-71.1.0-py3-none-any.whl", hash = "sha256:33874fdc59b3188304b2e7c80d9029097ea31627180896fb549c578ceb8a0855"},
-    {file = "setuptools-71.1.0.tar.gz", hash = "sha256:032d42ee9fb536e33087fb66cac5f840eb9391ed05637b3f2a76a7c8fb477936"},
+    {file = "setuptools-72.1.0-py3-none-any.whl", hash = "sha256:5a03e1860cf56bb6ef48ce186b0e557fdba433237481a9a625176c2831be15d1"},
+    {file = "setuptools-72.1.0.tar.gz", hash = "sha256:8d243eff56d095e5817f796ede6ae32941278f542e0f941867cc05ae52b162ec"},
 ]
 
 [package.extras]
@@ -1406,8 +1407,8 @@ pytket = "1.30.0"
 [package.source]
 type = "git"
 url = "https://github.com/CQCL/tket2.git"
-reference = "eca258bfbef5fcd82a0d3b3d70cb736e275b3487"
-resolved_reference = "eca258bfbef5fcd82a0d3b3d70cb736e275b3487"
+reference = "da778dd79121c4e20b07934708db765ca717dc31"
+resolved_reference = "da778dd79121c4e20b07934708db765ca717dc31"
 
 [[package]]
 name = "tomli"
@@ -1482,4 +1483,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "275bd6ae43cc6f638b72832baa98301355c0691e1d8a848a553792901f61a0e5"
+content-hash = "da9df1340f5c1f1cb41fb0c0b5d96b421893886bfc67a8752fab8726660cdfeb"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1392,23 +1392,81 @@ mpmath = ">=1.1.0,<1.4"
 dev = ["hypothesis (>=6.70.0)", "pytest (>=7.1.0)"]
 
 [[package]]
-name = "tket2-py"
-version = "0.1.0a4"
-description = "pytket extension for the tket 2 compiler"
+name = "tket2"
+version = "0.2.0"
+description = "Quantinuum's TKET2 Quantum Compiler"
 optional = false
-python-versions = "^3.10"
-files = []
-develop = false
+python-versions = ">=3.10"
+files = [
+    {file = "tket2-0.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:85538ba800b63de51bcf1334de167b8f5ca57a2624f0bb555787b0111b761332"},
+    {file = "tket2-0.2.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:474f596653128624394a9ea8ca4668c8a43c4bc5fcab9981bc0c1f0700b12566"},
+    {file = "tket2-0.2.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02e9ef68dcba8099d0b484ad2892d45412967ab02cc222a7e0085e9420ae540a"},
+    {file = "tket2-0.2.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9ab2e864fecfac142655f09e3c78e16eb77831ec6c49a2d3a88abdf285263184"},
+    {file = "tket2-0.2.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:85f0d9ff11c4aca6634ca8a90657433747d0630553025cd68c266529fcf2631b"},
+    {file = "tket2-0.2.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:05d6beecbe2a6d38bda00ed174d7851312a7654a35860c0c316f1f61806a9d1f"},
+    {file = "tket2-0.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10939961ccfc5fb8ed23054bc90b80ca6cab2f077e4e2789fd6d316fe77f9102"},
+    {file = "tket2-0.2.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:216108174ee0323c7016ccb77b16d47b678b84ce9699be34a387bcb03a5407ec"},
+    {file = "tket2-0.2.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:a36c060e91c70752c8ab2a647afcdb276cee7bf4891f6e9139d3f0d8f5710262"},
+    {file = "tket2-0.2.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:571ed66d5fa82161af3ddcc2524b76c7e70c815ff6de91f195dd1b7baf018cdf"},
+    {file = "tket2-0.2.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:d5a58253f1e89346aaac5ca35a6c749ac201e3e2c4fabded409f5b9e506fa524"},
+    {file = "tket2-0.2.0-cp310-none-win32.whl", hash = "sha256:0911dddd1d659c5e2f1e0e59ab158cc047e4d1c0648f96787c97fcb69914b606"},
+    {file = "tket2-0.2.0-cp310-none-win_amd64.whl", hash = "sha256:1d8a63beb398fdd1600a3cf7cc9e07cbcced5eefe9d39f75111c4edfa415133b"},
+    {file = "tket2-0.2.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:cee49fb5b09e4dd4ed4b768a328351f222ed863e562e60054026c00a54b3de69"},
+    {file = "tket2-0.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c3ba74e83750c230f74af3d8154d0760a82fd768e203abf83f1d442bf4837a7d"},
+    {file = "tket2-0.2.0-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:59ecd52a44984101b947e7b6e454686b0fa42d968d6b03b8a38252b6d60f1f3c"},
+    {file = "tket2-0.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f7df45d0d80c9a9920c6cf0217ec859946c04881b8172cf0d7616e341a8fd47b"},
+    {file = "tket2-0.2.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b872a6aadd637e6dfd54e9b92ccf6126e41dd03404363a52b2f8f65157b4a87d"},
+    {file = "tket2-0.2.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0db435270ad2eabf25eb8d84e684d7c1f7b447c60c0d6128231441d48212b447"},
+    {file = "tket2-0.2.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c296fe29f54a0af1499533b7530b799a761d671af2a3349bb9d40674149c5f1d"},
+    {file = "tket2-0.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:139c5cb285d37320afecda16095decfdad3ee72991c22ea8f1ba5301429e899c"},
+    {file = "tket2-0.2.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:10de3255e029cda66a86fdb9e37f64eea4b1308562bc4a2a1b2c733d8a1df711"},
+    {file = "tket2-0.2.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:2a9e9e88e608c62405534f45b96a36f4f59ec0d8894e9a69a2b2c77c530d0ac3"},
+    {file = "tket2-0.2.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:fe461009bf95532e84c09fbf9c7f015bcec9066f0bc7f669959ea5e7dc3031ce"},
+    {file = "tket2-0.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:509598cacda037eac65773f45350cacf1a7e39cac0232fcecb59797b44a5bca8"},
+    {file = "tket2-0.2.0-cp311-none-win32.whl", hash = "sha256:aef143f456b6b9fe7f914b5e53bce173cef419f33ba0675ba150a01e923aae4d"},
+    {file = "tket2-0.2.0-cp311-none-win_amd64.whl", hash = "sha256:d481b636649792307676af019e9d97e00f6e34edb49007918700dfddd674eaf7"},
+    {file = "tket2-0.2.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:1daa99dfd32c3631449d4bf012c3ee57af8d9ec7722cc09eca555b3bd69ab158"},
+    {file = "tket2-0.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f2c3bdff6d6a6f1e7ff718f3c68ed758e333d8568a4553af9b19051f49bfae75"},
+    {file = "tket2-0.2.0-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f54529349e33623671e4f3fbf424a386c66876379c45e838d138a22f84007dbf"},
+    {file = "tket2-0.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:82b3e4901c98a9a8000239a728b439a81a1b50b735ab39d8a5baa8b5406cd03b"},
+    {file = "tket2-0.2.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3c110968c3a7a2b04a338c4bb1d588cb6c810713c3618a3d796bee6d461c4457"},
+    {file = "tket2-0.2.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc362867c3dd6e2e872163eebef39ed18d26ca715fbbe9dec3fe6ec9adcdc61b"},
+    {file = "tket2-0.2.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:860198bacb7f14a6aee02630eb4f686cca20108cd8713fe0aa078176a7871f32"},
+    {file = "tket2-0.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f467fdfb1d1a2d197940ff711bbf54934675141df46f255769a074bff4f56122"},
+    {file = "tket2-0.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3bb3100ba604a5915733f2b15230d8dfcdd92be60cca7f554f24bcf075530a04"},
+    {file = "tket2-0.2.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:2ab7c00ad7a3f3cbe45570087194545b22c0eea24e269a5511a7c500a6867ed5"},
+    {file = "tket2-0.2.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:f3357eb2bd5edb4e2e8ac9fa0a82cb9c6a9c9b0796c2d9b6b384a974690e0b3a"},
+    {file = "tket2-0.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:76a437c9cc9116b69dd42028b2059ffa8bc2e69e7898f93671ba30c0ec51dd18"},
+    {file = "tket2-0.2.0-cp312-none-win32.whl", hash = "sha256:501391a85f4c5d9e3b6ddca2d8765f56f045dd96c8e6ee90f998082b257b5bc0"},
+    {file = "tket2-0.2.0-cp312-none-win_amd64.whl", hash = "sha256:6a5f763b48f721995cf5b83c72cd275ec7140ff5d140753fcde4f89bf1d2be53"},
+    {file = "tket2-0.2.0-pp310-pypy310_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c361724bdf1d3a95abd75b33e0fe06421b082c867e06be3c3f13ea323f5ee778"},
+    {file = "tket2-0.2.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab8db595d573da59e08d9fd1e7957734495470b3c119a043e01c6c24d928201b"},
+    {file = "tket2-0.2.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:584aae56ba7f8fac3325d62f129e5ccb2f73c4b83b5e1b2ba620fa4c7eb5e100"},
+    {file = "tket2-0.2.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:21c9d398a5298d17578132ed3d6c22ee8c9935a0b97d3d6c61d87e75dccf0116"},
+    {file = "tket2-0.2.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:becb2182b6402a77c7f506754e3bface43294225afc8978b7408709c2ca9cf46"},
+    {file = "tket2-0.2.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:87eca576c484ed77ab098c675a51b88c28c0de77c64cfc9623a73e5d1a004bb6"},
+    {file = "tket2-0.2.0-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:6e868028cde96c5c83d6e5dd5f3d568e53abbf7fd4dff43f41efe96582613e67"},
+    {file = "tket2-0.2.0-pp310-pypy310_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:7a1e1ebbeb7193e2842c8e6235c1d2f262ea91096f1d9802abf057a7fa435d72"},
+    {file = "tket2-0.2.0-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:38019b4cab2368fc112daf8ccccbadc315d3fbad3b1089dd5b1b2698c8fcb3c9"},
+    {file = "tket2-0.2.0-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:245c50a1fca6a3d349ab8f57627a0d4c2bdc2acecc0bcd64ced7930c0cd3337e"},
+    {file = "tket2-0.2.0.tar.gz", hash = "sha256:84721a12592711f4b9cb40ea780c44892d0bc24728af0ec5910678ca495fdb09"},
+]
 
 [package.dependencies]
-hugr = "^0.5.0"
-pytket = "1.30.0"
+hugr = ">=0.5.0,<0.6"
+pytket = ">=1.29.2,<2"
+tket2-eccs = ">=0.1.0,<0.2"
 
-[package.source]
-type = "git"
-url = "https://github.com/CQCL/tket2.git"
-reference = "da778dd79121c4e20b07934708db765ca717dc31"
-resolved_reference = "da778dd79121c4e20b07934708db765ca717dc31"
+[[package]]
+name = "tket2-eccs"
+version = "0.1.0"
+description = "Precompiled rewrite sets for the tket 2 compiler"
+optional = false
+python-versions = "<4.0,>=3.10"
+files = [
+    {file = "tket2_eccs-0.1.0-py3-none-any.whl", hash = "sha256:28129539435e094131edd01a0e7e77f5660ce5aa471b307d2cd60d710e48db2e"},
+    {file = "tket2_eccs-0.1.0.tar.gz", hash = "sha256:1cbe4ce02c8863cb6416aafe39e499fa8c1349351f3028d9be02951e8009944d"},
+]
 
 [[package]]
 name = "tomli"
@@ -1483,4 +1541,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "da9df1340f5c1f1cb41fb0c0b5d96b421893886bfc67a8752fab8726660cdfeb"
+content-hash = "8b5decbd3509b37043b11a803ed1ed0e2b1bd9ac663c9641be69a1dd564712ed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,7 @@ optional = true
 
 [tool.poetry.group.pytket.dependencies]
 pytket = { version = "^1.30.0" }
-#tket2 = { version = "^0.1.0a5" } # TODO: Use this instead of a git dep once released
-tket2-py = { git = "https://github.com/CQCL/tket2.git", rev = "da778dd79121c4e20b07934708db765ca717dc31" }
+tket2 = { version = "^0.2.0" }
 
 [tool.poetry.group.docs]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,9 @@ execute_llvm = { path = "execute_llvm" }
 optional = true
 
 [tool.poetry.group.pytket.dependencies]
-pytket = { version = "^1.24.0" }
-tket2-py = { git = "https://github.com/CQCL/tket2.git", rev = "eca258bfbef5fcd82a0d3b3d70cb736e275b3487" }
-
+pytket = { version = "^1.30.0" }
+#tket2 = { version = "^0.1.0a5" } # TODO: Use this instead of a git dep once released
+tket2-py = { git = "https://github.com/CQCL/tket2.git", rev = "da778dd79121c4e20b07934708db765ca717dc31" }
 
 [tool.poetry.group.docs]
 optional = true

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -45,6 +45,9 @@ def run_int_fn():
         try:
             import execute_llvm
 
+            if not hasattr(execute_llvm, "run_int_function"):
+                pytest.skip("Skipping llvm execution")
+
             hugr_json: str = hugr.serialize()
             res = execute_llvm.run_int_function(hugr_json, fn_name)
             if res != expected:

--- a/tests/integration/test_py.py
+++ b/tests/integration/test_py.py
@@ -1,3 +1,5 @@
+"""Tests for using python expressions in guppy functions."""
+
 from importlib.util import find_spec
 
 import pytest

--- a/tests/integration/test_tket.py
+++ b/tests/integration/test_tket.py
@@ -1,0 +1,152 @@
+"""Tests for lowering guppy definitions to pytket circuits.
+
+As pytket does not have the same expressivity as HUGR, this test suite only
+includes programs that we know should be lowerable.
+
+This depends on the lowering passes implemented by `tket2`. If guppy generated
+HUGRs change their structure in a way that is no longer supported by those
+passes, disable the failing tests and open an issue to improve support in tket2.
+
+https://github.com/CQCL/tket2/issues/new
+"""
+
+from importlib.util import find_spec
+from typing import no_type_check
+
+import math
+import pytest
+
+from guppylang.decorator import guppy
+from guppylang.module import GuppyModule
+from guppylang.prelude.builtins import py
+from guppylang.prelude.quantum import qubit, quantum
+from guppylang.prelude.quantum import measure, phased_x, rz, zz_max
+from tests.util import guppy_to_circuit
+
+tket2_installed = find_spec("tket2") is not None
+
+
+@pytest.mark.skipif(not tket2_installed, reason="Tket2 is not installed")
+def test_pytket_single_qubit(validate):
+    from pytket import Circuit
+
+    circ = Circuit(1)
+    circ.H(0)
+
+    module = GuppyModule("test")
+    module.load(quantum)
+
+    @guppy(module)
+    def foo(q: qubit) -> qubit:
+        f = py(circ)
+        return f(q)
+
+    validate(module.compile())
+
+
+@pytest.mark.skipif(not tket2_installed, reason="Tket2 is not installed")
+def test_pytket_multi_qubit(validate):
+    from pytket import Circuit
+
+    circ = Circuit(3)
+    circ.CX(0, 1)
+    circ.H(2)
+    circ.T(0)
+    circ.CZ(2, 0)
+
+    module = GuppyModule("test")
+    module.load(quantum)
+
+    @guppy(module)
+    def foo(q1: qubit, q2: qubit, q3: qubit) -> tuple[qubit, qubit, qubit]:
+        return py(circ)(q1, q2, q3)
+
+    validate(module.compile())
+
+
+@pytest.mark.skip(
+    "Now requires a conversion pass to turn TKET1 measurements into TKET2 measurements"
+)
+@pytest.mark.skipif(not tket2_installed, reason="Tket2 is not installed")
+def test_pytket_measure(validate):
+    from pytket import Circuit
+
+    circ = Circuit(1)
+    circ.H(0)
+    circ.measure_all()
+
+    module = GuppyModule("test")
+    module.load(quantum)
+
+    @guppy(module)
+    def foo(q: qubit) -> tuple[qubit, bool]:
+        return py(circ)(q)
+
+    validate(module.compile())
+
+
+@pytest.mark.skipif(not tket2_installed, reason="Tket2 is not installed")
+def test_load_pure_circuit():
+    import pytket
+
+    module = GuppyModule("test")
+    module.load(quantum)
+
+    @guppy(module)
+    @no_type_check
+    def my_func(
+        q0: qubit,
+        q1: qubit,
+    ) -> tuple[qubit, qubit]:  # pragma: no cover
+        q0 = phased_x(q0, py(math.pi / 2), py(-math.pi / 2))
+        q0 = rz(q0, py(math.pi))
+        q1 = phased_x(q1, py(math.pi / 2), py(-math.pi / 2))
+        q1 = rz(q1, py(math.pi))
+        q0, q1 = zz_max(q0, q1)
+        q0 = rz(q0, py(math.pi))
+        q1 = rz(q1, py(math.pi))
+        return (q0, q1)
+
+    circ = guppy_to_circuit(my_func)
+    assert circ.num_operations() == 7
+
+    tk1 = circ.to_tket1()
+    assert tk1.n_gates == 7
+    assert tk1.n_qubits == 2
+
+    gates = list(tk1)
+    assert gates[4].op.type == pytket.circuit.OpType.ZZMax
+
+
+@pytest.mark.skipif(not tket2_installed, reason="Tket2 is not installed")
+def test_load_hybrid_circuit():
+    import pytket
+
+    module = GuppyModule("test")
+    module.load(quantum)
+
+    @guppy(module)
+    @no_type_check
+    def my_func(
+        q0: qubit,
+        q1: qubit,
+    ) -> tuple[bool,]:  # pragma: no cover
+        q0 = phased_x(q0, py(math.pi / 2), py(-math.pi / 2))
+        q0 = rz(q0, py(math.pi))
+        q1 = phased_x(q1, py(math.pi / 2), py(-math.pi / 2))
+        q1 = rz(q1, py(math.pi))
+        q0, q1 = zz_max(q0, q1)
+        _ = measure(q0)
+        return (measure(q1),)
+
+    circ = guppy_to_circuit(my_func)
+
+    # The 7 operations in the function, plus two implicit QFree
+    assert circ.num_operations() == 9
+
+    tk1 = circ.to_tket1()
+    assert tk1.n_gates == 7
+    assert tk1.n_qubits == 2
+
+    gates = list(tk1)
+    assert gates[4].op.type == pytket.circuit.OpType.ZZMax

--- a/tests/integration/test_tket.py
+++ b/tests/integration/test_tket.py
@@ -11,7 +11,6 @@ https://github.com/CQCL/tket2/issues/new
 """
 
 from importlib.util import find_spec
-from typing import no_type_check
 
 import math
 import pytest
@@ -34,11 +33,10 @@ def test_lower_pure_circuit():
     module.load(quantum)
 
     @guppy(module)
-    @no_type_check
     def my_func(
         q0: qubit,
         q1: qubit,
-    ) -> tuple[qubit, qubit]:  # pragma: no cover
+    ) -> tuple[qubit, qubit]:
         q0 = phased_x(q0, py(math.pi / 2), py(-math.pi / 2))
         q0 = rz(q0, py(math.pi))
         q1 = phased_x(q1, py(math.pi / 2), py(-math.pi / 2))
@@ -67,11 +65,10 @@ def test_lower_hybrid_circuit():
     module.load(quantum)
 
     @guppy(module)
-    @no_type_check
     def my_func(
         q0: qubit,
         q1: qubit,
-    ) -> tuple[bool,]:  # pragma: no cover
+    ) -> tuple[bool,]:
         q0 = phased_x(q0, py(math.pi / 2), py(-math.pi / 2))
         q0 = rz(q0, py(math.pi))
         q1 = phased_x(q1, py(math.pi / 2), py(-math.pi / 2))

--- a/tests/integration/test_tket.py
+++ b/tests/integration/test_tket.py
@@ -27,66 +27,7 @@ tket2_installed = find_spec("tket2") is not None
 
 
 @pytest.mark.skipif(not tket2_installed, reason="Tket2 is not installed")
-def test_pytket_single_qubit(validate):
-    from pytket import Circuit
-
-    circ = Circuit(1)
-    circ.H(0)
-
-    module = GuppyModule("test")
-    module.load(quantum)
-
-    @guppy(module)
-    def foo(q: qubit) -> qubit:
-        f = py(circ)
-        return f(q)
-
-    validate(module.compile())
-
-
-@pytest.mark.skipif(not tket2_installed, reason="Tket2 is not installed")
-def test_pytket_multi_qubit(validate):
-    from pytket import Circuit
-
-    circ = Circuit(3)
-    circ.CX(0, 1)
-    circ.H(2)
-    circ.T(0)
-    circ.CZ(2, 0)
-
-    module = GuppyModule("test")
-    module.load(quantum)
-
-    @guppy(module)
-    def foo(q1: qubit, q2: qubit, q3: qubit) -> tuple[qubit, qubit, qubit]:
-        return py(circ)(q1, q2, q3)
-
-    validate(module.compile())
-
-
-@pytest.mark.skip(
-    "Now requires a conversion pass to turn TKET1 measurements into TKET2 measurements"
-)
-@pytest.mark.skipif(not tket2_installed, reason="Tket2 is not installed")
-def test_pytket_measure(validate):
-    from pytket import Circuit
-
-    circ = Circuit(1)
-    circ.H(0)
-    circ.measure_all()
-
-    module = GuppyModule("test")
-    module.load(quantum)
-
-    @guppy(module)
-    def foo(q: qubit) -> tuple[qubit, bool]:
-        return py(circ)(q)
-
-    validate(module.compile())
-
-
-@pytest.mark.skipif(not tket2_installed, reason="Tket2 is not installed")
-def test_load_pure_circuit():
+def test_lower_pure_circuit():
     import pytket
 
     module = GuppyModule("test")
@@ -119,7 +60,7 @@ def test_load_pure_circuit():
 
 
 @pytest.mark.skipif(not tket2_installed, reason="Tket2 is not installed")
-def test_load_hybrid_circuit():
+def test_lower_hybrid_circuit():
     import pytket
 
     module = GuppyModule("test")

--- a/tests/util.py
+++ b/tests/util.py
@@ -7,7 +7,9 @@ from guppylang.module import GuppyModule
 
 if TYPE_CHECKING:
     try:
-        from tket2.circuit import Tk2Circuit
+        from tket2.circuit import (
+            Tk2Circuit,  # type: ignore[import-untyped, import-not-found, unused-ignore]
+        )
     except ImportError:
         Tk2Circuit = Any
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,6 +1,15 @@
+from typing import TYPE_CHECKING, Any
+
 import guppylang
+from guppylang.definition.function import RawFunctionDef
 from guppylang.hugr_builder.hugr import Hugr
 from guppylang.module import GuppyModule
+
+if TYPE_CHECKING:
+    try:
+        from tket2.circuit import Tk2Circuit
+    except ImportError:
+        Tk2Circuit = Any
 
 
 def compile_guppy(fn) -> Hugr:
@@ -28,3 +37,18 @@ def dump_llvm(hugr: Hugr):
 
     except ImportError:
         pass
+
+
+def guppy_to_circuit(guppy_func: RawFunctionDef) -> "Tk2Circuit":
+    """Convert a Guppy function definition to a `Tk2Circuit`."""
+    # TODO: Should this be part of the guppy API?
+    from tket2.circuit import Tk2Circuit
+
+    module = guppy_func.id.module
+    assert module is not None, "Function definition must belong to a module"
+
+    hugr = module.compile()
+    assert hugr is not None, "Module must be compilable"
+
+    json = hugr.to_raw().to_json()
+    return Tk2Circuit.from_guppy_json(json, guppy_func.name)


### PR DESCRIPTION
Adds the tests removed from tket2 in https://github.com/CQCL/tket2/pull/516

This requires a tket2 alpha release to avoid the git ref dependency.