### PR TITLE
ci: Configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # NOTE: This won't update the `uv.lock` file yet, so that should be updated
+  # manually when needed.
+  # https://github.com/dependabot/dependabot-core/issues/10478
+  - package-ecosystem: "pip"
+    directories: # Location of package manifests
+      - "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      # Use a conventional commit tag
+      prefix: "chore(deps-py)"
+    groups:
+      dev:
+        dependency-type: "development"
+        update-types: ["patch", "minor"]
+      patch:
+        update-types: ["patch"]
+      minor:
+        update-types: ["minor"]
+      # Major updates still generate individual PRs
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      # Use a conventional commit tag
+      prefix: "ci(deps)"


### PR DESCRIPTION
Note that the new `uv.lock` file added in #398 will not be updated at the moment.
There's an open issue for that: [dependabot-core#10478](https://www.github.com/dependabot/dependabot-core/issues/10478)