### PR TITLE
feat: Cache accessed source files

### DIFF
--- a/guppylang/definition/common.py
+++ b/guppylang/definition/common.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING, ClassVar, TypeAlias
 from hugr.build.dfg import DefinitionBuilder, OpVar
 from hugr.ext import Package
 
+from guppylang.span import SourceMap
+
 if TYPE_CHECKING:
     from guppylang.checker.core import Globals
     from guppylang.compiler.core import CompiledGlobals
@@ -92,7 +94,7 @@ class ParsableDef(Definition):
     """
 
     @abstractmethod
-    def parse(self, globals: "Globals") -> ParsedDef:
+    def parse(self, globals: "Globals", sources: SourceMap) -> ParsedDef:
         """Performs parsing and validation, returning a definition that can be checked.
 
         The provided globals contain all other raw definitions that have been defined.

--- a/guppylang/definition/const.py
+++ b/guppylang/definition/const.py
@@ -10,6 +10,7 @@ from guppylang.checker.core import Globals
 from guppylang.compiler.core import CompiledGlobals, DFContainer
 from guppylang.definition.common import CompilableDef, ParsableDef
 from guppylang.definition.value import CompiledValueDef, ValueDef
+from guppylang.span import SourceMap
 from guppylang.tys.parsing import type_from_ast
 
 
@@ -22,7 +23,7 @@ class RawConstDef(ParsableDef):
 
     description: str = field(default="constant", init=False)
 
-    def parse(self, globals: Globals) -> "ConstDef":
+    def parse(self, globals: Globals, sources: SourceMap) -> "ConstDef":
         """Parses and checks the user-provided signature of the function."""
         return ConstDef(
             self.id,

--- a/guppylang/definition/custom.py
+++ b/guppylang/definition/custom.py
@@ -16,6 +16,7 @@ from guppylang.definition.common import ParsableDef
 from guppylang.definition.value import CallReturnWires, CompiledCallableDef
 from guppylang.error import GuppyError, InternalGuppyError
 from guppylang.nodes import GlobalCall
+from guppylang.span import SourceMap
 from guppylang.tys.subst import Inst, Subst
 from guppylang.tys.ty import (
     FuncInput,
@@ -56,7 +57,7 @@ class RawCustomFunctionDef(ParsableDef):
 
     description: str = field(default="function", init=False)
 
-    def parse(self, globals: "Globals") -> "CustomFunctionDef":
+    def parse(self, globals: "Globals", sources: SourceMap) -> "CustomFunctionDef":
         """Parses and checks the user-provided signature of the custom function.
 
         The signature is optional if custom type checking logic is provided by the user.

--- a/guppylang/definition/declaration.py
+++ b/guppylang/definition/declaration.py
@@ -16,6 +16,7 @@ from guppylang.definition.function import PyFunc, parse_py_func
 from guppylang.definition.value import CallableDef, CallReturnWires, CompiledCallableDef
 from guppylang.error import GuppyError
 from guppylang.nodes import GlobalCall
+from guppylang.span import SourceMap
 from guppylang.tys.subst import Inst, Subst
 from guppylang.tys.ty import Type, type_to_row
 
@@ -32,9 +33,9 @@ class RawFunctionDecl(ParsableDef):
     python_scope: PyScope
     description: str = field(default="function", init=False)
 
-    def parse(self, globals: Globals) -> "CheckedFunctionDecl":
+    def parse(self, globals: Globals, sources: SourceMap) -> "CheckedFunctionDecl":
         """Parses and checks the user-provided signature of the function."""
-        func_ast, docstring = parse_py_func(self.python_func)
+        func_ast, docstring = parse_py_func(self.python_func, sources)
         ty = check_signature(func_ast, globals.with_python_scope(self.python_scope))
         if not has_empty_body(func_ast):
             raise GuppyError(

--- a/guppylang/definition/extern.py
+++ b/guppylang/definition/extern.py
@@ -9,6 +9,7 @@ from guppylang.checker.core import Globals
 from guppylang.compiler.core import CompiledGlobals, DFContainer
 from guppylang.definition.common import CompilableDef, ParsableDef
 from guppylang.definition.value import CompiledValueDef, ValueDef
+from guppylang.span import SourceMap
 from guppylang.tys.parsing import type_from_ast
 
 
@@ -22,7 +23,7 @@ class RawExternDef(ParsableDef):
 
     description: str = field(default="extern", init=False)
 
-    def parse(self, globals: Globals) -> "ExternDef":
+    def parse(self, globals: Globals, sources: SourceMap) -> "ExternDef":
         """Parses and checks the user-provided signature of the function."""
         return ExternDef(
             self.id,


### PR DESCRIPTION
We used to store the entire source code that was used to build an AST as a field within *every node* of the AST. This was a hack so that we can render the source line from an AST node when an error occurs. With our new diagnostics system, we should do better than that!

With this PR, we cache the source of every file accessed by the compiler in a new `SourceMap` class. Then, we can look up the source associated with a span when rendering a diagnostic.

Note that we can't rely on Pythons `linecache` since we also need to keep track of cells in jupyter notebooks as individual "files".