### PR TITLE
test: rfc: refactor: run_float_fn -> run_float_fn_approx

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -89,11 +89,26 @@ def _run_fn(run_fn_name: str):
     return f
 
 
-
 @pytest.fixture
 def run_int_fn():
     return _run_fn("run_int_function")
 
+
 @pytest.fixture
-def run_float_fn():
-    return _run_fn("run_float_function")
+def run_float_fn_approx():
+    """Like run_int_fn, but takes optional additional parameters `rel`, `abs` and `nan_ok`
+    as per `pytest.approx`."""
+    run_fn = _run_fn("run_float_function")
+
+    def run_approx(
+        hugr: Package,
+        expected: float,
+        fn_name: str = "main",
+        *,
+        rel: float | None = None,
+        abs: float | None = None,
+        nan_ok: bool = False,
+    ):
+        return run_fn(hugr, pytest.approx(expected, rel=rel, abs=abs, nan_ok=nan_ok))
+
+    return run_approx

--- a/tests/integration/test_arithmetic.py
+++ b/tests/integration/test_arithmetic.py
@@ -232,7 +232,7 @@ def test_supported_ops(validate, run_int_fn):
     run_int_fn(hugr, expected=2, fn_name="run_rem")
 
 
-def test_angle_exec(validate, run_float_fn):
+def test_angle_exec(validate, run_float_fn_approx):
     module = GuppyModule("test_angle_exec")
     module.load_all(angles)
 
@@ -247,4 +247,4 @@ def test_angle_exec(validate, run_float_fn):
     hugr = module.compile()
     validate(hugr)
     import math
-    run_float_fn(hugr, expected=pytest.approx(-6 * math.pi))
+    run_float_fn_approx(hugr, expected=-6 * math.pi)


### PR DESCRIPTION
Uses `pytest.approx`, see https://docs.pytest.org/en/stable/reference/reference.html#pytest-approx, with optional configurable `rel` and `abs`.