### PR TITLE
fix: Fix redefinition of structs

### DIFF
--- a/guppylang/module.py
+++ b/guppylang/module.py
@@ -295,6 +295,7 @@ class GuppyModule:
                 for method_def in defn.generated_methods():
                     generated[method_def.id] = method_def
                     self._globals.impls[defn.id][method_def.name] = method_def.id
+        self._globals.defs.update(generated)
 
         # Now, we can check all other definitions
         other_defs = self._check_defs(

--- a/tests/integration/test_redefinition.py
+++ b/tests/integration/test_redefinition.py
@@ -36,6 +36,33 @@ def test_method_redefinition(validate):
     validate(module.compile())
 
 
+def test_redefine_after_error(validate):
+    module = GuppyModule("test")
+
+    @guppy.struct(module)
+    class Foo:
+        x: int
+
+    @guppy(module)
+    def foo() -> int:
+        return y
+
+    try:
+        module.compile()
+    except:
+        pass
+
+    @guppy.struct(module)
+    class Foo:
+        x: int
+
+    @guppy(module)
+    def foo(f: Foo) -> int:
+        return f.x
+
+    validate(module.compile())
+
+
 @pytest.mark.skip("See https://github.com/CQCL/guppylang/issues/456")
 def test_struct_redefinition(validate):
     module = GuppyModule("test")


### PR DESCRIPTION
Closes #498.

The problem was that the autogenerated `__new__` method of structs wasn't added to `globals.defs`, yielding a `KeyError` when trying to unregister it before overriding.