### PR TITLE
feat: Allow py expressions in type arguments

### DIFF
--- a/guppylang/checker/core.py
+++ b/guppylang/checker/core.py
@@ -270,6 +270,11 @@ class Globals:
                 return defn
         return None
 
+    def with_python_scope(self, python_scope: PyScope) -> "Globals":
+        return Globals(
+            self.defs, self.names, self.impls, self.python_scope | python_scope
+        )
+
     def __or__(self, other: "Globals") -> "Globals":
         impls = {
             def_id: self.impls.get(def_id, {}) | other.impls.get(def_id, {})

--- a/guppylang/definition/function.py
+++ b/guppylang/definition/function.py
@@ -56,7 +56,7 @@ class RawFunctionDef(ParsableDef):
     def parse(self, globals: Globals) -> "ParsedFunctionDef":
         """Parses and checks the user-provided signature of the function."""
         func_ast, docstring = parse_py_func(self.python_func)
-        ty = check_signature(func_ast, globals)
+        ty = check_signature(func_ast, globals.with_python_scope(self.python_scope))
         if ty.parametrized:
             raise GuppyError(
                 "Generic function definitions are not supported yet", func_ast
@@ -92,7 +92,7 @@ class ParsedFunctionDef(CheckableDef, CallableDef):
     def check(self, globals: Globals) -> "CheckedFunctionDef":
         """Type checks the body of the function."""
         # Add python variable scope to the globals
-        globals = globals | Globals({}, {}, {}, self.python_scope)
+        globals = globals.with_python_scope(self.python_scope)
         cfg = check_global_func_def(self.defined_at, self.ty, globals)
         return CheckedFunctionDef(
             self.id,

--- a/guppylang/prelude/builtins.py
+++ b/guppylang/prelude/builtins.py
@@ -8,7 +8,6 @@ import hugr.std.int
 
 from guppylang.decorator import guppy
 from guppylang.definition.custom import DefaultCallChecker, NoopCompiler
-from guppylang.error import GuppyError
 from guppylang.prelude._internal.checker import (
     ArrayLenChecker,
     CallableChecker,
@@ -57,13 +56,12 @@ T = guppy.type_var("T")
 L = guppy.type_var("L", linear=True)
 
 
-def py(*_args: Any) -> Any:
+def py(*args: Any) -> Any:
     """Function to tag compile-time evaluated Python expressions in a Guppy context.
 
-    This function throws an error when execute in a Python context. It is only intended
-    to be used inside Guppy functions.
+    This function acts like the identity when execute in a Python context.
     """
-    raise GuppyError("`py` can only by used in a Guppy context")
+    return tuple(args)
 
 
 class _Owned:

--- a/tests/error/py_errors/invalid_type_arg.err
+++ b/tests/error/py_errors/invalid_type_arg.err
@@ -1,0 +1,6 @@
+Guppy compilation failed. Error in file $FILE:7
+
+5:    @compile_guppy
+6:    def foo(xs: array[int, py(1.0)]) -> None:
+                             ^^^^^^^
+GuppyError: Compile-time `py(...)` expression with type `<class 'float'>` is not a valid type argument

--- a/tests/error/py_errors/invalid_type_arg.py
+++ b/tests/error/py_errors/invalid_type_arg.py
@@ -1,0 +1,8 @@
+from guppylang import py
+from guppylang.prelude.builtins import array
+from tests.util import compile_guppy
+
+
+@compile_guppy
+def foo(xs: array[int, py(1.0)]) -> None:
+    pass

--- a/tests/integration/test_py.py
+++ b/tests/integration/test_py.py
@@ -6,7 +6,7 @@ import pytest
 
 from guppylang.decorator import guppy
 from guppylang.module import GuppyModule
-from guppylang.prelude.builtins import py
+from guppylang.prelude.builtins import py, array
 from guppylang.prelude import quantum
 from guppylang.prelude.quantum import qubit
 from tests.util import compile_guppy
@@ -166,3 +166,23 @@ def test_pytket_measure(validate):
         return py(circ)(q)
 
     validate(module.compile())
+
+
+def test_func_type_arg(validate):
+    module = GuppyModule("test")
+    n = 10
+
+    @guppy(module)
+    def foo(xs: array[int, py(n)]) -> array[int, py(n)]:
+        return xs
+
+    @guppy.declare(module)
+    def bar(xs: array[int, py(n)]) -> array[int, py(n)]: ...
+
+    @guppy.struct(module)
+    class Baz:
+        xs: array[int, py(n)]
+
+    validate(module.compile())
+
+


### PR DESCRIPTION
Closes #513

Function declarations and struct definitions now also store the `python_scope` in which they were defined in oder to resolve py-expressions ocurring in their signatures.

Also I needed to update the way the python scope of functions is computed: The approach using `__closure__` doesn't capture variables that are bound in the signature. Instead we now also inspect the calling frame to extract the `f_globals` and `f_locals` from there. The same is also used for structs since Python classes don't have `__closure__`