### PR TITLE
fix: Evade false positives for inout variable usage

### DIFF
--- a/guppylang/checker/linearity_checker.py
+++ b/guppylang/checker/linearity_checker.py
@@ -105,7 +105,11 @@ class BBLinearityChecker(ast.NodeVisitor):
     globals: Globals
 
     def check(
-        self, bb: "CheckedBB[Variable]", is_entry: bool, func_inputs: dict[PlaceId, Variable], globals: Globals
+        self,
+        bb: "CheckedBB[Variable]",
+        is_entry: bool,
+        func_inputs: dict[PlaceId, Variable],
+        globals: Globals,
     ) -> Scope:
         # Manufacture a scope that holds all places that are live at the start
         # of this BB
@@ -464,7 +468,7 @@ def check_cfg_linearity(
     than just variables.
     """
     bb_checker = BBLinearityChecker()
-    func_inputs = {v.id: v for v in cfg.entry_bb.sig.input_row}
+    func_inputs: dict[PlaceId, Variable] = {v.id: v for v in cfg.entry_bb.sig.input_row}
     scopes: dict[BB, Scope] = {
         bb: bb_checker.check(
             bb, is_entry=bb == cfg.entry_bb, func_inputs=func_inputs, globals=globals

--- a/tests/integration/test_inout.py
+++ b/tests/integration/test_inout.py
@@ -339,3 +339,18 @@ def test_subtype(validate):
         return q
 
     validate(module.compile())
+
+def test_shadow_check(validate):
+    module = GuppyModule("test")
+
+    module.load(quantum, qubit)
+
+    @guppy.declare(module)
+    def foo(i: qubit) -> None: ...
+
+    @guppy(module)
+    def main(i: qubit) -> None:
+        if True:
+            foo(i)
+
+    validate(module.compile())


### PR DESCRIPTION
I don't think this is the best/neatest solution, but it fixes the false positives