### PR TITLE
feat!: Add functions to quantum module and make quantum_functional independent

### DIFF
--- a/examples/demo.ipynb
+++ b/examples/demo.ipynb
@@ -87,8 +87,7 @@
    "outputs": [],
    "source": [
     "from guppylang.prelude.builtins import owned\n",
-    "from guppylang.prelude.quantum import qubit, measure\n",
-    "from guppylang.prelude.quantum_functional import h, cx\n",
+    "from guppylang.prelude.quantum import qubit, measure, h, cx\n",
     "\n",
     "module.load(qubit, h, cx, measure)\n",
     "\n",
@@ -101,8 +100,9 @@
     "    # Allocate two fresh qubits\n",
     "    q1, q2 = qubit(), qubit()\n",
     "    # Entangle\n",
-    "    q1, q2 = cx(h(q1), q2)\n",
-    "    q2 = h(q2)\n",
+    "    h(q1)\n",
+    "    cx(q1, q2)\n",
+    "    h(q2)\n",
     "    # Measure\n",
     "    b1, b2 = measure(q1), measure(q2)\n",
     "    return b1 ^ b2"
@@ -298,10 +298,10 @@
       "Guppy compilation failed. Error in file <In [9]>:6\n",
       "\n",
       "4:    @guppy(bad_module)\n",
-      "5:    def bad(q: qubit @owned) -> tuple[qubit, qubit]:\n",
-      "6:        return cx(q, q)\n",
-      "                       ^\n",
-      "GuppyError: Variable `q` with linear type `qubit` was already used (at 6:14)\n"
+      "5:    def bad(q: qubit @owned) -> qubit:\n",
+      "6:        cx(q, q)\n",
+      "                ^\n",
+      "GuppyError: Variable `q` with linear type `qubit` was already used (at 6:7)\n"
      ]
     }
    ],
@@ -310,8 +310,9 @@
     "bad_module.load_all(guppylang.prelude.quantum)\n",
     "\n",
     "@guppy(bad_module)\n",
-    "def bad(q: qubit @owned) -> tuple[qubit, qubit]:\n",
-    "    return cx(q, q)\n",
+    "def bad(q: qubit @owned) -> qubit:\n",
+    "    cx(q, q)\n",
+    "    return q\n",
     "\n",
     "bad_module.compile()  # Raises an error"
    ]
@@ -341,9 +342,9 @@
       "Guppy compilation failed. Error in file <In [10]>:7\n",
       "\n",
       "5:    def bad(q: qubit @owned) -> qubit:\n",
-      "6:        tmp = h(qubit())\n",
-      "7:        tmp, q = cx(tmp, q)\n",
-      "          ^^^\n",
+      "6:        tmp = qubit()\n",
+      "7:        cx(tmp, q)\n",
+      "             ^^^\n",
       "GuppyError: Variable `tmp` with linear type `qubit` is not used on all control-flow paths\n"
      ]
     }
@@ -354,8 +355,8 @@
     "\n",
     "@guppy(bad_module)\n",
     "def bad(q: qubit @owned) -> qubit:\n",
-    "    tmp = h(qubit())\n",
-    "    tmp, q = cx(tmp, q)\n",
+    "    tmp = qubit()\n",
+    "    cx(tmp, q)\n",
     "    #discard(tmp)  # Compiler complains if tmp is not explicitly discarded\n",
     "    return q\n",
     "\n",
@@ -422,15 +423,14 @@
     "    q2: qubit\n",
     "\n",
     "    @guppy(module)\n",
-    "    def method(self: \"QubitPair @owned\") -> \"QubitPair\":\n",
-    "        self.q1 = h(self.q1)\n",
-    "        self.q1, self.q2 = cx(self.q1, self.q2)\n",
-    "        return self\n",
+    "    def method(self: \"QubitPair\") -> None:\n",
+    "        h(self.q1)\n",
+    "        cx(self.q1, self.q2)\n",
     "\n",
     "@guppy(module)\n",
     "def make_struct() -> QubitPair:\n",
     "    pair = QubitPair(qubit(), qubit())\n",
-    "    # pair = pair.method()  # TODO: Calling methods doesn't work yet\n",
+    "    pair.method()\n",
     "    return pair\n",
     "\n",
     "program = module.compile()"
@@ -559,7 +559,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.5"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/guppylang/checker/expr_checker.py
+++ b/guppylang/checker/expr_checker.py
@@ -128,7 +128,7 @@ binary_table: dict[type[AstOp], tuple[str, str, str]] = {
     ast.BitAnd:   ("__and__",      "__rand__",      "&"),
     ast.MatMult:  ("__matmul__",   "__rmatmul__",   "@"),
     ast.Eq:       ("__eq__",       "__eq__",        "=="),
-    ast.NotEq:    ("__neq__",      "__neq__",       "!="),
+    ast.NotEq:    ("__ne__",       "__ne__",        "!="),
     ast.Lt:       ("__lt__",       "__gt__",        "<"),
     ast.LtE:      ("__le__",       "__ge__",        "<="),
     ast.Gt:       ("__gt__",       "__lt__",        ">"),

--- a/guppylang/decorator.py
+++ b/guppylang/decorator.py
@@ -17,7 +17,7 @@ from guppylang.definition.common import DefId, Definition
 from guppylang.definition.const import RawConstDef
 from guppylang.definition.custom import (
     CustomCallChecker,
-    CustomCallCompiler,
+    CustomInoutCallCompiler,
     DefaultCallChecker,
     NotImplementedCallCompiler,
     OpCompiler,
@@ -197,7 +197,7 @@ class _Guppy:
     def custom(
         self,
         module: GuppyModule,
-        compiler: CustomCallCompiler | None = None,
+        compiler: CustomInoutCallCompiler | None = None,
         checker: CustomCallChecker | None = None,
         higher_order_value: bool = True,
         name: str = "",

--- a/guppylang/definition/custom.py
+++ b/guppylang/definition/custom.py
@@ -17,7 +17,14 @@ from guppylang.definition.value import CallReturnWires, CompiledCallableDef
 from guppylang.error import GuppyError, InternalGuppyError
 from guppylang.nodes import GlobalCall
 from guppylang.tys.subst import Inst, Subst
-from guppylang.tys.ty import FuncInput, FunctionType, InputFlags, NoneType, Type
+from guppylang.tys.ty import (
+    FuncInput,
+    FunctionType,
+    InputFlags,
+    NoneType,
+    Type,
+    type_to_row,
+)
 
 
 @dataclass(frozen=True)
@@ -41,7 +48,7 @@ class RawCustomFunctionDef(ParsableDef):
 
     defined_at: ast.FunctionDef
     call_checker: "CustomCallChecker"
-    call_compiler: "CustomCallCompiler"
+    call_compiler: "CustomInoutCallCompiler"
 
     # Whether the function may be used as a higher-order value. This is only possible
     # if a static type for the function is provided.
@@ -92,8 +99,9 @@ class RawCustomFunctionDef(ParsableDef):
             globals,
             node,
             function_ty,
+            None,
         )
-        return self.call_compiler.compile(args)
+        return self.call_compiler.compile_with_inouts(args).regular_returns
 
     def _get_signature(self, globals: Globals) -> FunctionType | None:
         """Returns the type of the function, if known.
@@ -237,7 +245,7 @@ class CustomFunctionDef(CompiledCallableDef):
             )
         hugr_ty = concrete_ty.to_hugr()
 
-        self.call_compiler._setup(type_args, dfg, globals, node, hugr_ty)
+        self.call_compiler._setup(type_args, dfg, globals, node, hugr_ty, self)
         return self.call_compiler.compile_with_inouts(args)
 
 
@@ -284,6 +292,7 @@ class CustomInoutCallCompiler(ABC):
     globals: CompiledGlobals
     node: AstNode
     ty: ht.FunctionType
+    func: CustomFunctionDef | None
 
     def _setup(
         self,
@@ -292,12 +301,14 @@ class CustomInoutCallCompiler(ABC):
         globals: CompiledGlobals,
         node: AstNode,
         hugr_ty: ht.FunctionType,
+        func: CustomFunctionDef | None,
     ) -> None:
         self.type_args = type_args
         self.dfg = dfg
         self.globals = globals
         self.node = node
         self.ty = hugr_ty
+        self.func = func
 
     @abstractmethod
     def compile_with_inouts(self, args: list[Wire]) -> CallReturnWires:
@@ -306,6 +317,11 @@ class CustomInoutCallCompiler(ABC):
         Returns the outputs of the call together with any borrowed arguments that are
         passed through the function.
         """
+
+    @property
+    def builder(self) -> DfBase[ops.DfParentOp]:
+        """The hugr dataflow builder."""
+        return self.dfg.builder
 
 
 class CustomCallCompiler(CustomInoutCallCompiler, ABC):
@@ -317,11 +333,6 @@ class CustomCallCompiler(CustomInoutCallCompiler, ABC):
 
         Use the provided `self.builder` to add nodes to the Hugr graph.
         """
-
-    @property
-    def builder(self) -> DfBase[ops.DfParentOp]:
-        """The hugr dataflow builder."""
-        return self.dfg.builder
 
     def compile_with_inouts(self, args: list[Wire]) -> CallReturnWires:
         return CallReturnWires(self.compile(args), inout_returns=[])
@@ -353,7 +364,7 @@ class NotImplementedCallCompiler(CustomCallCompiler):
         raise InternalGuppyError("Function should have been removed during checking")
 
 
-class OpCompiler(CustomCallCompiler):
+class OpCompiler(CustomInoutCallCompiler):
     """Call compiler for functions that are directly implemented via Hugr ops.
 
     args:
@@ -366,10 +377,16 @@ class OpCompiler(CustomCallCompiler):
     def __init__(self, op: Callable[[ht.FunctionType, Inst], ops.DataflowOp]) -> None:
         self.op = op
 
-    def compile(self, args: list[Wire]) -> list[Wire]:
+    def compile_with_inouts(self, args: list[Wire]) -> CallReturnWires:
         op = self.op(self.ty, self.type_args)
         node = self.builder.add_op(op, *args)
-        return list(node)
+        num_returns = (
+            len(type_to_row(self.func.ty.output)) if self.func else len(self.ty.output)
+        )
+        return CallReturnWires(
+            regular_returns=list(node[:num_returns]),
+            inout_returns=list(node[num_returns:]),
+        )
 
 
 class NoopCompiler(CustomCallCompiler):

--- a/guppylang/prelude/_internal/compiler/quantum.py
+++ b/guppylang/prelude/_internal/compiler/quantum.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 from hugr import Wire
 from hugr import tys as ht
 
-from guppylang.definition.custom import CustomCallCompiler
+from guppylang.definition.custom import CustomInoutCallCompiler
+from guppylang.definition.value import CallReturnWires
 from guppylang.prelude._internal.json_defs import load_extension
 
 # ----------------------------------------------
@@ -35,10 +36,10 @@ ANGLE_T = QUANTUM_EXTENSION.get_type("angle")
 # ------------------------------------------------------
 
 
-class MeasureCompiler(CustomCallCompiler):
-    """Compiler for the `measure` function."""
+class MeasureReturnCompiler(CustomInoutCallCompiler):
+    """Compiler for the `measure_return` function."""
 
-    def compile(self, args: list[Wire]) -> list[Wire]:
+    def compile_with_inouts(self, args: list[Wire]) -> CallReturnWires:
         from guppylang.prelude._internal.util import quantum_op
 
         [q] = args
@@ -46,21 +47,4 @@ class MeasureCompiler(CustomCallCompiler):
             quantum_op("Measure")(ht.FunctionType([ht.Qubit], [ht.Qubit, ht.Bool]), []),
             q,
         )
-        self.builder.add_op(quantum_op("QFree")(ht.FunctionType([ht.Qubit], []), []), q)
-        return [bit]
-
-
-class QAllocCompiler(CustomCallCompiler):
-    """Compiler for the `qubit` function."""
-
-    def compile(self, args: list[Wire]) -> list[Wire]:
-        from guppylang.prelude._internal.util import quantum_op
-
-        assert not args, "qubit() does not take any arguments"
-        q = self.builder.add_op(
-            quantum_op("QAlloc")(ht.FunctionType([], [ht.Qubit]), [])
-        )
-        q = self.builder.add_op(
-            quantum_op("Reset")(ht.FunctionType([ht.Qubit], [ht.Qubit]), []), q
-        )
-        return [q]
+        return CallReturnWires(regular_returns=[bit], inout_returns=[q])

--- a/guppylang/prelude/quantum.py
+++ b/guppylang/prelude/quantum.py
@@ -1,14 +1,15 @@
 """Guppy standard module for quantum operations."""
 
-# mypy: disable-error-code="empty-body, misc, valid-type"
+import typing
 
+# mypy: disable-error-code="empty-body, misc, valid-type"
 from hugr import tys as ht
 
 from guppylang.decorator import guppy
 from guppylang.module import GuppyModule
 from guppylang.prelude._internal.compiler.quantum import (
-    MeasureCompiler,
-    QAllocCompiler,
+    HSERIES_EXTENSION,
+    MeasureReturnCompiler,
 )
 from guppylang.prelude._internal.util import quantum_op
 from guppylang.prelude.angles import angle
@@ -20,21 +21,123 @@ quantum.load(angle)
 
 @guppy.type(quantum, ht.Qubit, linear=True)
 class qubit:
-    @guppy.custom(quantum, QAllocCompiler())
-    def __new__() -> "qubit": ...
+    @guppy(quantum)
+    @typing.no_type_check
+    def __new__() -> "qubit":
+        q = dirty_qubit()
+        reset(q)
+        return q
+
+
+@guppy.hugr_op(quantum, quantum_op("H"))
+def h(q: qubit) -> None: ...
+
+
+@guppy.hugr_op(quantum, quantum_op("CZ"))
+def cz(control: qubit, target: qubit) -> None: ...
+
+
+@guppy.hugr_op(quantum, quantum_op("CX"))
+def cx(control: qubit, target: qubit) -> None: ...
+
+
+@guppy.hugr_op(quantum, quantum_op("T"))
+def t(q: qubit) -> None: ...
+
+
+@guppy.hugr_op(quantum, quantum_op("S"))
+def s(q: qubit) -> None: ...
+
+
+@guppy.hugr_op(quantum, quantum_op("X"))
+def x(q: qubit) -> None: ...
+
+
+@guppy.hugr_op(quantum, quantum_op("Y"))
+def y(q: qubit) -> None: ...
+
+
+@guppy.hugr_op(quantum, quantum_op("Z"))
+def z(q: qubit) -> None: ...
+
+
+@guppy.hugr_op(quantum, quantum_op("Tdg"))
+def tdg(q: qubit) -> None: ...
+
+
+@guppy.hugr_op(quantum, quantum_op("Sdg"))
+def sdg(q: qubit) -> None: ...
+
+
+@guppy.hugr_op(quantum, quantum_op("ZZMax", ext=HSERIES_EXTENSION))
+def zz_max(q1: qubit, q2: qubit) -> None: ...
+
+
+@guppy.hugr_op(quantum, quantum_op("Rz"))
+def rz(q: qubit, angle: angle) -> None: ...
+
+
+@guppy.hugr_op(quantum, quantum_op("Rx"))
+def rx(q: qubit, angle: angle) -> None: ...
 
 
 @guppy.hugr_op(quantum, quantum_op("QAlloc"))
 def dirty_qubit() -> qubit: ...
 
 
-@guppy.hugr_op(quantum, quantum_op("Measure"))
-def measure_return(q: qubit @ owned) -> tuple[qubit, bool]: ...
+@guppy.custom(quantum, MeasureReturnCompiler())
+def measure_return(q: qubit) -> bool: ...
 
 
 @guppy.hugr_op(quantum, quantum_op("QFree"))
 def discard(q: qubit @ owned) -> None: ...
 
 
-@guppy.custom(quantum, MeasureCompiler())
-def measure(q: qubit @ owned) -> bool: ...
+@guppy(quantum)
+@typing.no_type_check
+def measure(q: qubit @ owned) -> bool:
+    res = measure_return(q)
+    discard(q)
+    return res
+
+
+@guppy(quantum)
+@typing.no_type_check
+def phased_x(q: qubit, angle1: angle, angle2: angle) -> None:
+    f1 = float(angle1)
+    f2 = float(angle2)
+    _phased_x(q, f1, f2)
+
+
+@guppy(quantum)
+@typing.no_type_check
+def zz_phase(q1: qubit, q2: qubit, angle: angle) -> None:
+    f = float(angle)
+    _zz_phase(q1, q2, f)
+
+
+@guppy.hugr_op(quantum, quantum_op("Reset"))
+def reset(q: qubit) -> None: ...
+
+
+# ------------------------------------------------------
+# --------- Internal definitions -----------------------
+# ------------------------------------------------------
+
+
+@guppy.hugr_op(quantum, quantum_op("PhasedX", ext=HSERIES_EXTENSION))
+def _phased_x(q: qubit, angle1: float, angle2: float) -> None:
+    """PhasedX operation from the hseries extension.
+
+    See `guppylang.prelude.quantum.phased_x` for a public definition that
+    accepts angle parameters.
+    """
+
+
+@guppy.hugr_op(quantum, quantum_op("ZZPhase", ext=HSERIES_EXTENSION))
+def _zz_phase(q1: qubit, q2: qubit, angle: float) -> None:
+    """ZZPhase operation from the hseries extension.
+
+    See `guppylang.prelude.quantum.phased_x` for a public definition that
+    accepts angle parameters.
+    """

--- a/guppylang/prelude/quantum_functional.py
+++ b/guppylang/prelude/quantum_functional.py
@@ -1,110 +1,134 @@
 """Guppy standard module for quantum operations."""
 
-# mypy: disable-error-code="empty-body, misc, valid-type"
+from typing import no_type_check
 
-import typing
-
+import guppylang.prelude.quantum as quantum
 from guppylang.decorator import guppy
-from guppylang.prelude._internal.compiler.quantum import HSERIES_EXTENSION
-from guppylang.prelude._internal.util import quantum_op
+
+# mypy: disable-error-code="empty-body, misc, valid-type"
+from guppylang.module import GuppyModule
 from guppylang.prelude.angles import angle
 from guppylang.prelude.builtins import owned
-from guppylang.prelude.quantum import quantum, qubit
+from guppylang.prelude.quantum import qubit
+
+quantum_functional = GuppyModule("quantum_functional")
+quantum_functional.load(angle, qubit, quantum)
 
 
-@guppy.hugr_op(quantum, quantum_op("H"))
-def h(q: qubit @ owned) -> qubit: ...
+@guppy(quantum_functional)
+@no_type_check
+def h(q: qubit @ owned) -> qubit:
+    quantum.h(q)
+    return q
 
 
-@guppy.hugr_op(quantum, quantum_op("CZ"))
-def cz(control: qubit @ owned, target: qubit @ owned) -> tuple[qubit, qubit]: ...
+@guppy(quantum_functional)
+@no_type_check
+def cz(control: qubit @ owned, target: qubit @ owned) -> tuple[qubit, qubit]:
+    quantum.cz(control, target)
+    return control, target
 
 
-@guppy.hugr_op(quantum, quantum_op("CX"))
-def cx(control: qubit @ owned, target: qubit @ owned) -> tuple[qubit, qubit]: ...
+@guppy(quantum_functional)
+@no_type_check
+def cx(control: qubit @ owned, target: qubit @ owned) -> tuple[qubit, qubit]:
+    quantum.cx(control, target)
+    return control, target
 
 
-@guppy.hugr_op(quantum, quantum_op("T"))
-def t(q: qubit @ owned) -> qubit: ...
+@guppy(quantum_functional)
+@no_type_check
+def t(q: qubit @ owned) -> qubit:
+    quantum.t(q)
+    return q
 
 
-@guppy.hugr_op(quantum, quantum_op("S"))
-def s(q: qubit @ owned) -> qubit: ...
+@guppy(quantum_functional)
+@no_type_check
+def s(q: qubit @ owned) -> qubit:
+    quantum.s(q)
+    return q
 
 
-@guppy.hugr_op(quantum, quantum_op("X"))
-def x(q: qubit @ owned) -> qubit: ...
+@guppy(quantum_functional)
+@no_type_check
+def x(q: qubit @ owned) -> qubit:
+    quantum.x(q)
+    return q
 
 
-@guppy.hugr_op(quantum, quantum_op("Y"))
-def y(q: qubit @ owned) -> qubit: ...
+@guppy(quantum_functional)
+@no_type_check
+def y(q: qubit @ owned) -> qubit:
+    quantum.y(q)
+    return q
 
 
-@guppy.hugr_op(quantum, quantum_op("Z"))
-def z(q: qubit @ owned) -> qubit: ...
+@guppy(quantum_functional)
+@no_type_check
+def z(q: qubit @ owned) -> qubit:
+    quantum.z(q)
+    return q
 
 
-@guppy.hugr_op(quantum, quantum_op("Tdg"))
-def tdg(q: qubit @ owned) -> qubit: ...
+@guppy(quantum_functional)
+@no_type_check
+def tdg(q: qubit @ owned) -> qubit:
+    quantum.tdg(q)
+    return q
 
 
-@guppy.hugr_op(quantum, quantum_op("Sdg"))
-def sdg(q: qubit @ owned) -> qubit: ...
+@guppy(quantum_functional)
+@no_type_check
+def sdg(q: qubit @ owned) -> qubit:
+    quantum.sdg(q)
+    return q
 
 
-@guppy.hugr_op(quantum, quantum_op("ZZMax", ext=HSERIES_EXTENSION))
-def zz_max(q1: qubit @ owned, q2: qubit @ owned) -> tuple[qubit, qubit]: ...
+@guppy(quantum_functional)
+@no_type_check
+def zz_max(q1: qubit @ owned, q2: qubit @ owned) -> tuple[qubit, qubit]:
+    quantum.zz_max(q1, q2)
+    return q1, q2
 
 
-@guppy.hugr_op(quantum, quantum_op("Rz"))
-def rz(q: qubit @ owned, angle: angle) -> qubit: ...
+@guppy(quantum_functional)
+@no_type_check
+def rz(q: qubit @ owned, angle: angle) -> qubit:
+    quantum.rz(q, angle)
+    return q
 
 
-@guppy.hugr_op(quantum, quantum_op("Rx"))
-def rx(q: qubit @ owned, angle: angle) -> qubit: ...
+@guppy(quantum_functional)
+@no_type_check
+def rx(q: qubit @ owned, angle: angle) -> qubit:
+    quantum.rx(q, angle)
+    return q
 
 
-@guppy(quantum)
-@typing.no_type_check
+@guppy(quantum_functional)
+@no_type_check
 def phased_x(q: qubit @ owned, angle1: angle, angle2: angle) -> qubit:
-    f1 = float(angle1)
-    f2 = float(angle2)
-    return _phased_x(q, f1, f2)
+    quantum.phased_x(q, angle1, angle2)
+    return q
 
 
-@guppy(quantum)
-@typing.no_type_check
+@guppy(quantum_functional)
+@no_type_check
 def zz_phase(q1: qubit @ owned, q2: qubit @ owned, angle: angle) -> tuple[qubit, qubit]:
-    f = float(angle)
-    return _zz_phase(q1, q2, f)
+    quantum.zz_phase(q1, q2, angle)
+    return q1, q2
 
 
-@guppy.hugr_op(quantum, quantum_op("Reset"))
-def reset(q: qubit @ owned) -> qubit: ...
+@guppy(quantum_functional)
+@no_type_check
+def reset(q: qubit @ owned) -> qubit:
+    quantum.reset(q)
+    return q
 
 
-# ------------------------------------------------------
-# --------- Internal definitions -----------------------
-# ------------------------------------------------------
-
-
-@guppy.hugr_op(quantum, quantum_op("PhasedX", ext=HSERIES_EXTENSION))
-def _phased_x(q: qubit @ owned, angle1: float, angle2: float) -> qubit:
-    """PhasedX operation from the hseries extension.
-
-    See `guppylang.prelude.quantum.phased_x` for a public definition that
-    accepts angle parameters.
-    """
-
-
-@guppy.hugr_op(quantum, quantum_op("ZZPhase", ext=HSERIES_EXTENSION))
-def _zz_phase(
-    q1: qubit @ owned,
-    q2: qubit @ owned,
-    angle: float,
-) -> tuple[qubit, qubit]:
-    """ZZPhase operation from the hseries extension.
-
-    See `guppylang.prelude.quantum.phased_x` for a public definition that
-    accepts angle parameters.
-    """
+@guppy(quantum_functional)
+@no_type_check
+def measure_return(q: qubit @ owned) -> tuple[qubit, bool]:
+    b = quantum.measure_return(q)
+    return q, b

--- a/tests/error/linear_errors/unused_expr.err
+++ b/tests/error/linear_errors/unused_expr.err
@@ -1,7 +1,7 @@
-Guppy compilation failed. Error in file $FILE:13
+Guppy compilation failed. Error in file $FILE:14
 
-11:    @guppy(module)
-12:    def foo(q: qubit @owned) -> None:
-13:        h(q)
+12:    @guppy(module)
+13:    def foo(q: qubit @owned) -> None:
+14:        h(q)
            ^^^^
 GuppyTypeError: Value with linear type `qubit` is not used

--- a/tests/error/linear_errors/unused_expr.py
+++ b/tests/error/linear_errors/unused_expr.py
@@ -6,6 +6,7 @@ from guppylang.prelude.quantum_functional import h
 
 module = GuppyModule("test")
 module.load_all(quantum)
+module.load(h)
 
 
 @guppy(module)

--- a/tests/error/linear_errors/while_unused.err
+++ b/tests/error/linear_errors/while_unused.err
@@ -1,7 +1,7 @@
-Guppy compilation failed. Error in file $FILE:12
+Guppy compilation failed. Error in file $FILE:13
 
-10:    @guppy(module)
-11:    def test(n: int) -> None:
-12:        q = qubit()
+11:    @guppy(module)
+12:    def test(n: int) -> None:
+13:        q = qubit()
            ^
 GuppyError: Variable `q` with linear type `qubit` is not used on all control-flow paths

--- a/tests/error/linear_errors/while_unused.py
+++ b/tests/error/linear_errors/while_unused.py
@@ -5,6 +5,7 @@ from guppylang.prelude.quantum_functional import h
 
 module = GuppyModule("test")
 module.load_all(quantum)
+module.load(h)
 
 
 @guppy(module)

--- a/tests/error/poly_errors/non_linear2.py
+++ b/tests/error/poly_errors/non_linear2.py
@@ -8,7 +8,7 @@ import guppylang.prelude.quantum as quantum
 
 module = GuppyModule("test")
 module.load_all(quantum)
-
+module.load(h)
 
 T = guppy.type_var(module, "T")
 

--- a/tests/integration/test_comprehension.py
+++ b/tests/integration/test_comprehension.py
@@ -6,7 +6,7 @@ from guppylang.prelude.builtins import linst, owned
 from guppylang.prelude.quantum import qubit
 from guppylang.prelude.quantum_functional import h, cx
 
-import guppylang.prelude.quantum as quantum
+import guppylang.prelude.quantum_functional as quantum
 from guppylang.tys.ty import NoneType
 from tests.util import compile_guppy
 
@@ -22,6 +22,7 @@ def test_basic(validate):
 def test_basic_linear(validate):
     module = GuppyModule("test")
     module.load_all(quantum)
+    module.load(qubit)
 
     @guppy(module)
     def test(qs: linst[qubit] @owned) -> linst[qubit]:
@@ -49,6 +50,7 @@ def test_multiple(validate):
 def test_multiple_struct(validate):
     module = GuppyModule("test")
     module.load_all(quantum)
+    module.load(qubit)
 
     @guppy.struct(module)
     class MyStruct:
@@ -72,6 +74,7 @@ def test_tuple_pat(validate):
 def test_tuple_pat_linear(validate):
     module = GuppyModule("test")
     module.load_all(quantum)
+    module.load(qubit)
 
     @guppy(module)
     def test(qs: linst[tuple[int, qubit, qubit]] @owned) -> linst[tuple[qubit, qubit]]:
@@ -153,6 +156,7 @@ def test_nested_right(validate):
 def test_nested_linear(validate):
     module = GuppyModule("test")
     module.load_all(quantum)
+    module.load(qubit)
 
     @guppy(module)
     def test(qs: linst[qubit] @owned) -> linst[qubit]:
@@ -164,6 +168,7 @@ def test_nested_linear(validate):
 def test_classical_linst_comp(validate):
     module = GuppyModule("test")
     module.load_all(quantum)
+    module.load(qubit)
 
     @guppy(module)
     def test(xs: list[int]) -> linst[int]:
@@ -175,6 +180,7 @@ def test_classical_linst_comp(validate):
 def test_linear_discard(validate):
     module = GuppyModule("test")
     module.load_all(quantum)
+    module.load(qubit)
 
     @guppy.declare(module)
     def discard(q: qubit @owned) -> None: ...
@@ -189,6 +195,7 @@ def test_linear_discard(validate):
 def test_linear_discard_struct(validate):
     module = GuppyModule("test")
     module.load_all(quantum)
+    module.load(qubit)
 
     @guppy.struct(module)
     class MyStruct:
@@ -208,6 +215,7 @@ def test_linear_discard_struct(validate):
 def test_linear_consume_in_guard(validate):
     module = GuppyModule("test")
     module.load_all(quantum)
+    module.load(qubit)
 
     @guppy.declare(module)
     def cond(q: qubit @owned) -> bool: ...
@@ -222,6 +230,7 @@ def test_linear_consume_in_guard(validate):
 def test_linear_consume_in_iter(validate):
     module = GuppyModule("test")
     module.load_all(quantum)
+    module.load(qubit)
 
     @guppy.declare(module)
     def make_list(q: qubit @owned) -> list[int]: ...
@@ -236,6 +245,7 @@ def test_linear_consume_in_iter(validate):
 def test_linear_next_nonlinear_iter(validate):
     module = GuppyModule("test")
     module.load_all(quantum)
+    module.load(qubit)
 
     @guppy.type(module, NoneType().to_hugr())
     class MyIter:
@@ -268,6 +278,7 @@ def test_linear_next_nonlinear_iter(validate):
 def test_nonlinear_next_linear_iter(validate):
     module = GuppyModule("test")
     module.load_all(quantum)
+    module.load(qubit)
 
     @guppy.type(
         module,

--- a/tests/integration/test_linear.py
+++ b/tests/integration/test_linear.py
@@ -1,11 +1,10 @@
 from guppylang.decorator import guppy
 from guppylang.module import GuppyModule
 from guppylang.prelude.builtins import linst, owned
-from guppylang.prelude.quantum import qubit, measure_return, measure
+from guppylang.prelude.quantum import qubit, measure
 
-import guppylang.prelude.quantum as quantum
 import guppylang.prelude.quantum_functional as quantum_functional
-from guppylang.prelude.quantum_functional import cx, t, h
+from guppylang.prelude.quantum_functional import cx, t, h, measure_return
 from guppylang.tys.ty import NoneType
 
 import pytest
@@ -13,7 +12,8 @@ import pytest
 
 def test_id(validate):
     module = GuppyModule("test")
-    module.load_all(quantum)
+    module.load_all(quantum_functional)
+    module.load(qubit)
 
     @guppy(module)
     def test(q: qubit @owned) -> qubit:
@@ -24,7 +24,8 @@ def test_id(validate):
 
 def test_assign(validate):
     module = GuppyModule("test")
-    module.load_all(quantum)
+    module.load_all(quantum_functional)
+    module.load(qubit)
 
     @guppy(module)
     def test(q: qubit @owned) -> qubit:
@@ -38,7 +39,8 @@ def test_assign(validate):
 def test_linear_return_order(validate):
     # See https://github.com/CQCL-DEV/guppy/issues/35
     module = GuppyModule("test")
-    module.load_all(quantum)
+    module.load_all(quantum_functional)
+    module.load(qubit)
 
     @guppy(module)
     def test(q: qubit @owned) -> tuple[qubit, bool]:
@@ -49,7 +51,8 @@ def test_linear_return_order(validate):
 
 def test_interleave(validate):
     module = GuppyModule("test")
-    module.load_all(quantum)
+    module.load_all(quantum_functional)
+    module.load(qubit)
 
     @guppy.declare(module)
     def f(q1: qubit @owned, q2: qubit @owned) -> tuple[qubit, qubit]: ...
@@ -71,7 +74,8 @@ def test_interleave(validate):
 
 def test_linear_struct(validate):
     module = GuppyModule("test")
-    module.load_all(quantum)
+    module.load_all(quantum_functional)
+    module.load(qubit)
 
     @guppy.struct(module)
     class MyStruct:
@@ -100,7 +104,8 @@ def test_linear_struct(validate):
 
 def test_mixed_classical_linear_struct(validate):
     module = GuppyModule("test")
-    module.load_all(quantum)
+    module.load_all(quantum_functional)
+    module.load(qubit)
 
     @guppy.struct(module)
     class MyStruct:
@@ -129,7 +134,8 @@ def test_mixed_classical_linear_struct(validate):
 
 def test_drop_classical_field(validate):
     module = GuppyModule("test")
-    module.load_all(quantum)
+    module.load_all(quantum_functional)
+    module.load(qubit)
 
     @guppy.struct(module)
     class MyStruct:
@@ -146,7 +152,8 @@ def test_drop_classical_field(validate):
 
 def test_if(validate):
     module = GuppyModule("test")
-    module.load_all(quantum)
+    module.load_all(quantum_functional)
+    module.load(qubit)
 
     @guppy(module)
     def test(b: bool) -> qubit:
@@ -162,7 +169,8 @@ def test_if(validate):
 
 def test_if_return(validate):
     module = GuppyModule("test")
-    module.load_all(quantum)
+    module.load_all(quantum_functional)
+    module.load(qubit)
 
     @guppy(module)
     def test(b: bool) -> qubit:
@@ -178,7 +186,8 @@ def test_if_return(validate):
 
 def test_if_struct_rebuild(validate):
     module = GuppyModule("test")
-    module.load_all(quantum)
+    module.load_all(quantum_functional)
+    module.load(qubit)
 
     @guppy.struct(module)
     class MyStruct:
@@ -201,7 +210,8 @@ def test_if_struct_rebuild(validate):
 
 def test_struct_reassign(validate):
     module = GuppyModule("test")
-    module.load_all(quantum)
+    module.load_all(quantum_functional)
+    module.load(qubit)
 
     @guppy.struct(module)
     class MyStruct1:
@@ -227,7 +237,8 @@ def test_struct_reassign(validate):
 
 def test_struct_reassign2(validate):
     module = GuppyModule("test")
-    module.load_all(quantum)
+    module.load_all(quantum_functional)
+    module.load(qubit)
 
     @guppy.struct(module)
     class MyStruct:
@@ -250,7 +261,8 @@ def test_struct_reassign2(validate):
 
 def test_measure(validate):
     module = GuppyModule("test")
-    module.load_all(quantum)
+    module.load_all(quantum_functional)
+    module.load(qubit, measure)
 
     @guppy(module)
     def test(q: qubit @owned, x: int) -> int:
@@ -262,7 +274,8 @@ def test_measure(validate):
 
 def test_return_call(validate):
     module = GuppyModule("test")
-    module.load_all(quantum)
+    module.load_all(quantum_functional)
+    module.load(qubit)
 
     @guppy.declare(module)
     def op(q: qubit @owned) -> qubit: ...
@@ -276,7 +289,8 @@ def test_return_call(validate):
 
 def test_while(validate):
     module = GuppyModule("test")
-    module.load_all(quantum)
+    module.load_all(quantum_functional)
+    module.load(qubit)
 
     @guppy(module)
     def test(q: qubit @owned, i: int) -> qubit:
@@ -290,7 +304,8 @@ def test_while(validate):
 
 def test_while_break(validate):
     module = GuppyModule("test")
-    module.load_all(quantum)
+    module.load_all(quantum_functional)
+    module.load(qubit)
 
     @guppy(module)
     def test(q: qubit @owned, i: int) -> qubit:
@@ -306,7 +321,8 @@ def test_while_break(validate):
 
 def test_while_continue(validate):
     module = GuppyModule("test")
-    module.load_all(quantum)
+    module.load_all(quantum_functional)
+    module.load(qubit)
 
     @guppy(module)
     def test(q: qubit @owned, i: int) -> qubit:
@@ -322,7 +338,8 @@ def test_while_continue(validate):
 
 def test_while_reset(validate):
     module = GuppyModule("test")
-    module.load_all(quantum)
+    module.load_all(quantum_functional)
+    module.load(qubit)
 
     @guppy(module)
     def foo(i: bool) -> bool:
@@ -338,7 +355,8 @@ def test_while_reset(validate):
 
 def test_while_move_back(validate):
     module = GuppyModule("test")
-    module.load_all(quantum)
+    module.load_all(quantum_functional)
+    module.load(qubit)
 
     @guppy.struct(module)
     class MyStruct:
@@ -362,7 +380,8 @@ def test_while_move_back(validate):
 
 def test_for(validate):
     module = GuppyModule("test")
-    module.load_all(quantum)
+    module.load_all(quantum_functional)
+    module.load(qubit)
 
     @guppy(module)
     def test(qs: linst[tuple[qubit, qubit]] @owned) -> linst[qubit]:
@@ -377,7 +396,8 @@ def test_for(validate):
 
 def test_for_measure(validate):
     module = GuppyModule("test")
-    module.load_all(quantum)
+    module.load_all(quantum_functional)
+    module.load(qubit, measure)
 
     @guppy(module)
     def test(qs: linst[qubit] @owned) -> bool:
@@ -391,7 +411,8 @@ def test_for_measure(validate):
 
 def test_for_continue(validate):
     module = GuppyModule("test")
-    module.load_all(quantum)
+    module.load_all(quantum_functional)
+    module.load(qubit, measure)
 
     @guppy(module)
     def test(qs: linst[qubit] @owned) -> int:
@@ -407,7 +428,8 @@ def test_for_continue(validate):
 
 def test_for_nonlinear_break(validate):
     module = GuppyModule("test")
-    module.load_all(quantum)
+    module.load_all(quantum_functional)
+    module.load(qubit)
 
     @guppy.type(module, NoneType().to_hugr())
     class MyIter:
@@ -444,7 +466,8 @@ def test_for_nonlinear_break(validate):
 
 def test_rus(validate):
     module = GuppyModule("test")
-    module.load_all(quantum)
+    module.load_all(quantum_functional)
+    module.load(qubit, measure)
 
     @guppy(module)
     def repeat_until_success(q: qubit @owned) -> qubit:
@@ -459,7 +482,8 @@ def test_rus(validate):
 
 def test_linst_iter_arg(validate):
     module = GuppyModule("test")
-    module.load_all(quantum)
+    module.load_all(quantum_functional)
+    module.load(qubit)
 
     @guppy(module)
     def owned_arg(qs: linst[qubit] @owned) -> linst[qubit]:
@@ -470,7 +494,8 @@ def test_linst_iter_arg(validate):
 
 def test_linst_iter(validate):
     module = GuppyModule("test")
-    module.load_all(quantum)
+    module.load_all(quantum_functional)
+    module.load(qubit)
 
     @guppy(module)
     def owned_arg() -> linst[qubit]:

--- a/tests/integration/test_linst.py
+++ b/tests/integration/test_linst.py
@@ -4,12 +4,13 @@ from guppylang.prelude.builtins import linst, owned
 from guppylang.prelude.quantum import qubit
 from guppylang.prelude.quantum_functional import h
 
-import guppylang.prelude.quantum as quantum
+import guppylang.prelude.quantum_functional as quantum_functional
 
 
 def test_types(validate):
     module = GuppyModule("test")
-    module.load_all(quantum)
+    module.load_all(quantum_functional)
+    module.load(qubit)
 
     @guppy(module)
     def test(
@@ -22,7 +23,8 @@ def test_types(validate):
 
 def test_len(validate):
     module = GuppyModule("test")
-    module.load_all(quantum)
+    module.load_all(quantum_functional)
+    module.load(qubit)
 
     @guppy(module)
     def test(xs: linst[qubit] @owned) -> tuple[int, linst[qubit]]:
@@ -33,7 +35,8 @@ def test_len(validate):
 
 def test_literal(validate):
     module = GuppyModule("test")
-    module.load_all(quantum)
+    module.load_all(quantum_functional)
+    module.load(qubit)
 
     @guppy(module)
     def test(q1: qubit @owned, q2: qubit @owned) -> linst[qubit]:
@@ -44,7 +47,8 @@ def test_literal(validate):
 
 def test_arith(validate):
     module = GuppyModule("test")
-    module.load_all(quantum)
+    module.load_all(quantum_functional)
+    module.load(qubit)
 
     @guppy(module)
     def test(xs: linst[qubit] @owned, ys: linst[qubit] @owned, q: qubit @owned) -> linst[qubit]:
@@ -56,7 +60,6 @@ def test_arith(validate):
 
 def test_copyable(validate):
     module = GuppyModule("test")
-    module.load_all(quantum)
 
     @guppy(module)
     def test() -> linst[int]:

--- a/tests/integration/test_qalloc.py
+++ b/tests/integration/test_qalloc.py
@@ -2,13 +2,16 @@ from guppylang.decorator import guppy
 from guppylang.module import GuppyModule
 from guppylang.prelude.quantum import qubit
 
-from guppylang.prelude.quantum import dirty_qubit, quantum, measure
+from guppylang.prelude.quantum import dirty_qubit, measure
 from guppylang.prelude.quantum_functional import cx
+
+import guppylang.prelude.quantum_functional as quantum_functional
 
 
 def test_dirty_qubit(validate):
     module = GuppyModule("test")
-    module.load_all(quantum)
+    module.load_all(quantum_functional)
+    module.load(qubit, dirty_qubit, measure)
 
     @guppy(module)
     def test() -> tuple[bool, bool]:

--- a/tests/integration/test_quantum.py
+++ b/tests/integration/test_quantum.py
@@ -13,9 +13,7 @@ from guppylang.prelude.builtins import owned, py
 from guppylang.prelude.quantum import (
     dirty_qubit,
     discard,
-    quantum,
     measure,
-    measure_return,
     qubit
 )
 from guppylang.prelude.quantum_functional import (
@@ -35,6 +33,8 @@ from guppylang.prelude.quantum_functional import (
     rz,
     zz_phase,
     reset,
+    quantum_functional,
+    measure_return,
 )
 
 
@@ -49,8 +49,8 @@ def compile_quantum_guppy(fn) -> Package:
     ), "`@compile_quantum_guppy` does not support extra arguments."
 
     module = GuppyModule("module")
-    module.load(angle)
-    module.load_all(quantum)
+    module.load(angle, qubit, dirty_qubit, discard, measure)
+    module.load_all(quantum_functional)
     guppylang.decorator.guppy(module)(fn)
     return module.compile()
 


### PR DESCRIPTION
Closes #378 and closes #465.

BREAKING CHANGE: `quantum_functional` is now its own module and no longer implicitly comes with `quantum`.