### PR TITLE
feat: Allow imports of function definitions and aliased imports

### DIFF
--- a/guppylang/decorator.py
+++ b/guppylang/decorator.py
@@ -34,6 +34,7 @@ FuncDefDecorator = Callable[[PyFunc], RawFunctionDef]
 FuncDeclDecorator = Callable[[PyFunc], RawFunctionDecl]
 CustomFuncDecorator = Callable[[PyFunc], RawCustomFunctionDef]
 ClassDecorator = Callable[[type], type]
+OpaqueTypeDecorator = Callable[[type], OpaqueTypeDef]
 StructDecorator = Callable[[type], RawStructDef]
 
 
@@ -127,7 +128,7 @@ class _Guppy:
         name: str = "",
         linear: bool = False,
         bound: ht.TypeBound | None = None,
-    ) -> ClassDecorator:
+    ) -> OpaqueTypeDecorator:
         """Decorator to annotate a class definitions as Guppy types.
 
         Requires the static Hugr translation of the type. Additionally, the type can be
@@ -136,7 +137,7 @@ class _Guppy:
         """
         module._instance_func_buffer = {}
 
-        def dec(c: type) -> type:
+        def dec(c: type) -> OpaqueTypeDef:
             defn = OpaqueTypeDef(
                 DefId.fresh(module),
                 name or c.__name__,
@@ -148,7 +149,7 @@ class _Guppy:
             )
             module.register_def(defn)
             module._register_buffered_instance_funcs(defn)
-            return c
+            return defn
 
         return dec
 

--- a/guppylang/module.py
+++ b/guppylang/module.py
@@ -142,12 +142,15 @@ class GuppyModule:
         # Also include any impls that are defined by the imported modules
         impls: dict[DefId, dict[str, DefId]] = {}
         for module in modules:
-            for def_id in module._globals.impls:
+            # We also need to include any impls that are transitively imported
+            all_globals = module._imported_globals | module._globals
+            all_checked_defs = module._imported_checked_defs | module._checked_defs
+            for def_id in all_globals.impls:
                 impls.setdefault(def_id, {})
-                impls[def_id] |= module._globals.impls[def_id]
+                impls[def_id] |= all_globals.impls[def_id]
                 defs |= {
-                    def_id: module._checked_defs[def_id]
-                    for def_id in module._globals.impls[def_id].values()
+                    def_id: all_checked_defs[def_id]
+                    for def_id in all_globals.impls[def_id].values()
                 }
         self._imported_globals |= Globals(defs, names, impls, {})
         self._imported_checked_defs |= defs

--- a/guppylang/module.py
+++ b/guppylang/module.py
@@ -136,7 +136,7 @@ class GuppyModule:
                     raise GuppyError(msg)
                 imports.append((alias, mods[0]))
             else:
-                msg = f"Object `{imp}` cannot be imported"
+                msg = f"Only Guppy definitions or modules can be imported. Got `{imp}`"
                 raise GuppyError(msg)
 
         # Also include any impls that are defined by the imported modules

--- a/guppylang/module.py
+++ b/guppylang/module.py
@@ -264,7 +264,6 @@ class GuppyModule:
             if isinstance(defn, CheckedStructDef):
                 self._globals.impls.setdefault(defn.id, {})
                 for method_def in defn.generated_methods():
-                    # We might have checked
                     generated[method_def.id] = method_def
                     self._globals.impls[defn.id][method_def.name] = method_def.id
 

--- a/tests/error/misc_errors/return_flag_callable.err
+++ b/tests/error/misc_errors/return_flag_callable.err
@@ -1,6 +1,6 @@
 Guppy compilation failed. Error in file $FILE:14
 
 12:    @guppy.declare(module)
-13:    def foo(f: Callable[[], qubit @inout]) -> None: ...
-                               ^^^^^^^^^^^^
+13:    def foo(f: "Callable[[], qubit @inout]") -> None: ...
+                                ^^^^^^^^^^^^
 GuppyError: `@` type annotations are not allowed in this position

--- a/tests/error/misc_errors/return_flag_callable.py
+++ b/tests/error/misc_errors/return_flag_callable.py
@@ -11,7 +11,7 @@ module.load(quantum)
 
 
 @guppy.declare(module)
-def foo(f: Callable[[], qubit @inout]) -> None: ...
+def foo(f: "Callable[[], qubit @inout]") -> None: ...
 
 
 module.compile()

--- a/tests/integration/modules/mod_a.py
+++ b/tests/integration/modules/mod_a.py
@@ -1,0 +1,25 @@
+"""Dummy module used in `test_imports.py`"""
+
+import hugr.tys as ht
+
+from guppylang import GuppyModule, guppy
+
+mod_a = GuppyModule("mod_a")
+
+
+@guppy(mod_a)
+def f(x: int) -> int:
+    return x + 1
+
+
+@guppy.declare(mod_a)
+def g() -> int:
+    ...
+
+
+@guppy.type(mod_a, ht.Bool)
+class MyType:
+    @guppy.declare(mod_a)
+    def __neg__(self: "MyType") -> "MyType":
+        ...
+

--- a/tests/integration/modules/mod_b.py
+++ b/tests/integration/modules/mod_b.py
@@ -1,0 +1,25 @@
+"""Dummy module used in `test_imports.py`"""
+
+from guppylang import GuppyModule, guppy
+from guppylang.prelude._internal.util import int_op
+
+mod_b = GuppyModule("mod_b")
+
+
+@guppy(mod_b)
+def f(x: bool) -> bool:
+    return not x
+
+
+@guppy.hugr_op(mod_b, int_op("h", "dummy", 0))
+def h() -> int:
+    ...
+
+
+@guppy.struct(mod_b)
+class MyType:
+    x: int
+
+    @guppy(mod_b)
+    def __pos__(self: "MyType") -> "MyType":
+        return self

--- a/tests/integration/modules/mod_c.py
+++ b/tests/integration/modules/mod_c.py
@@ -1,0 +1,23 @@
+from guppylang import GuppyModule, guppy
+from tests.integration.modules.mod_a import f, mod_a, MyType
+
+mod_c = GuppyModule("mod_c")
+mod_c.load(mod_a)
+
+
+@guppy.declare(mod_c)
+def g() -> MyType:
+    ...
+
+
+@guppy(mod_c)
+def h(x: int) -> int:
+    return f(x)
+
+
+# Extend type defined in module A
+@guppy.extend_type(mod_c, MyType)
+class _:
+    @guppy(mod_c)
+    def __int__(self: "MyType") -> int:
+        return 0

--- a/tests/integration/test_imports.py
+++ b/tests/integration/test_imports.py
@@ -90,12 +90,9 @@ def test_type_transitive(validate):
     module.load(g)  # `g` returns a type that was defined in `mod_a`
 
     @guppy(module)
-    def test() -> None:
+    def test() -> int:
         x = g()  # Type of x was defined in `mod_a`
-        # TODO: Should we be allowed to use a method that was defined in `mod_a` even
-        #  though we have not explicitly imported it? This would work in Python, but
-        #  not in Rust
-        # int(-x)
+        return int(-x)  # Call method that was defined in `mod_a`
 
     validate(module.compile())
 

--- a/tests/integration/test_imports.py
+++ b/tests/integration/test_imports.py
@@ -1,0 +1,128 @@
+from guppylang import GuppyModule, guppy
+
+
+def test_import_func(validate):
+    from tests.integration.modules.mod_a import f, g
+
+    module = GuppyModule("test")
+    module.load(f, g)
+
+    @guppy(module)
+    def test(x: int) -> int:
+        return f(x) + g()
+
+    validate(module.compile())
+
+
+def test_import_type(validate):
+    from tests.integration.modules.mod_a import MyType
+
+    module = GuppyModule("test")
+    module.load(MyType)
+
+    @guppy(module)
+    def test(x: MyType) -> MyType:
+        # Check that we've correctly imported the __neg__ method
+        return -x
+
+    validate(module.compile())
+
+
+def test_func_alias(validate):
+    from tests.integration.modules.mod_a import f as g
+
+    module = GuppyModule("test")
+    module.load(g=g)
+
+    @guppy(module)
+    def test(x: int) -> int:
+        return g(x)
+
+    validate(module.compile())
+
+
+def test_type_alias(validate):
+    from tests.integration.modules.mod_a import MyType
+
+    module = GuppyModule("test")
+    module.load(MyType_Alias=MyType)
+
+    @guppy(module)
+    def test(x: "MyType_Alias") -> "MyType_Alias":
+        # Check that we still have the __neg__ method
+        return -x
+
+    validate(module.compile())
+
+
+def test_conflict_alias(validate):
+    from tests.integration.modules.mod_a import f
+    from tests.integration.modules.mod_b import f as f_b
+
+    module = GuppyModule("test")
+    module.load(f, f_b=f_b)
+
+    @guppy(module)
+    def test(x: int, y: bool) -> tuple[int, bool]:
+        return f(x), f_b(y)
+
+    validate(module.compile())
+
+
+def test_conflict_alias_type(validate):
+    from tests.integration.modules.mod_a import MyType
+    from tests.integration.modules.mod_b import MyType as MyTypeB
+
+    module = GuppyModule("test")
+    module.load(MyType, MyTypeB=MyTypeB)
+
+    @guppy(module)
+    def test(x: MyType, y: MyTypeB) -> tuple[MyType, MyTypeB]:
+        return -x, +y
+
+    validate(module.compile())
+
+
+def test_type_transitive(validate):
+    from tests.integration.modules.mod_c import g
+
+    module = GuppyModule("test")
+    module.load(g)  # `g` returns a type that was defined in `mod_a`
+
+    @guppy(module)
+    def test() -> None:
+        x = g()  # Type of x was defined in `mod_a`
+        # TODO: Should we be allowed to use a method that was defined in `mod_a` even
+        #  though we have not explicitly imported it? This would work in Python, but
+        #  not in Rust
+        # int(-x)
+
+    validate(module.compile())
+
+
+def test_type_transitive_conflict(validate):
+    from tests.integration.modules.mod_b import MyType
+    from tests.integration.modules.mod_c import g
+
+    module = GuppyModule("test")
+    module.load(MyType, g)
+
+    @guppy(module)
+    def test(ty_b: MyType) -> MyType:
+        ty_a = g()  # g returns a type with the same name `MyType`
+        return +ty_b
+
+    validate(module.compile())
+
+
+def test_func_transitive(validate):
+    from tests.integration.modules.mod_c import h
+
+    module = GuppyModule("test")
+    module.load(h)  # `h` calls a function that was defined in `mod_a`
+
+    @guppy(module)
+    def test(x: int) -> int:
+        return h(x)
+
+    validate(module.compile())


### PR DESCRIPTION
Closes #425 and closes #427 and closes #134

* Allow importing of function definitions (before we could only import declarations)
* Until we have Hugr linking, we just lower everything into the same Hugr. This requires some changes to the compilation logic:
  - Differentiate between checking (`module.check()`) and full Hugr compilation (`module.compile()`) of modules
  - Importing modules only checks them
  - Hugr lowering is done at the end in one step over all imported modules
* Allow to import individual definitions instead of whole modules
* Allow aliased imports using kwargs (see test examples)