### PR TITLE
fix: Linearity checking bug

### DIFF
--- a/guppylang/checker/linearity_checker.py
+++ b/guppylang/checker/linearity_checker.py
@@ -314,7 +314,7 @@ def check_cfg_linearity(cfg: "CheckedCFG[Variable]") -> "CheckedCFG[Place]":
                     )
 
             # On the other hand, unused linear variables *must* be outputted
-            for place in scope.vars.values():
+            for place in scope.values():
                 for leaf in leaf_places(place):
                     x = leaf.id
                     used_later = x in live

--- a/tests/error/linear_errors/while_unused.err
+++ b/tests/error/linear_errors/while_unused.err
@@ -1,0 +1,7 @@
+Guppy compilation failed. Error in file $FILE:13
+
+11:    @guppy(module)
+12:    def test(n: int) -> None:
+13:        q = qubit()
+           ^
+GuppyError: Variable `q` with linear type `qubit` is not used on all control-flow paths

--- a/tests/error/linear_errors/while_unused.py
+++ b/tests/error/linear_errors/while_unused.py
@@ -1,0 +1,20 @@
+import guppylang.prelude.quantum as quantum
+from guppylang.decorator import guppy
+from guppylang.module import GuppyModule
+from guppylang.prelude.quantum import qubit
+
+
+module = GuppyModule("test")
+module.load(quantum)
+
+
+@guppy(module)
+def test(n: int) -> None:
+    q = qubit()
+    i = 0
+    while i < n:
+        q = h(q)
+        i += 1
+
+
+module.compile()


### PR DESCRIPTION
Fixes #354.

When checking for unused linear variables, we should look at *all* variables in scope, not only the ones that were defined in the current BB