### PR TITLE
feat: Add array literals

### DIFF
--- a/guppylang/compiler/expr_compiler.py
+++ b/guppylang/compiler/expr_compiler.py
@@ -19,6 +19,7 @@ from guppylang.ast_util import AstVisitor, get_type, with_loc, with_type
 from guppylang.cfg.builder import tmp_vars
 from guppylang.checker.core import Variable
 from guppylang.compiler.core import CompilerBase, DFContainer
+from guppylang.definition.custom import CustomFunctionDef
 from guppylang.definition.value import CompiledCallableDef, CompiledValueDef
 from guppylang.error import GuppyError, InternalGuppyError
 from guppylang.nodes import (
@@ -43,6 +44,7 @@ from guppylang.tys.const import BoundConstVar, ConstValue, ExistentialConstVar
 from guppylang.tys.subst import Inst
 from guppylang.tys.ty import (
     BoundTypeVar,
+    FuncInput,
     FunctionType,
     InputFlags,
     NoneType,
@@ -319,8 +321,15 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
         rets = func.compile_call(
             args, list(node.type_args), self.dfg, self.globals, node
         )
-        self._update_inout_ports(node.args, iter(rets.inout_returns), func.ty)
-        return self._pack_returns(rets.regular_returns, func.ty.output)
+        if isinstance(func, CustomFunctionDef) and not func.has_signature:
+            func_ty = FunctionType(
+                [FuncInput(get_type(arg), InputFlags.NoFlags) for arg in node.args],
+                get_type(node),
+            )
+        else:
+            func_ty = func.ty.instantiate(node.type_args)
+        self._update_inout_ports(node.args, iter(rets.inout_returns), func_ty)
+        return self._pack_returns(rets.regular_returns, func_ty.output)
 
     def visit_Call(self, node: ast.Call) -> Wire:
         raise InternalGuppyError("Node should have been removed during type checking.")

--- a/guppylang/definition/struct.py
+++ b/guppylang/definition/struct.py
@@ -219,6 +219,7 @@ class CheckedStructDef(TypeDef, CompiledDef):
             call_checker=DefaultCallChecker(),
             call_compiler=ConstructorCompiler(),
             higher_order_value=True,
+            has_signature=True,
         )
         return [constructor_def]
 

--- a/guppylang/prelude/builtins.py
+++ b/guppylang/prelude/builtins.py
@@ -14,6 +14,7 @@ from guppylang.prelude._internal.checker import (
     CoercingChecker,
     DunderChecker,
     FailingChecker,
+    NewArrayChecker,
     ResultChecker,
     ReversingChecker,
     UnsupportedChecker,
@@ -25,6 +26,7 @@ from guppylang.prelude._internal.compiler import (
     FloatModCompiler,
     IntTruedivCompiler,
     NatTruedivCompiler,
+    NewArrayCompiler,
 )
 from guppylang.prelude._internal.util import (
     custom_op,
@@ -81,6 +83,9 @@ _n = TypeVar("_n")
 
 class array(Generic[_T, _n]):
     """Class to import in order to use arrays."""
+
+    def __init__(self, *args: _T):
+        pass
 
 
 @guppy.extend_type(builtins, bool_type_def)
@@ -659,6 +664,11 @@ class Array:
 
     @guppy.custom(builtins, checker=ArrayLenChecker())
     def __len__(self: array[T, n]) -> int: ...
+
+    @guppy.custom(
+        builtins, NewArrayCompiler(), NewArrayChecker(), higher_order_value=False
+    )
+    def __new__(): ...
 
 
 # TODO: This is a temporary hack until we have implemented the proper results mechanism.

--- a/guppylang/tys/builtin.py
+++ b/guppylang/tys/builtin.py
@@ -9,6 +9,7 @@ from guppylang.definition.common import DefId
 from guppylang.definition.ty import OpaqueTypeDef, TypeDef
 from guppylang.error import GuppyError, InternalGuppyError
 from guppylang.tys.arg import Argument, ConstArg, TypeArg
+from guppylang.tys.const import ConstValue
 from guppylang.tys.param import ConstParam, TypeParam
 from guppylang.tys.ty import (
     FunctionType,
@@ -203,6 +204,13 @@ def list_type(element_ty: Type) -> OpaqueType:
 
 def linst_type(element_ty: Type) -> OpaqueType:
     return OpaqueType([TypeArg(element_ty)], linst_type_def)
+
+
+def array_type(element_ty: Type, length: int) -> OpaqueType:
+    nat_type = NumericType(NumericType.Kind.Nat)
+    return OpaqueType(
+        [TypeArg(element_ty), ConstArg(ConstValue(nat_type, length))], array_type_def
+    )
 
 
 def is_bool_type(ty: Type) -> bool:

--- a/tests/error/array_errors/new_array_cannot_infer.err
+++ b/tests/error/array_errors/new_array_cannot_infer.err
@@ -1,0 +1,7 @@
+Guppy compilation failed. Error in file $FILE:13
+
+11:    @guppy(module)
+12:    def main() -> None:
+13:        xs = array()
+                ^^^^^^^
+GuppyTypeError: Cannot infer the array element type. Consider adding a type annotation.

--- a/tests/error/array_errors/new_array_cannot_infer.py
+++ b/tests/error/array_errors/new_array_cannot_infer.py
@@ -1,0 +1,16 @@
+import guppylang.prelude.quantum as quantum
+from guppylang.decorator import guppy
+from guppylang.module import GuppyModule
+from guppylang.prelude.builtins import array
+
+
+module = GuppyModule("test")
+module.load(quantum)
+
+
+@guppy(module)
+def main() -> None:
+    xs = array()
+
+
+module.compile()

--- a/tests/error/array_errors/new_array_check_fail.err
+++ b/tests/error/array_errors/new_array_check_fail.err
@@ -1,0 +1,7 @@
+Guppy compilation failed. Error in file $FILE:13
+
+11:    @guppy(module)
+12:    def main() -> int:
+13:        return array(1)
+                  ^^^^^^^^
+GuppyTypeError: Expected expression of type `int`, got `array`

--- a/tests/error/array_errors/new_array_check_fail.py
+++ b/tests/error/array_errors/new_array_check_fail.py
@@ -1,0 +1,16 @@
+import guppylang.prelude.quantum as quantum
+from guppylang.decorator import guppy
+from guppylang.module import GuppyModule
+from guppylang.prelude.builtins import array
+
+
+module = GuppyModule("test")
+module.load(quantum)
+
+
+@guppy(module)
+def main() -> int:
+    return array(1)
+
+
+module.compile()

--- a/tests/error/array_errors/new_array_elem_mismatch1.err
+++ b/tests/error/array_errors/new_array_elem_mismatch1.err
@@ -1,0 +1,7 @@
+Guppy compilation failed. Error in file $FILE:13
+
+11:    @guppy(module)
+12:    def main() -> array[int, 1]:
+13:        array(False)
+           ^^^^^^^^^^^^
+GuppyError: Expected return statement

--- a/tests/error/array_errors/new_array_elem_mismatch1.py
+++ b/tests/error/array_errors/new_array_elem_mismatch1.py
@@ -1,0 +1,16 @@
+import guppylang.prelude.quantum as quantum
+from guppylang.decorator import guppy
+from guppylang.module import GuppyModule
+from guppylang.prelude.builtins import array
+
+
+module = GuppyModule("test")
+module.load(quantum)
+
+
+@guppy(module)
+def main() -> array[int, 1]:
+    array(False)
+
+
+module.compile()

--- a/tests/error/array_errors/new_array_elem_mismatch2.err
+++ b/tests/error/array_errors/new_array_elem_mismatch2.err
@@ -1,0 +1,7 @@
+Guppy compilation failed. Error in file $FILE:13
+
+11:    @guppy(module)
+12:    def main() -> None:
+13:        array(1, False)
+                    ^^^^^
+GuppyTypeError: Expected expression of type `int`, got `bool`

--- a/tests/error/array_errors/new_array_elem_mismatch2.py
+++ b/tests/error/array_errors/new_array_elem_mismatch2.py
@@ -1,0 +1,16 @@
+import guppylang.prelude.quantum as quantum
+from guppylang.decorator import guppy
+from guppylang.module import GuppyModule
+from guppylang.prelude.builtins import array
+
+
+module = GuppyModule("test")
+module.load(quantum)
+
+
+@guppy(module)
+def main() -> None:
+    array(1, False)
+
+
+module.compile()

--- a/tests/error/array_errors/new_array_wrong_length.err
+++ b/tests/error/array_errors/new_array_wrong_length.err
@@ -1,0 +1,7 @@
+Guppy compilation failed. Error in file $FILE:13
+
+11:    @guppy(module)
+12:    def main() -> array[int, 2]:
+13:        return array(1, 2, 3)
+                  ^^^^^^^^^^^^^^
+GuppyTypeError: Expected expression of type `array[int, 2]`, got `array[int, 3]`

--- a/tests/error/array_errors/new_array_wrong_length.py
+++ b/tests/error/array_errors/new_array_wrong_length.py
@@ -1,0 +1,16 @@
+import guppylang.prelude.quantum as quantum
+from guppylang.decorator import guppy
+from guppylang.module import GuppyModule
+from guppylang.prelude.builtins import array
+
+
+module = GuppyModule("test")
+module.load(quantum)
+
+
+@guppy(module)
+def main() -> array[int, 2]:
+    return array(1, 2, 3)
+
+
+module.compile()

--- a/tests/integration/test_array.py
+++ b/tests/integration/test_array.py
@@ -29,3 +29,30 @@ def test_index(validate):
         return xs[0] + xs[i] + xs[xs[2 * i]]
 
     validate(main)
+
+
+def test_new_array(validate):
+    @compile_guppy
+    def main(x: int, y: int) -> array[int, 3]:
+        xs = array(x, y, x)
+        return xs
+
+    validate(main)
+
+
+def test_new_array_infer_empty(validate):
+    @compile_guppy
+    def main() -> array[float, 0]:
+        return array()
+
+    validate(main)
+
+
+def test_new_array_infer_nested(validate):
+    @compile_guppy
+    def main(ys: array[int, 0]) -> array[array[int, 0], 2]:
+        xs = array(ys, array())
+        return xs
+
+    validate(main)
+


### PR DESCRIPTION
Closes #396.

* New arrays can be created using the constructor `array(x, y, z)`.
* Uses a `CustomCallChecker` to support varargs
* This broke some code that relied on the static signature of functions. Added special cases for `CustomFunctions` without known signature (such as the array constructor) that infers a concrete signature based on the context.