### PR TITLE
test: cargo build validator in CI

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -63,6 +63,9 @@ jobs:
       - name: Install Guppy with llvm-based execution
         run: uv sync --extra execution
 
+      - name: Cargo build validator
+        run: cargo build -p validator --release
+
       - name: Run tests
         run: uv run pytest
 
@@ -105,6 +108,9 @@ jobs:
 
       - name: Install Guppy with execution and pytket
         run: uv sync --extra execution --extra pytket
+
+      - name: Cargo build validator
+        run: cargo build -p validator --release
 
       - name: Run python tests with coverage instrumentation
         run: uv run pytest --cov=./ --cov-report=xml

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -68,14 +68,14 @@ class LLVMException(Exception):
 
 @pytest.fixture
 def run_int_fn():
-    def f(hugr: Hugr, expected: int, fn_name: str = "main"):
+    def f(hugr: Package, expected: int, fn_name: str = "main"):
         try:
             import execute_llvm
 
             if not hasattr(execute_llvm, "run_int_function"):
                 pytest.skip("Skipping llvm execution")
 
-            hugr_json: str = hugr.to_json()
+            hugr_json: str = hugr.modules[0].to_json()
             res = execute_llvm.run_int_function(hugr_json, fn_name)
             if res != expected:
                 raise LLVMException(


### PR DESCRIPTION
Many hugr-building tests are showing up as `s` == skipped after #455. We need to `cargo build` the validator first.

Also "fix" (perhaps hack) `run_int_fn` to extract the first `module` Hugr from the Package coming back from compilation.