### PR TITLE
chore: Unskip now-passing tests

### DIFF
--- a/tests/integration/test_array.py
+++ b/tests/integration/test_array.py
@@ -31,7 +31,6 @@ def test_len(validate):
     assert val.val.v == 42
 
 
-@pytest.mark.skip("Skipped until Hugr lowering is updated")
 def test_index(validate):
     @compile_guppy
     def main(xs: array[int, 5], i: int) -> int:
@@ -85,7 +84,7 @@ def test_linear_subscript(validate):
     module.load_all(quantum)
 
     @guppy.declare(module)
-    def foo(q: qubit @inout) -> None: ...
+    def foo(q: qubit @ inout) -> None: ...
 
     @guppy(module)
     def main(qs: array[qubit, 42], i: int) -> array[qubit, 42]:
@@ -100,10 +99,10 @@ def test_inout_subscript(validate):
     module.load_all(quantum)
 
     @guppy.declare(module)
-    def foo(q: qubit @inout) -> None: ...
+    def foo(q: qubit @ inout) -> None: ...
 
     @guppy(module)
-    def main(qs: array[qubit, 42] @inout, i: int) -> None:
+    def main(qs: array[qubit, 42] @ inout, i: int) -> None:
         foo(qs[i])
 
     validate(module.compile())
@@ -114,7 +113,7 @@ def test_multi_subscripts(validate):
     module.load_all(quantum)
 
     @guppy.declare(module)
-    def foo(q1: qubit @inout, q2: qubit @inout) -> None: ...
+    def foo(q1: qubit @ inout, q2: qubit @ inout) -> None: ...
 
     @guppy(module)
     def main(qs: array[qubit, 42]) -> array[qubit, 42]:
@@ -135,7 +134,7 @@ def test_struct_array(validate):
         q2: qubit
 
     @guppy.declare(module)
-    def foo(q1: qubit @inout, q2: qubit @inout) -> None: ...
+    def foo(q1: qubit @ inout, q2: qubit @ inout) -> None: ...
 
     @guppy(module)
     def main(ss: array[S, 10]) -> array[S, 10]:
@@ -153,11 +152,11 @@ def test_nested_subscripts(validate):
     module.load_all(quantum)
 
     @guppy.declare(module)
-    def foo(q: qubit @inout) -> None: ...
+    def foo(q: qubit @ inout) -> None: ...
 
     @guppy.declare(module)
     def bar(
-        q1: qubit @inout, q2: qubit @inout, q3: qubit @inout, q4: qubit @inout
+        q1: qubit @ inout, q2: qubit @ inout, q3: qubit @ inout, q4: qubit @ inout
     ) -> None: ...
 
     @guppy(module)
@@ -193,7 +192,7 @@ def test_struct_nested_subscript(validate):
         baz: tuple[B, B]
 
     @guppy.declare(module)
-    def foo(q1: qubit @inout) -> None: ...
+    def foo(q1: qubit @ inout) -> None: ...
 
     @guppy(module)
     def main(a: A, i: int, j: int, k: int) -> A:

--- a/tests/integration/test_if.py
+++ b/tests/integration/test_if.py
@@ -232,7 +232,7 @@ def test_break_different_types2(validate):
     validate(foo)
 
 
-@pytest.mark.skip("Known bug")
+@pytest.mark.skip("Known bug, `z` redefined with different type")
 def test_continue_different_types1(validate):
     @compile_guppy
     def foo(x: int) -> int:
@@ -249,7 +249,7 @@ def test_continue_different_types1(validate):
     validate(foo)
 
 
-@pytest.mark.skip("Known bug")
+@pytest.mark.skip("Known bug, `z` redefined with different type")
 def test_continue_different_types2(validate):
     @compile_guppy
     def foo(x: int) -> int:

--- a/tests/integration/test_poly.py
+++ b/tests/integration/test_poly.py
@@ -294,7 +294,7 @@ def test_custom_higher_order():
         return f(x)
 
 
-@pytest.mark.skip("Not yet supported")
+@pytest.mark.skip("Higher-order polymorphic functions are not yet supported")
 def test_higher_order_value(validate):
     module = GuppyModule("test")
     T = guppy.type_var(module, "T")

--- a/tests/integration/test_py.py
+++ b/tests/integration/test_py.py
@@ -73,9 +73,6 @@ def test_tuple_implicit(validate):
     validate(foo)
 
 
-@pytest.mark.skip(
-    reason="collections extensions not defined in the validator. Remove once updated to hugr 0.8",
-)
 def test_list_basic(validate):
     @compile_guppy
     def foo() -> list[int]:
@@ -85,9 +82,6 @@ def test_list_basic(validate):
     validate(foo)
 
 
-@pytest.mark.skip(
-    reason="collections extensions not defined in the validator. Remove once updated to hugr 0.8",
-)
 def test_list_empty(validate):
     @compile_guppy
     def foo() -> list[int]:
@@ -96,9 +90,6 @@ def test_list_empty(validate):
     validate(foo)
 
 
-@pytest.mark.skip(
-    reason="collections extensions not defined in the validator. Remove once updated to hugr 0.8",
-)
 def test_list_empty_nested(validate):
     @compile_guppy
     def foo() -> None:
@@ -107,9 +98,6 @@ def test_list_empty_nested(validate):
     validate(foo)
 
 
-@pytest.mark.skip(
-    reason="collections extensions not defined in the validator. Remove once updated to hugr 0.8",
-)
 def test_list_empty_multiple(validate):
     @compile_guppy
     def foo() -> None:
@@ -119,7 +107,6 @@ def test_list_empty_multiple(validate):
 
 
 @pytest.mark.skipif(not tket2_installed, reason="Tket2 is not installed")
-@pytest.mark.skip("Fails because of extensions in types #343")
 def test_pytket_single_qubit(validate):
     from pytket import Circuit
 
@@ -138,7 +125,6 @@ def test_pytket_single_qubit(validate):
 
 
 @pytest.mark.skipif(not tket2_installed, reason="Tket2 is not installed")
-@pytest.mark.skip("Fails because of extensions in types #343")
 def test_pytket_multi_qubit(validate):
     from pytket import Circuit
 

--- a/tests/integration/test_py.py
+++ b/tests/integration/test_py.py
@@ -107,6 +107,7 @@ def test_list_empty_multiple(validate):
 
 
 @pytest.mark.skipif(not tket2_installed, reason="Tket2 is not installed")
+@pytest.mark.skip("Fails because of extensions in types #343")
 def test_pytket_single_qubit(validate):
     from pytket import Circuit
 
@@ -125,6 +126,7 @@ def test_pytket_single_qubit(validate):
 
 
 @pytest.mark.skipif(not tket2_installed, reason="Tket2 is not installed")
+@pytest.mark.skip("Fails because of extensions in types #343")
 def test_pytket_multi_qubit(validate):
     from pytket import Circuit
 

--- a/uv.lock
+++ b/uv.lock
@@ -518,7 +518,7 @@ wheels = [
 
 [[package]]
 name = "guppylang"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "graphviz" },


### PR DESCRIPTION
Some leftover skips from the hugr update, and from https://github.com/CQCL/guppylang/issues/343

Also adds some extra info on the remaining skips.