### PR TITLE
feat!: Hide lists and function tensors behind experimental flag

### DIFF
--- a/guppylang/__init__.py
+++ b/guppylang/__init__.py
@@ -1,4 +1,5 @@
 from guppylang.decorator import guppy
+from guppylang.experimental import enable_experimental_features
 from guppylang.module import GuppyModule
 from guppylang.prelude import builtins, quantum
 from guppylang.prelude.builtins import Bool, Float, Int, List, linst, py

--- a/guppylang/cfg/builder.py
+++ b/guppylang/cfg/builder.py
@@ -26,6 +26,7 @@ from guppylang.nodes import (
     NestedFunctionDef,
     PyExpr,
 )
+from guppylang.tys.builtin import check_lists_enabled
 from guppylang.tys.ty import NoneType
 
 # In order to build expressions, need an endless stream of unique temporary variables
@@ -304,6 +305,7 @@ class ExprBuilder(ast.NodeTransformer):
         return make_var(tmp, node)
 
     def visit_ListComp(self, node: ast.ListComp) -> ast.AST:
+        check_lists_enabled(node)
         # Check for illegal expressions
         illegals = find_nodes(is_illegal_in_list_comp, node)
         if illegals:

--- a/guppylang/cfg/builder.py
+++ b/guppylang/cfg/builder.py
@@ -16,6 +16,7 @@ from guppylang.cfg.bb import BB, BBStatement
 from guppylang.cfg.cfg import CFG
 from guppylang.checker.core import Globals
 from guppylang.error import GuppyError, InternalGuppyError
+from guppylang.experimental import check_lists_enabled
 from guppylang.nodes import (
     DesugaredGenerator,
     DesugaredListComp,
@@ -26,7 +27,6 @@ from guppylang.nodes import (
     NestedFunctionDef,
     PyExpr,
 )
-from guppylang.tys.builtin import check_lists_enabled
 from guppylang.tys.ty import NoneType
 
 # In order to build expressions, need an endless stream of unique temporary variables

--- a/guppylang/checker/expr_checker.py
+++ b/guppylang/checker/expr_checker.py
@@ -27,6 +27,7 @@ from contextlib import suppress
 from dataclasses import replace
 from typing import Any, NoReturn, cast
 
+import guppylang
 from guppylang.ast_util import (
     AstNode,
     AstVisitor,
@@ -78,6 +79,7 @@ from guppylang.nodes import (
 from guppylang.tys.arg import TypeArg
 from guppylang.tys.builtin import (
     bool_type,
+    check_lists_enabled,
     get_element_type,
     is_bool_type,
     is_linst_type,
@@ -214,6 +216,7 @@ class ExprChecker(AstVisitor[tuple[ast.expr, Subst]]):
         return node, subst
 
     def visit_List(self, node: ast.List, ty: Type) -> tuple[ast.expr, Subst]:
+        check_lists_enabled(node)
         if not is_list_type(ty) and not is_linst_type(ty):
             return self._fail(ty, node)
         el_ty = get_element_type(ty)
@@ -265,6 +268,7 @@ class ExprChecker(AstVisitor[tuple[ast.expr, Subst]]):
         if isinstance(func_ty, TupleType) and (
             function_elements := parse_function_tensor(func_ty)
         ):
+            check_function_tensors_enabled(node.func)
             if any(f.parametrized for f in function_elements):
                 raise GuppyTypeError(
                     "Polymorphic functions in tuples are not supported", node.func
@@ -435,6 +439,7 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
         return node, TupleType([ty for _, ty in elems])
 
     def visit_List(self, node: ast.List) -> tuple[ast.expr, Type]:
+        check_lists_enabled(node)
         if len(node.elts) == 0:
             raise GuppyTypeInferenceError(
                 "Cannot infer type variable in expression of type `list[?T]`", node
@@ -602,6 +607,7 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
         elif isinstance(ty, TupleType) and (
             function_elems := parse_function_tensor(ty)
         ):
+            check_function_tensors_enabled(node.func)
             if any(f.parametrized for f in function_elems):
                 raise GuppyTypeError(
                     "Polymorphic functions in tuples are not supported", node.func
@@ -988,6 +994,15 @@ def instantiate_poly(node: ast.expr, ty: FunctionType, inst: Inst) -> ast.expr:
         node = with_loc(node, TypeApply(value=with_type(ty, node), inst=inst))
         return with_type(ty.instantiate(inst), node)
     return with_type(ty, node)
+
+
+def check_function_tensors_enabled(node: ast.expr | None = None) -> None:
+    if not guppylang.experimental.EXPERIMENTAL_FEATURES_ENABLED:
+        raise GuppyError(
+            "Function tensors are an experimental feature. Call "
+            "`guppylang.enable_experimental_features()` to enable them.",
+            node,
+        )
 
 
 def to_bool(node: ast.expr, node_ty: Type, ctx: Context) -> tuple[ast.expr, Type]:

--- a/guppylang/checker/expr_checker.py
+++ b/guppylang/checker/expr_checker.py
@@ -27,7 +27,6 @@ from contextlib import suppress
 from dataclasses import replace
 from typing import Any, NoReturn, cast
 
-import guppylang
 from guppylang.ast_util import (
     AstNode,
     AstVisitor,
@@ -58,6 +57,7 @@ from guppylang.error import (
     GuppyTypeInferenceError,
     InternalGuppyError,
 )
+from guppylang.experimental import check_function_tensors_enabled, check_lists_enabled
 from guppylang.nodes import (
     DesugaredGenerator,
     DesugaredListComp,
@@ -79,7 +79,6 @@ from guppylang.nodes import (
 from guppylang.tys.arg import TypeArg
 from guppylang.tys.builtin import (
     bool_type,
-    check_lists_enabled,
     get_element_type,
     is_bool_type,
     is_linst_type,
@@ -994,15 +993,6 @@ def instantiate_poly(node: ast.expr, ty: FunctionType, inst: Inst) -> ast.expr:
         node = with_loc(node, TypeApply(value=with_type(ty, node), inst=inst))
         return with_type(ty.instantiate(inst), node)
     return with_type(ty, node)
-
-
-def check_function_tensors_enabled(node: ast.expr | None = None) -> None:
-    if not guppylang.experimental.EXPERIMENTAL_FEATURES_ENABLED:
-        raise GuppyError(
-            "Function tensors are an experimental feature. Use "
-            "`guppylang.enable_experimental_features()` to enable them.",
-            node,
-        )
 
 
 def to_bool(node: ast.expr, node_ty: Type, ctx: Context) -> tuple[ast.expr, Type]:

--- a/guppylang/checker/expr_checker.py
+++ b/guppylang/checker/expr_checker.py
@@ -999,7 +999,7 @@ def instantiate_poly(node: ast.expr, ty: FunctionType, inst: Inst) -> ast.expr:
 def check_function_tensors_enabled(node: ast.expr | None = None) -> None:
     if not guppylang.experimental.EXPERIMENTAL_FEATURES_ENABLED:
         raise GuppyError(
-            "Function tensors are an experimental feature. Call "
+            "Function tensors are an experimental feature. Use "
             "`guppylang.enable_experimental_features()` to enable them.",
             node,
         )

--- a/guppylang/experimental.py
+++ b/guppylang/experimental.py
@@ -1,4 +1,8 @@
+from ast import expr
 from types import TracebackType
+
+from guppylang.ast_util import AstNode
+from guppylang.error import GuppyError
 
 EXPERIMENTAL_FEATURES_ENABLED = False
 
@@ -49,3 +53,21 @@ class disable_experimental_features:
     ) -> None:
         global EXPERIMENTAL_FEATURES_ENABLED
         EXPERIMENTAL_FEATURES_ENABLED = self.original
+
+
+def check_function_tensors_enabled(node: expr | None = None) -> None:
+    if not EXPERIMENTAL_FEATURES_ENABLED:
+        raise GuppyError(
+            "Function tensors are an experimental feature. Use "
+            "`guppylang.enable_experimental_features()` to enable them.",
+            node,
+        )
+
+
+def check_lists_enabled(loc: AstNode | None = None) -> None:
+    if not EXPERIMENTAL_FEATURES_ENABLED:
+        raise GuppyError(
+            "Lists are an experimental feature and not fully supported yet. Use "
+            "`guppylang.enable_experimental_features()` to enable them.",
+            loc,
+        )

--- a/guppylang/experimental.py
+++ b/guppylang/experimental.py
@@ -1,0 +1,51 @@
+from types import TracebackType
+
+EXPERIMENTAL_FEATURES_ENABLED = False
+
+
+class enable_experimental_features:
+    """Enables experimental Guppy features.
+
+    Can be used as a context manager to enable experimental features in a `with` block.
+    """
+
+    def __init__(self) -> None:
+        global EXPERIMENTAL_FEATURES_ENABLED
+        self.original = EXPERIMENTAL_FEATURES_ENABLED
+        EXPERIMENTAL_FEATURES_ENABLED = True
+
+    def __enter__(self) -> None:
+        pass
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        global EXPERIMENTAL_FEATURES_ENABLED
+        EXPERIMENTAL_FEATURES_ENABLED = self.original
+
+
+class disable_experimental_features:
+    """Disables experimental Guppy features.
+
+    Can be used as a context manager to enable experimental features in a `with` block.
+    """
+
+    def __init__(self) -> None:
+        global EXPERIMENTAL_FEATURES_ENABLED
+        self.original = EXPERIMENTAL_FEATURES_ENABLED
+        EXPERIMENTAL_FEATURES_ENABLED = False
+
+    def __enter__(self) -> None:
+        pass
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        global EXPERIMENTAL_FEATURES_ENABLED
+        EXPERIMENTAL_FEATURES_ENABLED = self.original

--- a/guppylang/module.py
+++ b/guppylang/module.py
@@ -28,6 +28,7 @@ from guppylang.definition.parameter import ParamDef
 from guppylang.definition.struct import CheckedStructDef
 from guppylang.definition.ty import TypeDef
 from guppylang.error import GuppyError, pretty_errors
+from guppylang.experimental import enable_experimental_features
 
 PyFunc = Callable[..., Any]
 PyFuncDefOrDecl = tuple[bool, PyFunc]
@@ -88,7 +89,9 @@ class GuppyModule:
         if import_builtins:
             import guppylang.prelude.builtins as builtins
 
-            self.load_all(builtins)
+            # Std lib is allowed to use experimental features
+            with enable_experimental_features():
+                self.load_all(builtins)
 
     def load(
         self,

--- a/guppylang/tys/builtin.py
+++ b/guppylang/tys/builtin.py
@@ -138,7 +138,7 @@ class _LinstTypeDef(OpaqueTypeDef):
 def check_lists_enabled(loc: AstNode | None = None) -> None:
     if not guppylang.experimental.EXPERIMENTAL_FEATURES_ENABLED:
         raise GuppyError(
-            "Lists are an experimental feature and not fully supported yet. Call "
+            "Lists are an experimental feature and not fully supported yet. Use "
             "`guppylang.enable_experimental_features()` to enable them.",
             loc,
         )

--- a/guppylang/tys/builtin.py
+++ b/guppylang/tys/builtin.py
@@ -6,11 +6,11 @@ import hugr.std
 import hugr.std.collections
 from hugr import tys as ht
 
-import guppylang
 from guppylang.ast_util import AstNode
 from guppylang.definition.common import DefId
 from guppylang.definition.ty import OpaqueTypeDef, TypeDef
 from guppylang.error import GuppyError, InternalGuppyError
+from guppylang.experimental import check_lists_enabled
 from guppylang.tys.arg import Argument, ConstArg, TypeArg
 from guppylang.tys.const import ConstValue
 from guppylang.tys.param import ConstParam, TypeParam
@@ -133,15 +133,6 @@ class _LinstTypeDef(OpaqueTypeDef):
     ) -> OpaqueType:
         check_lists_enabled(loc)
         return super().check_instantiate(args, globals, loc)
-
-
-def check_lists_enabled(loc: AstNode | None = None) -> None:
-    if not guppylang.experimental.EXPERIMENTAL_FEATURES_ENABLED:
-        raise GuppyError(
-            "Lists are an experimental feature and not fully supported yet. Use "
-            "`guppylang.enable_experimental_features()` to enable them.",
-            loc,
-        )
 
 
 def _list_to_hugr(args: Sequence[Argument]) -> ht.Type:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,10 @@
 import argparse
 from pathlib import Path
 
+import guppylang
+
+guppylang.enable_experimental_features()
+
 
 def pytest_addoption(parser):
     def dir_path(s):

--- a/tests/error/experimental_errors/function_tensor.err
+++ b/tests/error/experimental_errors/function_tensor.err
@@ -1,0 +1,7 @@
+Guppy compilation failed. Error in file $FILE:19
+
+17:    @guppy(module)
+18:    def main() -> tuple[int, int]:
+19:        return (f, g)(1, 2)
+                  ^^^^^^
+GuppyError: Function tensors are an experimental feature. Call `guppylang.enable_experimental_features()` to enable them.

--- a/tests/error/experimental_errors/function_tensor.err
+++ b/tests/error/experimental_errors/function_tensor.err
@@ -4,4 +4,4 @@ Guppy compilation failed. Error in file $FILE:19
 18:    def main() -> tuple[int, int]:
 19:        return (f, g)(1, 2)
                   ^^^^^^
-GuppyError: Function tensors are an experimental feature. Call `guppylang.enable_experimental_features()` to enable them.
+GuppyError: Function tensors are an experimental feature. Use `guppylang.enable_experimental_features()` to enable them.

--- a/tests/error/experimental_errors/function_tensor.py
+++ b/tests/error/experimental_errors/function_tensor.py
@@ -1,0 +1,22 @@
+from guppylang.decorator import guppy
+from guppylang.module import GuppyModule
+
+module = GuppyModule("test")
+
+
+@guppy(module)
+def f(x: int) -> int:
+    return x
+
+
+@guppy(module)
+def g(x: int) -> int:
+    return x
+
+
+@guppy(module)
+def main() -> tuple[int, int]:
+    return (f, g)(1, 2)
+
+
+module.compile()

--- a/tests/error/experimental_errors/linst_type.err
+++ b/tests/error/experimental_errors/linst_type.err
@@ -1,0 +1,6 @@
+Guppy compilation failed. Error in file $FILE:9
+
+7:    @guppy(module)
+8:    def main(x: linst[int]) -> linst[int]:
+                  ^^^^^^^^^^
+GuppyError: Lists are an experimental feature and not fully supported yet. Call `guppylang.enable_experimental_features()` to enable them.

--- a/tests/error/experimental_errors/linst_type.err
+++ b/tests/error/experimental_errors/linst_type.err
@@ -3,4 +3,4 @@ Guppy compilation failed. Error in file $FILE:9
 7:    @guppy(module)
 8:    def main(x: linst[int]) -> linst[int]:
                   ^^^^^^^^^^
-GuppyError: Lists are an experimental feature and not fully supported yet. Call `guppylang.enable_experimental_features()` to enable them.
+GuppyError: Lists are an experimental feature and not fully supported yet. Use `guppylang.enable_experimental_features()` to enable them.

--- a/tests/error/experimental_errors/linst_type.py
+++ b/tests/error/experimental_errors/linst_type.py
@@ -1,0 +1,13 @@
+from guppylang.decorator import guppy
+from guppylang.prelude.builtins import linst
+from guppylang.module import GuppyModule
+
+module = GuppyModule("test")
+
+
+@guppy(module)
+def main(x: linst[int]) -> linst[int]:
+    return x
+
+
+module.compile()

--- a/tests/error/experimental_errors/list_comprehension.err
+++ b/tests/error/experimental_errors/list_comprehension.err
@@ -4,4 +4,4 @@ Guppy compilation failed. Error in file $FILE:9
 8:    def main() -> None:
 9:        [i for i in range(10)]
           ^^^^^^^^^^^^^^^^^^^^^^
-GuppyError: Lists are an experimental feature and not fully supported yet. Call `guppylang.enable_experimental_features()` to enable them.
+GuppyError: Lists are an experimental feature and not fully supported yet. Use `guppylang.enable_experimental_features()` to enable them.

--- a/tests/error/experimental_errors/list_comprehension.err
+++ b/tests/error/experimental_errors/list_comprehension.err
@@ -1,0 +1,7 @@
+Guppy compilation failed. Error in file $FILE:9
+
+7:    @guppy(module)
+8:    def main() -> None:
+9:        [i for i in range(10)]
+          ^^^^^^^^^^^^^^^^^^^^^^
+GuppyError: Lists are an experimental feature and not fully supported yet. Call `guppylang.enable_experimental_features()` to enable them.

--- a/tests/error/experimental_errors/list_comprehension.py
+++ b/tests/error/experimental_errors/list_comprehension.py
@@ -1,0 +1,12 @@
+from guppylang.decorator import guppy
+from guppylang.module import GuppyModule
+
+module = GuppyModule("test")
+
+
+@guppy(module)
+def main() -> None:
+    [i for i in range(10)]
+
+
+module.compile()

--- a/tests/error/experimental_errors/list_literal.err
+++ b/tests/error/experimental_errors/list_literal.err
@@ -4,4 +4,4 @@ Guppy compilation failed. Error in file $FILE:9
 8:    def main() -> None:
 9:        [1, 2, 3]
           ^^^^^^^^^
-GuppyError: Lists are an experimental feature and not fully supported yet. Call `guppylang.enable_experimental_features()` to enable them.
+GuppyError: Lists are an experimental feature and not fully supported yet. Use `guppylang.enable_experimental_features()` to enable them.

--- a/tests/error/experimental_errors/list_literal.err
+++ b/tests/error/experimental_errors/list_literal.err
@@ -1,0 +1,7 @@
+Guppy compilation failed. Error in file $FILE:9
+
+7:    @guppy(module)
+8:    def main() -> None:
+9:        [1, 2, 3]
+          ^^^^^^^^^
+GuppyError: Lists are an experimental feature and not fully supported yet. Call `guppylang.enable_experimental_features()` to enable them.

--- a/tests/error/experimental_errors/list_literal.py
+++ b/tests/error/experimental_errors/list_literal.py
@@ -1,0 +1,12 @@
+from guppylang.decorator import guppy
+from guppylang.module import GuppyModule
+
+module = GuppyModule("test")
+
+
+@guppy(module)
+def main() -> None:
+    [1, 2, 3]
+
+
+module.compile()

--- a/tests/error/experimental_errors/list_type.err
+++ b/tests/error/experimental_errors/list_type.err
@@ -1,0 +1,6 @@
+Guppy compilation failed. Error in file $FILE:8
+
+6:    @guppy(module)
+7:    def main(x: list[int]) -> list[int]:
+                  ^^^^^^^^^
+GuppyError: Lists are an experimental feature and not fully supported yet. Call `guppylang.enable_experimental_features()` to enable them.

--- a/tests/error/experimental_errors/list_type.err
+++ b/tests/error/experimental_errors/list_type.err
@@ -3,4 +3,4 @@ Guppy compilation failed. Error in file $FILE:8
 6:    @guppy(module)
 7:    def main(x: list[int]) -> list[int]:
                   ^^^^^^^^^
-GuppyError: Lists are an experimental feature and not fully supported yet. Call `guppylang.enable_experimental_features()` to enable them.
+GuppyError: Lists are an experimental feature and not fully supported yet. Use `guppylang.enable_experimental_features()` to enable them.

--- a/tests/error/experimental_errors/list_type.py
+++ b/tests/error/experimental_errors/list_type.py
@@ -1,0 +1,12 @@
+from guppylang.decorator import guppy
+from guppylang.module import GuppyModule
+
+module = GuppyModule("test")
+
+
+@guppy(module)
+def main(x: list[int]) -> list[int]:
+    return x
+
+
+module.compile()

--- a/tests/error/test_experimental_errors.py
+++ b/tests/error/test_experimental_errors.py
@@ -1,0 +1,21 @@
+import pathlib
+import pytest
+
+from guppylang.experimental import disable_experimental_features
+from tests.error.util import run_error_test
+
+path = pathlib.Path(__file__).parent.resolve() / "experimental_errors"
+files = [
+    x
+    for x in path.iterdir()
+    if x.is_file() and x.suffix == ".py" and x.name != "__init__.py"
+]
+
+# Turn paths into strings, otherwise pytest doesn't display the names
+files = [str(f) for f in files]
+
+
+@pytest.mark.parametrize("file", files)
+def test_experimental_errors(file, capsys):
+    with disable_experimental_features():
+        run_error_test(file, capsys)


### PR DESCRIPTION
Closes #437.

BREAKING CHANGE: Lists and function tensors are no longer available by default. `guppylang.enable_experimental_features()` must be called before compilation to enable them.