### PR TITLE
test: only skip validation tests when given explicit flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,10 @@ uv run pre-commit install
 Run tests using
 
 ```sh
-uv run pytest -v
+uv run pytest [-v]  # -v just enables verbose test output
 ```
+
+(If you have not build the validator, you can `uv run pytest --no_validation`)
 
 You have to install extra dependencies to test automatic circuit conversion from `pytket`.
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Run tests using
 uv run pytest [-v]  # -v just enables verbose test output
 ```
 
-(If you have not build the validator, you can `uv run pytest --no_validation`)
+(If you have not built the validator, you can do `uv run pytest --no_validation`.)
 
 You have to install extra dependencies to test automatic circuit conversion from `pytket`.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,3 +16,10 @@ def pytest_addoption(parser):
         type=dir_path,
         help="A directory to which to export test cases",
     )
+
+    parser.addoption(
+        "--no_validation",
+        dest="validation",
+        action="store_false",
+        help="Disable validation tests (run by default)",
+    )


### PR DESCRIPTION
pytest previously skipped the validation tests if the validator was not built, leading to the situation in #468 where many tests were accidentally skipped in CI.

Instead, fail the tests if the validator is not installed, but allow `pytest --no_validation` to skip them instead.

The possibility of doing similar for execution tests (somewhat-silently skipped if `execute-llvm` isn't installed) is left for a later PR.