### PR TITLE
chore: Small error print improvements

### DIFF
--- a/guppylang/definition/common.py
+++ b/guppylang/definition/common.py
@@ -39,6 +39,11 @@ class DefId:
     def fresh(cls, module: "GuppyModule | None" = None) -> "DefId":
         return DefId(next(cls._ids), module)
 
+    def __str__(self) -> str:
+        if self.module is None:
+            return f"DefId({self.id}, None)"
+        return f"DefId({self.id}, {self.module.name})"
+
 
 @dataclass(frozen=True)
 class Definition(ABC):

--- a/guppylang/tys/parsing.py
+++ b/guppylang/tys/parsing.py
@@ -82,7 +82,7 @@ def _try_parse_defn(node: AstNode, globals: Globals) -> Definition | None:
     match node:
         case ast.Name(id=x):
             if x not in globals:
-                raise GuppyError("Unknown identifier", node)
+                raise GuppyError(f"Unknown identifier `{x}`", node)
             return globals[x]
         case ast.Attribute(value=ast.Name(id=module_name) as value, attr=x):
             if module_name not in globals:

--- a/uv.lock
+++ b/uv.lock
@@ -518,7 +518,7 @@ wheels = [
 
 [[package]]
 name = "guppylang"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "graphviz" },


### PR DESCRIPTION
Implement `__str__` for `DefId`, so it's easier to see the module name

before:
```py
DefId(id=298, module=<guppylang.module.GuppyModule object at 0x109e18110>)
```
after:
```py
DefId(298, quantum)
```

drive-by: Update uv.lock with the latest release version