### PR TITLE
chore: Use local ruff and mypy for pre-commit checks

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -45,17 +45,10 @@ jobs:
         run: poetry run mypy guppylang
 
       - name: Check formatting with ruff
-        uses: chartboost/ruff-action@v1
-        with:
-          src: "./guppylang"
-          args: format --check
-          version: 0.4.2
+        run: poetry run ruff format --check guppylang
 
       - name: Lint with ruff
-        uses: chartboost/ruff-action@v1
-        with:
-          src: "./guppylang"
-          args: check
+        run: poetry run ruff check guppylang
 
       - name: Install Guppy with validation and llvm-based execution
         run: poetry install --with execution,validation

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,30 +24,36 @@ repos:
     hooks:
       - id: typos
 
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.6
-    hooks:
-      - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
-      - id: ruff-format
-
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.10.0"
-    hooks:
-      - id: mypy
-        pass_filenames: false
-        args: [--package=guppylang]
-        additional_dependencies: [
-          hugr,
-          graphviz,
-          networkx,
-          ormsgpack,
-          pydantic,
-          pytket,
-          ]
-
   - repo: local
     hooks:
+      - id: poetry-install
+        name: sync poetry deps
+        description: Ensure development tools are installed.
+        entry: poetry install --sync
+        language: system
+        files: poetry.lock
+        pass_filenames: false
+      - id: ruff-format
+        name: ruff format
+        description: Format python code with `ruff`.
+        entry: poetry run ruff format guppylang
+        language: system
+        files: \.py$
+        pass_filenames: false
+      - id: ruff-check
+        name: ruff
+        description: Check python code with `ruff`.
+        entry: poetry run ruff check --fix --exit-non-zero-on-fix guppylang
+        language: system
+        files: \.py$
+        pass_filenames: false
+      - id: mypy-check
+        name: mypy
+        description: Check python code with `mypy`.
+        entry: poetry run mypy guppylang
+        language: system
+        files: \.py$
+        pass_filenames: false
       - id: cargo-check
         name: Cargo check
         entry: bash -c 'cd validator && exec cargo check'

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 
-@pytest.fixture()
+@pytest.fixture
 def export_test_cases_dir(request):
     r = request.config.getoption("--export-test-cases")
     if r and not r.exists():
@@ -12,7 +12,7 @@ def export_test_cases_dir(request):
     return r
 
 
-@pytest.fixture()
+@pytest.fixture
 def validate(request, export_test_cases_dir: Path):
     def validate_json(hugr: str):
         try:
@@ -39,7 +39,7 @@ class LLVMException(Exception):
     pass
 
 
-@pytest.fixture()
+@pytest.fixture
 def run_int_fn():
     def f(hugr: Hugr, expected: int, fn_name: str = "main"):
         try:

--- a/tests/integration/test_functional.py
+++ b/tests/integration/test_functional.py
@@ -4,7 +4,7 @@ from tests.integration.util import functional, _
 from tests.util import compile_guppy
 
 
-@pytest.mark.skip()
+@pytest.mark.skip
 def test_if_no_else(validate):
     @compile_guppy
     def foo(x: bool, y: int) -> int:
@@ -16,7 +16,7 @@ def test_if_no_else(validate):
     validate(foo)
 
 
-@pytest.mark.skip()
+@pytest.mark.skip
 def test_if_else(validate):
     @compile_guppy
     def foo(x: bool, y: int) -> int:
@@ -30,7 +30,7 @@ def test_if_else(validate):
     validate(foo)
 
 
-@pytest.mark.skip()
+@pytest.mark.skip
 def test_if_elif(validate):
     @compile_guppy
     def foo(x: bool, y: int) -> int:
@@ -44,7 +44,7 @@ def test_if_elif(validate):
     validate(foo)
 
 
-@pytest.mark.skip()
+@pytest.mark.skip
 def test_if_elif_else(validate):
     @compile_guppy
     def foo(x: bool, y: int) -> int:
@@ -60,7 +60,7 @@ def test_if_elif_else(validate):
     validate(foo)
 
 
-@pytest.mark.skip()
+@pytest.mark.skip
 def test_infinite_loop(validate):
     @compile_guppy
     def foo() -> int:
@@ -71,7 +71,7 @@ def test_infinite_loop(validate):
     validate(foo)
 
 
-@pytest.mark.skip()
+@pytest.mark.skip
 def test_counting_loop(validate):
     @compile_guppy
     def foo(i: int) -> int:
@@ -82,7 +82,7 @@ def test_counting_loop(validate):
     validate(foo)
 
 
-@pytest.mark.skip()
+@pytest.mark.skip
 def test_nested_loop(validate):
     @compile_guppy
     def foo(x: int, y: int) -> int:


### PR DESCRIPTION
Ensures that the checks run by pre-commit are the same as the ones run in CI, and the `ruff` and `mypy` versions are always controlled by `pyproject.toml`.
Before, we used pre-commit actions with their own versions that needed to be updated separately and tended to get out of date.

drive-by: Fix ruff lints added in the latest version