### PR TITLE
fix: Fix linearity checking bug

### DIFF
--- a/tests/integration/test_inout.py
+++ b/tests/integration/test_inout.py
@@ -266,7 +266,6 @@ def test_move_back(validate):
     validate(module.compile())
 
 
-@pytest.mark.skip("Fails due to https://github.com/CQCL/guppylang/issues/337")
 def test_move_back_branch(validate):
     module = GuppyModule("test")
     module.load(quantum)

--- a/tests/integration/test_linear.py
+++ b/tests/integration/test_linear.py
@@ -329,6 +329,30 @@ def test_while_reset(validate):
         return b
 
 
+def test_while_move_back(validate):
+    module = GuppyModule("test")
+    module.load(quantum)
+
+    @guppy.struct(module)
+    class MyStruct:
+        q: qubit
+
+    @guppy.declare(module)
+    def use(q: qubit) -> None: ...
+
+    @guppy(module)
+    def test(s: MyStruct) -> MyStruct:
+        use(s.q)
+        while True:
+            s.q = qubit()
+            return s
+        # Guppy is not yet smart enough to detect that this code is unreachable
+        s.q = qubit()
+        return s
+
+    validate(module.compile())
+
+
 def test_for(validate):
     module = GuppyModule("test")
     module.load(quantum)


### PR DESCRIPTION
Fixes #438.

When checking that all live linear places in scope are definitely used, we have to be more careful about determining whether variables are *actually* live rather than only being included in scope because of the less precise first pass of liveness analysis.