### PR TITLE
feat!: Add qualified imports and make them the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,22 +14,23 @@ It allows you to write high-level hybrid quantum programs with classical control
 ```python
 from guppylang import guppy, qubit, quantum
 
-guppy.load(quantum)
+guppy.load_all(quantum)
+
 
 # Teleports the state in `src` to `tgt`.
 @guppy
 def teleport(src: qubit, tgt: qubit) -> qubit:
-   # Create ancilla and entangle it with src and tgt
-   tmp = qubit()
-   tmp, tgt = cx(h(tmp), tgt)
-   src, tmp = cx(src, tmp)
+    # Create ancilla and entangle it with src and tgt
+    tmp = qubit()
+    tmp, tgt = cx(h(tmp), tgt)
+    src, tmp = cx(src, tmp)
 
-   # Apply classical corrections
-   if measure(h(src)):
-      tgt = z(tgt)
-   if measure(tmp):
-      tgt = x(tgt)
-   return tgt
+    # Apply classical corrections
+    if measure(h(src)):
+        tgt = z(tgt)
+    if measure(tmp):
+        tgt = x(tgt)
+    return tgt
 ```
 
 More examples and tutorials are available [here][examples].

--- a/examples/demo.ipynb
+++ b/examples/demo.ipynb
@@ -86,9 +86,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "module.load(guppylang.prelude.quantum)\n",
+    "from guppylang.prelude.quantum import qubit, h, cx, measure\n",
     "\n",
-    "from guppylang.prelude.quantum import qubit, h, rz, measure\n",
+    "module.load(qubit, h, cx, measure)\n",
     "\n",
     "@guppy(module)\n",
     "def bell() -> bool:\n",
@@ -305,7 +305,7 @@
    ],
    "source": [
     "bad_module = GuppyModule(name=\"bad_module\")\n",
-    "bad_module.load(guppylang.prelude.quantum)\n",
+    "bad_module.load_all(guppylang.prelude.quantum)\n",
     "\n",
     "@guppy(bad_module)\n",
     "def bad(q: qubit) -> tuple[qubit, qubit]:\n",
@@ -348,7 +348,7 @@
    ],
    "source": [
     "bad_module = GuppyModule(name=\"bad_module\")\n",
-    "bad_module.load(guppylang.prelude.quantum)\n",
+    "bad_module.load_all(guppylang.prelude.quantum)\n",
     "\n",
     "@guppy(bad_module)\n",
     "def bad(q: qubit) -> qubit:\n",
@@ -412,7 +412,7 @@
    "outputs": [],
    "source": [
     "module = GuppyModule(\"structs\")\n",
-    "module.load(guppylang.prelude.quantum)\n",
+    "module.load_all(guppylang.prelude.quantum)\n",
     "\n",
     "@guppy.struct(module)\n",
     "class QubitPair:\n",
@@ -557,7 +557,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.12.5"
   }
  },
  "nbformat": 4,

--- a/examples/random_walk_qpe.py
+++ b/examples/random_walk_qpe.py
@@ -15,7 +15,7 @@ from guppylang.prelude.builtins import py, result
 from guppylang.prelude.quantum import cx, discard, h, measure, qubit, rz, x
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 sqrt_e = math.sqrt(math.e)
 sqrt_e_div = math.sqrt((math.e - 1) / math.e)

--- a/examples/t_factory.py
+++ b/examples/t_factory.py
@@ -15,7 +15,7 @@ from guppylang.prelude.quantum import (
 )
 
 module = GuppyModule("t_factory")
-module.load(quantum)
+module.load_all(quantum)
 
 phi = np.arccos(1 / 3)
 pi = np.pi

--- a/guppylang/checker/expr_checker.py
+++ b/guppylang/checker/expr_checker.py
@@ -43,6 +43,8 @@ from guppylang.checker.core import (
     Locals,
     Variable,
 )
+from guppylang.definition.common import Definition
+from guppylang.definition.module import ModuleDef
 from guppylang.definition.ty import TypeDef
 from guppylang.definition.value import CallableDef, ValueDef
 from guppylang.error import (
@@ -345,26 +347,40 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
             var = self.ctx.locals[x]
             return with_loc(node, PlaceNode(place=var)), var.ty
         elif x in self.ctx.globals:
-            # Look-up what kind of definition it is
-            match self.ctx.globals[x]:
-                case ValueDef() as defn:
-                    return with_loc(node, GlobalName(id=x, def_id=defn.id)), defn.ty
-                # For types, we return their `__new__` constructor
-                case TypeDef() as defn if constr := self.ctx.globals.get_instance_func(
-                    defn, "__new__"
-                ):
-                    return with_loc(node, GlobalName(id=x, def_id=constr.id)), constr.ty
-                case defn:
-                    raise GuppyError(
-                        f"Expected a value, got {defn.description} `{x}`", node
-                    )
+            defn = self.ctx.globals[x]
+            return self._check_global(defn, x, node)
         raise InternalGuppyError(
             f"Variable `{x}` is not defined in `TypeSynthesiser`. This should have "
             "been caught by program analysis!"
         )
 
+    def _check_global(
+        self, defn: Definition, name: str, node: ast.expr
+    ) -> tuple[ast.expr, Type]:
+        """Checks a global definition in an expression position."""
+        match defn:
+            case ValueDef() as defn:
+                return with_loc(node, GlobalName(id=name, def_id=defn.id)), defn.ty
+            # For types, we return their `__new__` constructor
+            case TypeDef() as defn if constr := self.ctx.globals.get_instance_func(
+                defn, "__new__"
+            ):
+                return with_loc(node, GlobalName(id=name, def_id=constr.id)), constr.ty
+            case defn:
+                raise GuppyError(
+                    f"Expected a value, got {defn.description} `{name}`", node
+                )
+
     def visit_Attribute(self, node: ast.Attribute) -> tuple[ast.expr, Type]:
         # A `value.attr` attribute access
+        if module_def := self._is_module_def(node.value):
+            if node.attr not in module_def.globals:
+                raise GuppyError(
+                    f"Module `{module_def.name}` has no member `{node.attr}`", node
+                )
+            defn = module_def.globals[node.attr]
+            qual_name = f"{module_def.name}.{defn.name}"
+            return self._check_global(defn, qual_name, node)
         node.value, ty = self.synthesize(node.value)
         if isinstance(ty, StructType) and node.attr in ty.field_dict:
             field = ty.field_dict[node.attr]
@@ -397,6 +413,14 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
             # to use `node` as the error location
             node,
         )
+
+    def _is_module_def(self, node: ast.expr) -> ModuleDef | None:
+        """Checks whether an AST node corresponds to a defined module."""
+        if isinstance(node, ast.Name) and node.id in self.ctx.globals:
+            defn = self.ctx.globals[node.id]
+            if isinstance(defn, ModuleDef):
+                return defn
+        return None
 
     def visit_Tuple(self, node: ast.Tuple) -> tuple[ast.expr, Type]:
         elems = [self.synthesize(elem) for elem in node.elts]

--- a/guppylang/decorator.py
+++ b/guppylang/decorator.py
@@ -292,7 +292,7 @@ class _Guppy:
         if caller not in self._modules:
             self._modules[caller] = GuppyModule(caller.name)
         module = self._modules[caller]
-        module.load(m)
+        module.load_all(m)
 
     def take_module(self, id: ModuleIdentifier | None = None) -> GuppyModule:
         """Returns the local GuppyModule, removing it from the local state."""

--- a/guppylang/definition/module.py
+++ b/guppylang/definition/module.py
@@ -1,0 +1,23 @@
+from dataclasses import field, dataclass
+from typing import TYPE_CHECKING
+
+from guppylang.definition.common import Definition, CompiledDef
+
+if TYPE_CHECKING:
+    from guppylang.checker.core import Globals
+
+
+@dataclass(frozen=True)
+class ModuleDef(CompiledDef):
+    """A module definition.
+
+    Note that this definition is separate from the `GuppyModule` class and only serves
+    as a pointer to be stored in the globals.
+
+    In the future we could consider unifying this with `GuppyModule`.
+    """
+
+    globals: "Globals"
+
+    description: str = field(default="module", init=False)
+

--- a/guppylang/definition/module.py
+++ b/guppylang/definition/module.py
@@ -1,7 +1,7 @@
-from dataclasses import field, dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-from guppylang.definition.common import Definition, CompiledDef
+from guppylang.definition.common import CompiledDef
 
 if TYPE_CHECKING:
     from guppylang.checker.core import Globals
@@ -20,4 +20,3 @@ class ModuleDef(CompiledDef):
     globals: "Globals"
 
     description: str = field(default="module", init=False)
-

--- a/guppylang/module.py
+++ b/guppylang/module.py
@@ -20,6 +20,7 @@ from guppylang.definition.common import (
 )
 from guppylang.definition.declaration import RawFunctionDecl
 from guppylang.definition.function import RawFunctionDef
+from guppylang.definition.module import ModuleDef
 from guppylang.definition.parameter import ParamDef
 from guppylang.definition.struct import CheckedStructDef
 from guppylang.definition.ty import TypeDef
@@ -83,7 +84,7 @@ class GuppyModule:
         if import_builtins:
             import guppylang.prelude.builtins as builtins
 
-            self.load(builtins)
+            self.load_all(builtins)
 
     def load(
         self,
@@ -113,28 +114,17 @@ class GuppyModule:
                 names[alias or imp.name] = imp.id
                 modules.add(module)
             elif isinstance(imp, GuppyModule):
-                # TODO: In the future this should be a qualified module import. For now
-                #  we just import all contained definitions that don't start with `_`
                 imp.check()
-                imports.extend(
-                    (defn.name, defn)
-                    for defn in imp._globals.defs.values()
-                    if not defn.name.startswith("_")
-                )
+                def_id = DefId.fresh(imp)
+                name = alias or imp.name
+                defn = ModuleDef(def_id, name, None, imp._globals)
+                defs[def_id] = defn
+                names[name] = def_id
+                defs |= imp._checked_defs
+                modules.add(imp)
             elif isinstance(imp, ModuleType):
-                mods = [
-                    val for val in imp.__dict__.values() if isinstance(val, GuppyModule)
-                ]
-                if not mods:
-                    msg = f"No Guppy modules found in `{imp.__name__}`"
-                    raise GuppyError(msg)
-                if len(mods) > 1:
-                    msg = (
-                        f"Python module `{imp.__name__}` contains multiple Guppy "
-                        "modules. Cannot decide which one to import."
-                    )
-                    raise GuppyError(msg)
-                imports.append((alias, mods[0]))
+                mod = find_guppy_module_in_py_module(imp)
+                imports.append((alias, mod))
             else:
                 msg = f"Only Guppy definitions or modules can be imported. Got `{imp}`"
                 raise GuppyError(msg)
@@ -159,6 +149,17 @@ class GuppyModule:
         # lower everything into one Hugr at the same time.
         for module in modules:
             self._imported_checked_defs |= module._imported_checked_defs
+
+    def load_all(self, mod: "GuppyModule | ModuleType") -> None:
+        """Imports all public members of a module."""
+        if isinstance(mod, GuppyModule):
+            mod.check()
+            self.load(*(defn for defn in mod._globals.defs.values() if not defn.name.startswith("_")))
+        elif isinstance(mod, ModuleType):
+            self.load_all(find_guppy_module_in_py_module(mod))
+        else:
+            msg = f"Only Guppy definitions or modules can be imported. Got `{mod}`"
+            raise GuppyError(msg)
 
     def register_def(self, defn: RawDef, instance: TypeDef | None = None) -> None:
         """Registers a definition with this module.
@@ -335,3 +336,24 @@ def get_py_scope(f: PyFunc) -> PyScope:
             nonlocals[var] = value
 
     return nonlocals | f.__globals__.copy()
+
+
+def find_guppy_module_in_py_module(module: ModuleType) -> GuppyModule:
+    """Helper function to search the `__dict__` of a Python module for an instance of
+     `GuppyModule`.
+
+    Raises a user-error if no unique module can be found.
+    """
+    mods = [
+        val for val in module.__dict__.values() if isinstance(val, GuppyModule)
+    ]
+    if not mods:
+        msg = f"No Guppy modules found in `{module.__name__}`"
+        raise GuppyError(msg)
+    if len(mods) > 1:
+        msg = (
+            f"Python module `{module.__name__}` contains multiple Guppy modules. "
+            "Cannot decide which one to import."
+        )
+        raise GuppyError(msg)
+    return mods[0]

--- a/guppylang/module.py
+++ b/guppylang/module.py
@@ -154,7 +154,13 @@ class GuppyModule:
         """Imports all public members of a module."""
         if isinstance(mod, GuppyModule):
             mod.check()
-            self.load(*(defn for defn in mod._globals.defs.values() if not defn.name.startswith("_")))
+            self.load(
+                *(
+                    defn
+                    for defn in mod._globals.defs.values()
+                    if not defn.name.startswith("_")
+                )
+            )
         elif isinstance(mod, ModuleType):
             self.load_all(find_guppy_module_in_py_module(mod))
         else:
@@ -344,9 +350,7 @@ def find_guppy_module_in_py_module(module: ModuleType) -> GuppyModule:
 
     Raises a user-error if no unique module can be found.
     """
-    mods = [
-        val for val in module.__dict__.values() if isinstance(val, GuppyModule)
-    ]
+    mods = [val for val in module.__dict__.values() if isinstance(val, GuppyModule)]
     if not mods:
         msg = f"No Guppy modules found in `{module.__name__}`"
         raise GuppyError(msg)

--- a/guppylang/tys/parsing.py
+++ b/guppylang/tys/parsing.py
@@ -77,7 +77,7 @@ def arg_from_ast(
     raise GuppyError("Not a valid type argument", node)
 
 
-def _try_parse_defn(node: ast.expr, globals: Globals) -> Definition | None:
+def _try_parse_defn(node: AstNode, globals: Globals) -> Definition | None:
     """Tries to parse a (possibly qualified) name into a global definition."""
     match node:
         case ast.Name(id=x):
@@ -92,7 +92,7 @@ def _try_parse_defn(node: ast.expr, globals: Globals) -> Definition | None:
                 raise GuppyError(
                     f"Expected a module, got {module_def.description} "
                     f"`{module_def.name}`",
-                    value
+                    value,
                 )
             if x not in module_def.globals:
                 raise GuppyError(

--- a/quickstart.md
+++ b/quickstart.md
@@ -5,20 +5,21 @@ flow and mid-circuit measurements using Pythonic syntax:
 ```python
 from guppylang import guppy, qubit, quantum
 
-guppy.load(quantum)
+guppy.load_all(quantum)
+
 
 # Teleports the state in `src` to `tgt`.
 @guppy
 def teleport(src: qubit, tgt: qubit) -> qubit:
-   # Create ancilla and entangle it with src and tgt
-   tmp = qubit()
-   tmp, tgt = cx(h(tmp), tgt)
-   src, tmp = cx(src, tmp)
+    # Create ancilla and entangle it with src and tgt
+    tmp = qubit()
+    tmp, tgt = cx(h(tmp), tgt)
+    src, tmp = cx(src, tmp)
 
-   # Apply classical corrections
-   if measure(h(src)):
-      tgt = z(tgt)
-   if measure(tmp):
-      tgt = x(tgt)
-   return tgt
+    # Apply classical corrections
+    if measure(h(src)):
+        tgt = z(tgt)
+    if measure(tmp):
+        tgt = x(tgt)
+    return tgt
 ```

--- a/tests/error/array_errors/linear_index.py
+++ b/tests/error/array_errors/linear_index.py
@@ -6,7 +6,7 @@ from guppylang.prelude.quantum import qubit
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy(module)

--- a/tests/error/array_errors/linear_len.py
+++ b/tests/error/array_errors/linear_len.py
@@ -6,7 +6,7 @@ from guppylang.prelude.quantum import qubit
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy(module)

--- a/tests/error/comprehension_errors/capture1.py
+++ b/tests/error/comprehension_errors/capture1.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 from guppylang.prelude.builtins import linst
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy(module)

--- a/tests/error/comprehension_errors/capture2.py
+++ b/tests/error/comprehension_errors/capture2.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 from guppylang.prelude.builtins import linst
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.declare(module)

--- a/tests/error/comprehension_errors/capture3.py
+++ b/tests/error/comprehension_errors/capture3.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 from guppylang.prelude.builtins import linst
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.struct(module)

--- a/tests/error/comprehension_errors/capture4.py
+++ b/tests/error/comprehension_errors/capture4.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 from guppylang.prelude.builtins import linst
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.struct(module)

--- a/tests/error/comprehension_errors/guarded1.py
+++ b/tests/error/comprehension_errors/guarded1.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 from guppylang.prelude.builtins import linst
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy(module)

--- a/tests/error/comprehension_errors/guarded2.py
+++ b/tests/error/comprehension_errors/guarded2.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 from guppylang.prelude.builtins import linst
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.declare(module)

--- a/tests/error/comprehension_errors/guarded3.py
+++ b/tests/error/comprehension_errors/guarded3.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 from guppylang.prelude.builtins import linst
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.struct(module)

--- a/tests/error/comprehension_errors/multi_use1.py
+++ b/tests/error/comprehension_errors/multi_use1.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 from guppylang.prelude.builtins import linst
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy(module)

--- a/tests/error/comprehension_errors/multi_use2.py
+++ b/tests/error/comprehension_errors/multi_use2.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 from guppylang.prelude.builtins import linst
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy(module)

--- a/tests/error/comprehension_errors/multi_use3.py
+++ b/tests/error/comprehension_errors/multi_use3.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 from guppylang.prelude.builtins import linst
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.declare(module)

--- a/tests/error/comprehension_errors/not_used1.py
+++ b/tests/error/comprehension_errors/not_used1.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 from guppylang.prelude.builtins import linst
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy(module)

--- a/tests/error/comprehension_errors/not_used2.py
+++ b/tests/error/comprehension_errors/not_used2.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 from guppylang.prelude.builtins import linst
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.struct(module)

--- a/tests/error/comprehension_errors/pattern_override1.py
+++ b/tests/error/comprehension_errors/pattern_override1.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 from guppylang.prelude.builtins import linst
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy(module)

--- a/tests/error/comprehension_errors/pattern_override2.py
+++ b/tests/error/comprehension_errors/pattern_override2.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 from guppylang.prelude.builtins import linst
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy(module)

--- a/tests/error/comprehension_errors/used_twice1.py
+++ b/tests/error/comprehension_errors/used_twice1.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 from guppylang.prelude.builtins import linst
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy(module)

--- a/tests/error/comprehension_errors/used_twice2.py
+++ b/tests/error/comprehension_errors/used_twice2.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 from guppylang.prelude.builtins import linst
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.declare(module)

--- a/tests/error/comprehension_errors/used_twice3.py
+++ b/tests/error/comprehension_errors/used_twice3.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 from guppylang.prelude.builtins import linst
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.declare(module)

--- a/tests/error/import_errors/lib.py
+++ b/tests/error/import_errors/lib.py
@@ -1,0 +1,15 @@
+from guppylang.decorator import guppy
+from guppylang.module import GuppyModule
+
+
+module = GuppyModule("lib")
+
+
+@guppy.struct(module)
+class MyType:
+    x: int
+
+
+@guppy(module)
+def foo(x: int) -> int:
+    return x

--- a/tests/error/import_errors/not_in_module.err
+++ b/tests/error/import_errors/not_in_module.err
@@ -1,0 +1,7 @@
+Guppy compilation failed. Error in file $FILE:12
+
+10:    @guppy(module)
+11:    def main(x: int) -> int:
+12:        return lib.bar(x)
+                  ^^^^^^^
+GuppyError: Module `lib` has no member `bar`

--- a/tests/error/import_errors/not_in_module.py
+++ b/tests/error/import_errors/not_in_module.py
@@ -1,0 +1,15 @@
+from guppylang.decorator import guppy
+from guppylang.module import GuppyModule
+
+import tests.error.import_errors.lib as lib
+
+module = GuppyModule("test")
+module.load(lib)
+
+
+@guppy(module)
+def main(x: int) -> int:
+    return lib.bar(x)
+
+
+module.compile()

--- a/tests/error/import_errors/not_in_module_type.err
+++ b/tests/error/import_errors/not_in_module_type.err
@@ -1,0 +1,6 @@
+Guppy compilation failed. Error in file $FILE:11
+
+9:     @guppy(module)
+10:    def main(x: "lib.MyType2") -> int:
+                    ^^^^^^^^^^^
+GuppyError: Module `lib` has no member `MyType2`

--- a/tests/error/import_errors/not_in_module_type.py
+++ b/tests/error/import_errors/not_in_module_type.py
@@ -1,0 +1,15 @@
+from guppylang.decorator import guppy
+from guppylang.module import GuppyModule
+
+import tests.error.import_errors.lib as lib
+
+module = GuppyModule("test")
+module.load(lib)
+
+
+@guppy(module)
+def main(x: "lib.MyType2") -> int:
+    return 0
+
+
+module.compile()

--- a/tests/error/import_errors/not_in_module_type2.err
+++ b/tests/error/import_errors/not_in_module_type2.err
@@ -1,0 +1,6 @@
+Guppy compilation failed. Error in file $FILE:11
+
+9:     @guppy(module)
+10:    def main(x: "lib.MyType2[int]") -> int:
+                    ^^^^^^^^^^^
+GuppyError: Module `lib` has no member `MyType2`

--- a/tests/error/import_errors/not_in_module_type2.py
+++ b/tests/error/import_errors/not_in_module_type2.py
@@ -1,0 +1,15 @@
+from guppylang.decorator import guppy
+from guppylang.module import GuppyModule
+
+import tests.error.import_errors.lib as lib
+
+module = GuppyModule("test")
+module.load(lib)
+
+
+@guppy(module)
+def main(x: "lib.MyType2[int]") -> int:
+    return 0
+
+
+module.compile()

--- a/tests/error/inout_errors/already_used.py
+++ b/tests/error/inout_errors/already_used.py
@@ -4,7 +4,7 @@ from guppylang.prelude.builtins import inout
 from guppylang.prelude.quantum import measure, qubit, quantum
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.declare(module)

--- a/tests/error/inout_errors/conflict.py
+++ b/tests/error/inout_errors/conflict.py
@@ -7,7 +7,7 @@ from guppylang.prelude.quantum import quantum, qubit
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.declare(module)

--- a/tests/error/inout_errors/drop_after_call.py
+++ b/tests/error/inout_errors/drop_after_call.py
@@ -4,7 +4,7 @@ from guppylang.prelude.builtins import inout
 from guppylang.prelude.quantum import qubit, quantum
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.declare(module)

--- a/tests/error/inout_errors/moved.py
+++ b/tests/error/inout_errors/moved.py
@@ -4,7 +4,7 @@ from guppylang.prelude.builtins import inout
 from guppylang.prelude.quantum import measure, qubit, quantum
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.declare(module)

--- a/tests/error/inout_errors/moved_assign.py
+++ b/tests/error/inout_errors/moved_assign.py
@@ -4,7 +4,7 @@ from guppylang.prelude.builtins import inout
 from guppylang.prelude.quantum import measure, qubit, quantum
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy(module)

--- a/tests/error/inout_errors/moved_if.py
+++ b/tests/error/inout_errors/moved_if.py
@@ -4,7 +4,7 @@ from guppylang.prelude.builtins import inout
 from guppylang.prelude.quantum import measure, qubit, quantum
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.declare(module)

--- a/tests/error/inout_errors/moved_out.py
+++ b/tests/error/inout_errors/moved_out.py
@@ -4,7 +4,7 @@ from guppylang.prelude.builtins import inout
 from guppylang.prelude.quantum import measure, qubit, quantum
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.struct(module)

--- a/tests/error/inout_errors/moved_out_if.py
+++ b/tests/error/inout_errors/moved_out_if.py
@@ -4,7 +4,7 @@ from guppylang.prelude.builtins import inout
 from guppylang.prelude.quantum import measure, qubit, quantum
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.struct(module)

--- a/tests/error/inout_errors/nested_call_right_to_left.py
+++ b/tests/error/inout_errors/nested_call_right_to_left.py
@@ -4,7 +4,7 @@ from guppylang.prelude.builtins import inout
 from guppylang.prelude.quantum import qubit, quantum
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.declare(module)

--- a/tests/error/inout_errors/override_after_call.py
+++ b/tests/error/inout_errors/override_after_call.py
@@ -4,7 +4,7 @@ from guppylang.prelude.builtins import inout
 from guppylang.prelude.quantum import qubit, quantum
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.declare(module)

--- a/tests/error/inout_errors/shadow.py
+++ b/tests/error/inout_errors/shadow.py
@@ -4,7 +4,7 @@ from guppylang.prelude.builtins import inout
 from guppylang.prelude.quantum import qubit, quantum
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy(module)

--- a/tests/error/inout_errors/shadow_if.py
+++ b/tests/error/inout_errors/shadow_if.py
@@ -4,7 +4,7 @@ from guppylang.prelude.builtins import inout
 from guppylang.prelude.quantum import qubit, quantum
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy(module)

--- a/tests/error/inout_errors/unused_after_call.py
+++ b/tests/error/inout_errors/unused_after_call.py
@@ -4,7 +4,7 @@ from guppylang.prelude.builtins import inout
 from guppylang.prelude.quantum import qubit, quantum
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.declare(module)

--- a/tests/error/linear_errors/branch_use.py
+++ b/tests/error/linear_errors/branch_use.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.declare(module)

--- a/tests/error/linear_errors/branch_use_field1.py
+++ b/tests/error/linear_errors/branch_use_field1.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit, measure
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.struct(module)

--- a/tests/error/linear_errors/branch_use_field2.py
+++ b/tests/error/linear_errors/branch_use_field2.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit, measure
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.struct(module)

--- a/tests/error/linear_errors/break_unused.py
+++ b/tests/error/linear_errors/break_unused.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.declare(module)

--- a/tests/error/linear_errors/call_drop_field.py
+++ b/tests/error/linear_errors/call_drop_field.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.struct(module)

--- a/tests/error/linear_errors/continue_unused.py
+++ b/tests/error/linear_errors/continue_unused.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.declare(module)

--- a/tests/error/linear_errors/copy.py
+++ b/tests/error/linear_errors/copy.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy(module)

--- a/tests/error/linear_errors/field_copy1.py
+++ b/tests/error/linear_errors/field_copy1.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.struct(module)

--- a/tests/error/linear_errors/field_copy2.py
+++ b/tests/error/linear_errors/field_copy2.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 @guppy.struct(module)
 class MyStruct:

--- a/tests/error/linear_errors/field_copy3.py
+++ b/tests/error/linear_errors/field_copy3.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 @guppy.struct(module)
 class MyStruct:

--- a/tests/error/linear_errors/field_copy_nested1.py
+++ b/tests/error/linear_errors/field_copy_nested1.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit, measure
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.struct(module)

--- a/tests/error/linear_errors/field_copy_nested2.py
+++ b/tests/error/linear_errors/field_copy_nested2.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit, measure
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.struct(module)

--- a/tests/error/linear_errors/field_copy_nested3.py
+++ b/tests/error/linear_errors/field_copy_nested3.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit, measure
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.struct(module)

--- a/tests/error/linear_errors/field_copy_nested4.py
+++ b/tests/error/linear_errors/field_copy_nested4.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit, measure
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.struct(module)

--- a/tests/error/linear_errors/for_break.py
+++ b/tests/error/linear_errors/for_break.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 from guppylang.prelude.builtins import linst
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy(module)

--- a/tests/error/linear_errors/for_return.py
+++ b/tests/error/linear_errors/for_return.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 from guppylang.prelude.builtins import linst
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy(module)

--- a/tests/error/linear_errors/if_both_unused.py
+++ b/tests/error/linear_errors/if_both_unused.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.declare(module)

--- a/tests/error/linear_errors/if_both_unused_field.py
+++ b/tests/error/linear_errors/if_both_unused_field.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.struct(module)

--- a/tests/error/linear_errors/if_both_unused_reassign.py
+++ b/tests/error/linear_errors/if_both_unused_reassign.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.declare(module)

--- a/tests/error/linear_errors/if_both_unused_reassign_field.py
+++ b/tests/error/linear_errors/if_both_unused_reassign_field.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.struct(module)

--- a/tests/error/linear_errors/method_capture.py
+++ b/tests/error/linear_errors/method_capture.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.struct(module)

--- a/tests/error/linear_errors/reassign_unused.py
+++ b/tests/error/linear_errors/reassign_unused.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.declare(module)

--- a/tests/error/linear_errors/reassign_unused_field.py
+++ b/tests/error/linear_errors/reassign_unused_field.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.struct(module)

--- a/tests/error/linear_errors/reassign_unused_tuple.py
+++ b/tests/error/linear_errors/reassign_unused_tuple.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.declare(module)

--- a/tests/error/linear_errors/unused.py
+++ b/tests/error/linear_errors/unused.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy(module)

--- a/tests/error/linear_errors/unused_expr.py
+++ b/tests/error/linear_errors/unused_expr.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy(module)

--- a/tests/error/linear_errors/unused_field1.py
+++ b/tests/error/linear_errors/unused_field1.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.struct(module)

--- a/tests/error/linear_errors/unused_field2.py
+++ b/tests/error/linear_errors/unused_field2.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.struct(module)

--- a/tests/error/linear_errors/unused_field3.py
+++ b/tests/error/linear_errors/unused_field3.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit, measure
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.struct(module)

--- a/tests/error/linear_errors/unused_same_block.py
+++ b/tests/error/linear_errors/unused_same_block.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy(module)

--- a/tests/error/linear_errors/while_unused.py
+++ b/tests/error/linear_errors/while_unused.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy(module)

--- a/tests/error/misc_errors/list_linear.py
+++ b/tests/error/misc_errors/list_linear.py
@@ -6,7 +6,7 @@ import guppylang.prelude.quantum as quantum
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy(module)

--- a/tests/error/misc_errors/nested_arg_flag.py
+++ b/tests/error/misc_errors/nested_arg_flag.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import quantum, qubit
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.declare(module)

--- a/tests/error/misc_errors/result_value_linear.py
+++ b/tests/error/misc_errors/result_value_linear.py
@@ -6,7 +6,7 @@ from guppylang.prelude.quantum import qubit
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy(module)

--- a/tests/error/misc_errors/return_flag.py
+++ b/tests/error/misc_errors/return_flag.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import quantum, qubit
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.declare(module)

--- a/tests/error/misc_errors/return_flag_callable.py
+++ b/tests/error/misc_errors/return_flag_callable.py
@@ -7,7 +7,7 @@ from guppylang.prelude.quantum import quantum, qubit
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.declare(module)

--- a/tests/error/misc_errors/type_attr_not_module.err
+++ b/tests/error/misc_errors/type_attr_not_module.err
@@ -1,0 +1,6 @@
+Guppy compilation failed. Error in file $FILE:5
+
+3:    @compile_guppy
+4:    def f(x: "int.bar") -> None:
+                ^^^
+GuppyError: Expected a module, got type `int`

--- a/tests/error/misc_errors/type_attr_not_module.py
+++ b/tests/error/misc_errors/type_attr_not_module.py
@@ -1,0 +1,6 @@
+from tests.util import compile_guppy
+
+
+@compile_guppy
+def f(x: "int.bar") -> None:
+    return

--- a/tests/error/misc_errors/type_attr_undefined.err
+++ b/tests/error/misc_errors/type_attr_undefined.err
@@ -1,0 +1,6 @@
+Guppy compilation failed. Error in file $FILE:5
+
+3:    @compile_guppy
+4:    def f(x: "foo.bar") -> None:
+                ^^^
+GuppyError: Unknown identifier

--- a/tests/error/misc_errors/type_attr_undefined.py
+++ b/tests/error/misc_errors/type_attr_undefined.py
@@ -1,0 +1,6 @@
+from tests.util import compile_guppy
+
+
+@compile_guppy
+def f(x: "foo.bar") -> None:
+    return

--- a/tests/error/nested_errors/linear_capture.py
+++ b/tests/error/nested_errors/linear_capture.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy(module)

--- a/tests/error/poly_errors/non_linear1.py
+++ b/tests/error/poly_errors/non_linear1.py
@@ -5,7 +5,7 @@ from guppylang.prelude.quantum import qubit
 import guppylang.prelude.quantum as quantum
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 T = guppy.type_var(module, "T")

--- a/tests/error/poly_errors/non_linear2.py
+++ b/tests/error/poly_errors/non_linear2.py
@@ -7,7 +7,7 @@ from guppylang.prelude.quantum import h
 import guppylang.prelude.quantum as quantum
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 T = guppy.type_var(module, "T")

--- a/tests/error/py_errors/tket2_not_installed.py
+++ b/tests/error/py_errors/tket2_not_installed.py
@@ -8,7 +8,7 @@ circ = Circuit(1)
 circ.H(0)
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy(module)

--- a/tests/error/struct_errors/mutate_classical.py
+++ b/tests/error/struct_errors/mutate_classical.py
@@ -3,7 +3,7 @@ from guppylang.module import GuppyModule
 from guppylang.prelude.quantum import quantum, qubit
 
 module = GuppyModule("test")
-module.load(quantum)
+module.load_all(quantum)
 
 
 @guppy.struct(module)

--- a/tests/error/type_errors/and_not_bool_left.py
+++ b/tests/error/type_errors/and_not_bool_left.py
@@ -4,7 +4,7 @@ from guppylang.module import GuppyModule
 from tests.error.util import NonBool
 
 module = GuppyModule("test")
-module.load(tests.error.util)
+module.load_all(tests.error.util)
 
 
 @guppy(module)

--- a/tests/error/type_errors/and_not_bool_right.py
+++ b/tests/error/type_errors/and_not_bool_right.py
@@ -4,7 +4,7 @@ from guppylang.module import GuppyModule
 from tests.error.util import NonBool
 
 module = GuppyModule("test")
-module.load(tests.error.util)
+module.load_all(tests.error.util)
 
 
 @guppy(module)

--- a/tests/error/type_errors/if_expr_not_bool.py
+++ b/tests/error/type_errors/if_expr_not_bool.py
@@ -4,7 +4,7 @@ from guppylang.module import GuppyModule
 from tests.error.util import NonBool
 
 module = GuppyModule("test")
-module.load(tests.error.util)
+module.load_all(tests.error.util)
 
 
 @guppy(module)

--- a/tests/error/type_errors/if_not_bool.py
+++ b/tests/error/type_errors/if_not_bool.py
@@ -4,7 +4,7 @@ from guppylang.module import GuppyModule
 from tests.error.util import NonBool
 
 module = GuppyModule("test")
-module.load(tests.error.util)
+module.load_all(tests.error.util)
 
 
 @guppy(module)

--- a/tests/error/type_errors/not_not_bool.py
+++ b/tests/error/type_errors/not_not_bool.py
@@ -4,7 +4,7 @@ from guppylang.module import GuppyModule
 from tests.error.util import NonBool
 
 module = GuppyModule("test")
-module.load(tests.error.util)
+module.load_all(tests.error.util)
 
 
 @guppy(module)

--- a/tests/error/type_errors/or_not_bool_left.py
+++ b/tests/error/type_errors/or_not_bool_left.py
@@ -4,7 +4,7 @@ from guppylang.module import GuppyModule
 from tests.error.util import NonBool
 
 module = GuppyModule("test")
-module.load(tests.error.util)
+module.load_all(tests.error.util)
 
 
 @guppy(module)

--- a/tests/error/type_errors/or_not_bool_right.py
+++ b/tests/error/type_errors/or_not_bool_right.py
@@ -4,7 +4,7 @@ from guppylang.module import GuppyModule
 from tests.error.util import NonBool
 
 module = GuppyModule("test")
-module.load(tests.error.util)
+module.load_all(tests.error.util)
 
 
 @guppy(module)

--- a/tests/error/type_errors/while_not_bool.py
+++ b/tests/error/type_errors/while_not_bool.py
@@ -4,7 +4,7 @@ from guppylang.module import GuppyModule
 from tests.error.util import NonBool
 
 module = GuppyModule("test")
-module.load(tests.error.util)
+module.load_all(tests.error.util)
 
 
 @guppy(module)

--- a/tests/integration/modules/mod_c.py
+++ b/tests/integration/modules/mod_c.py
@@ -2,7 +2,7 @@ from guppylang import GuppyModule, guppy
 from tests.integration.modules.mod_a import f, mod_a, MyType
 
 mod_c = GuppyModule("mod_c")
-mod_c.load(mod_a)
+mod_c.load_all(mod_a)
 
 
 @guppy.declare(mod_c)

--- a/tests/integration/test_comprehension.py
+++ b/tests/integration/test_comprehension.py
@@ -20,7 +20,7 @@ def test_basic(validate):
 
 def test_basic_linear(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy(module)
     def test(qs: linst[qubit]) -> linst[qubit]:
@@ -47,7 +47,7 @@ def test_multiple(validate):
 
 def test_multiple_struct(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy.struct(module)
     class MyStruct:
@@ -70,7 +70,7 @@ def test_tuple_pat(validate):
 
 def test_tuple_pat_linear(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy(module)
     def test(qs: linst[tuple[int, qubit, qubit]]) -> linst[tuple[qubit, qubit]]:
@@ -151,7 +151,7 @@ def test_nested_right(validate):
 
 def test_nested_linear(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy(module)
     def test(qs: linst[qubit]) -> linst[qubit]:
@@ -162,7 +162,7 @@ def test_nested_linear(validate):
 
 def test_classical_linst_comp(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy(module)
     def test(xs: list[int]) -> linst[int]:
@@ -173,7 +173,7 @@ def test_classical_linst_comp(validate):
 
 def test_linear_discard(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy.declare(module)
     def discard(q: qubit) -> None: ...
@@ -187,7 +187,7 @@ def test_linear_discard(validate):
 
 def test_linear_discard_struct(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy.struct(module)
     class MyStruct:
@@ -206,7 +206,7 @@ def test_linear_discard_struct(validate):
 
 def test_linear_consume_in_guard(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy.declare(module)
     def cond(q: qubit) -> bool: ...
@@ -220,7 +220,7 @@ def test_linear_consume_in_guard(validate):
 
 def test_linear_consume_in_iter(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy.declare(module)
     def make_list(q: qubit) -> list[int]: ...
@@ -234,7 +234,7 @@ def test_linear_consume_in_iter(validate):
 
 def test_linear_next_nonlinear_iter(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy.type(module, NoneType().to_hugr())
     class MyIter:
@@ -266,7 +266,7 @@ def test_linear_next_nonlinear_iter(validate):
 
 def test_nonlinear_next_linear_iter(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy.type(
         module,

--- a/tests/integration/test_imports.py
+++ b/tests/integration/test_imports.py
@@ -123,3 +123,17 @@ def test_func_transitive(validate):
         return h(x)
 
     validate(module.compile())
+
+
+def test_qualified(validate):
+    import tests.integration.modules.mod_a as mod_a
+    import tests.integration.modules.mod_b as mod_b
+
+    module = GuppyModule("test")
+    module.load(mod_a, mod_b)
+
+    @guppy(module)
+    def test(x: int, y: bool) -> tuple[int, bool]:
+        return mod_a.f(x), mod_b.f(y)
+
+    validate(module.compile())

--- a/tests/integration/test_imports.py
+++ b/tests/integration/test_imports.py
@@ -137,3 +137,17 @@ def test_qualified(validate):
         return mod_a.f(x), mod_b.f(y)
 
     validate(module.compile())
+
+
+def test_qualified_types(validate):
+    import tests.integration.modules.mod_a as mod_a
+    import tests.integration.modules.mod_b as mod_b
+
+    module = GuppyModule("test")
+    module.load(mod_a, mod_b)
+
+    @guppy(module)
+    def test(x: mod_a.MyType, y: mod_b.MyType) -> tuple[mod_a.MyType, mod_b.MyType]:
+        return -x, +y
+
+    validate(module.compile())

--- a/tests/integration/test_inout.py
+++ b/tests/integration/test_inout.py
@@ -10,7 +10,7 @@ import guppylang.prelude.quantum as quantum
 
 def test_basic(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy.declare(module)
     def foo(q: qubit @inout) -> None: ...
@@ -25,7 +25,7 @@ def test_basic(validate):
 
 def test_mixed(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy.declare(module)
     def foo(q1: qubit @inout, q2: qubit) -> qubit: ...
@@ -40,7 +40,7 @@ def test_mixed(validate):
 
 def test_local(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy.declare(module)
     def foo(q: qubit @inout) -> None: ...
@@ -56,7 +56,7 @@ def test_local(validate):
 
 def test_nested_calls(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy.declare(module)
     def foo(x: int, q: qubit @inout) -> int: ...
@@ -71,7 +71,7 @@ def test_nested_calls(validate):
 
 def test_struct(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy.struct(module)
     class MyStruct:
@@ -102,7 +102,7 @@ def test_struct(validate):
 
 def test_control_flow(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy.declare(module)
     def foo(q: qubit @inout) -> None: ...
@@ -141,7 +141,7 @@ def test_control_flow(validate):
 
 def test_tensor(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy.struct(module)
     class A:
@@ -179,7 +179,7 @@ def test_tensor(validate):
 
 def test_basic_def(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy.declare(module)
     def h(q: qubit @inout) -> None: ...
@@ -200,7 +200,7 @@ def test_basic_def(validate):
 
 def test_empty_def(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy(module)
     def test(q: qubit @inout) -> None:
@@ -216,7 +216,7 @@ def test_empty_def(validate):
 
 def test_mixed_def(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy.declare(module)
     def foo(q: qubit @ inout) -> None: ...
@@ -233,7 +233,7 @@ def test_mixed_def(validate):
 
 def test_move_back(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy.struct(module)
     class MyStruct:
@@ -268,7 +268,7 @@ def test_move_back(validate):
 
 def test_move_back_branch(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy.struct(module)
     class MyStruct:
@@ -307,7 +307,7 @@ def test_move_back_branch(validate):
 
 def test_self(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy.declare(module)
     def foo(q: qubit @inout) -> None: ...

--- a/tests/integration/test_linear.py
+++ b/tests/integration/test_linear.py
@@ -10,7 +10,7 @@ from guppylang.tys.ty import NoneType
 
 def test_id(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy(module)
     def test(q: qubit) -> qubit:
@@ -21,7 +21,7 @@ def test_id(validate):
 
 def test_assign(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy(module)
     def test(q: qubit) -> qubit:
@@ -35,7 +35,7 @@ def test_assign(validate):
 def test_linear_return_order(validate):
     # See https://github.com/CQCL-DEV/guppy/issues/35
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy(module)
     def test(q: qubit) -> tuple[qubit, bool]:
@@ -46,7 +46,7 @@ def test_linear_return_order(validate):
 
 def test_interleave(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy.declare(module)
     def f(q1: qubit, q2: qubit) -> tuple[qubit, qubit]: ...
@@ -68,7 +68,7 @@ def test_interleave(validate):
 
 def test_linear_struct(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy.struct(module)
     class MyStruct:
@@ -93,7 +93,7 @@ def test_linear_struct(validate):
 
 def test_mixed_classical_linear_struct(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy.struct(module)
     class MyStruct:
@@ -122,7 +122,7 @@ def test_mixed_classical_linear_struct(validate):
 
 def test_drop_classical_field(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy.struct(module)
     class MyStruct:
@@ -139,7 +139,7 @@ def test_drop_classical_field(validate):
 
 def test_if(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy(module)
     def test(b: bool) -> qubit:
@@ -155,7 +155,7 @@ def test_if(validate):
 
 def test_if_return(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy(module)
     def test(b: bool) -> qubit:
@@ -171,7 +171,7 @@ def test_if_return(validate):
 
 def test_if_struct_rebuild(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy.struct(module)
     class MyStruct:
@@ -194,7 +194,7 @@ def test_if_struct_rebuild(validate):
 
 def test_struct_reassign(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy.struct(module)
     class MyStruct1:
@@ -220,7 +220,7 @@ def test_struct_reassign(validate):
 
 def test_struct_reassign2(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy.struct(module)
     class MyStruct:
@@ -243,7 +243,7 @@ def test_struct_reassign2(validate):
 
 def test_measure(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy(module)
     def test(q: qubit, x: int) -> int:
@@ -255,7 +255,7 @@ def test_measure(validate):
 
 def test_return_call(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy.declare(module)
     def op(q: qubit) -> qubit: ...
@@ -269,7 +269,7 @@ def test_return_call(validate):
 
 def test_while(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy(module)
     def test(q: qubit, i: int) -> qubit:
@@ -283,7 +283,7 @@ def test_while(validate):
 
 def test_while_break(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy(module)
     def test(q: qubit, i: int) -> qubit:
@@ -299,7 +299,7 @@ def test_while_break(validate):
 
 def test_while_continue(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy(module)
     def test(q: qubit, i: int) -> qubit:
@@ -315,7 +315,7 @@ def test_while_continue(validate):
 
 def test_while_reset(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy(module)
     def foo(i: bool) -> bool:
@@ -331,7 +331,7 @@ def test_while_reset(validate):
 
 def test_while_move_back(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy.struct(module)
     class MyStruct:
@@ -355,7 +355,7 @@ def test_while_move_back(validate):
 
 def test_for(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy(module)
     def test(qs: linst[tuple[qubit, qubit]]) -> linst[qubit]:
@@ -370,7 +370,7 @@ def test_for(validate):
 
 def test_for_measure(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy(module)
     def test(qs: linst[qubit]) -> bool:
@@ -384,7 +384,7 @@ def test_for_measure(validate):
 
 def test_for_continue(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy(module)
     def test(qs: linst[qubit]) -> int:
@@ -400,7 +400,7 @@ def test_for_continue(validate):
 
 def test_for_nonlinear_break(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy.type(module, NoneType().to_hugr())
     class MyIter:
@@ -437,7 +437,7 @@ def test_for_nonlinear_break(validate):
 
 def test_rus(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy(module)
     def repeat_until_success(q: qubit) -> qubit:

--- a/tests/integration/test_linst.py
+++ b/tests/integration/test_linst.py
@@ -8,7 +8,7 @@ import guppylang.prelude.quantum as quantum
 
 def test_types(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy(module)
     def test(
@@ -21,7 +21,7 @@ def test_types(validate):
 
 def test_len(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy(module)
     def test(xs: linst[qubit]) -> tuple[int, linst[qubit]]:
@@ -32,7 +32,7 @@ def test_len(validate):
 
 def test_literal(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy(module)
     def test(q1: qubit, q2: qubit) -> linst[qubit]:
@@ -43,7 +43,7 @@ def test_literal(validate):
 
 def test_arith(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy(module)
     def test(xs: linst[qubit], ys: linst[qubit], q: qubit) -> linst[qubit]:
@@ -55,7 +55,7 @@ def test_arith(validate):
 
 def test_copyable(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy(module)
     def test() -> linst[int]:

--- a/tests/integration/test_poly.py
+++ b/tests/integration/test_poly.py
@@ -231,7 +231,7 @@ def test_pass_poly_cross(validate):
 
 def test_linear(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
     T = guppy.type_var(module, "T", linear=True)
 
     @guppy.declare(module)
@@ -246,7 +246,7 @@ def test_linear(validate):
 
 def test_pass_nonlinear(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
     T = guppy.type_var(module, "T", linear=True)
 
     @guppy.declare(module)
@@ -261,7 +261,7 @@ def test_pass_nonlinear(validate):
 
 def test_pass_linear(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
     T = guppy.type_var(module, "T", linear=True)
 
     @guppy.declare(module)

--- a/tests/integration/test_py.py
+++ b/tests/integration/test_py.py
@@ -115,7 +115,7 @@ def test_pytket_single_qubit(validate):
     circ.H(0)
 
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy(module)
     def foo(q: qubit) -> qubit:
@@ -137,7 +137,7 @@ def test_pytket_multi_qubit(validate):
     circ.CZ(2, 0)
 
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy(module)
     def foo(q1: qubit, q2: qubit, q3: qubit) -> tuple[qubit, qubit, qubit]:
@@ -158,7 +158,7 @@ def test_pytket_measure(validate):
     circ.measure_all()
 
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy(module)
     def foo(q: qubit) -> tuple[qubit, bool]:

--- a/tests/integration/test_qalloc.py
+++ b/tests/integration/test_qalloc.py
@@ -8,7 +8,7 @@ from guppylang.prelude.quantum import cx, measure, dirty_qubit
 
 def test_dirty_qubit(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy(module)
     def test() -> tuple[bool, bool]:

--- a/tests/integration/test_redefinition.py
+++ b/tests/integration/test_redefinition.py
@@ -6,7 +6,7 @@ import guppylang.prelude.quantum as quantum
 
 def test_redefinition(validate):
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy(module)
     def test() -> bool:

--- a/tests/integration/test_tket.py
+++ b/tests/integration/test_tket.py
@@ -30,7 +30,7 @@ def test_lower_pure_circuit():
     import pytket
 
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy(module)
     def my_func(
@@ -62,7 +62,7 @@ def test_lower_hybrid_circuit():
     import pytket
 
     module = GuppyModule("test")
-    module.load(quantum)
+    module.load_all(quantum)
 
     @guppy(module)
     def my_func(


### PR DESCRIPTION
Closes #426.

BREAKING CHANGE: `GuppyModule.load` no longer loads the content of modules but instead just brings the name of the module into scope. Use `GuppyModule.load_all` to get the old behaviour.