### PR TITLE
feat!: return packages with pointers when compiling

### DIFF
--- a/guppylang/decorator.py
+++ b/guppylang/decorator.py
@@ -6,10 +6,10 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any, TypeVar, overload
 
-import hugr.ext
 from hugr import ops
 from hugr import tys as ht
 from hugr import val as hv
+from hugr.package import ModulePointer
 
 import guppylang
 from guppylang.ast_util import annotate_location, has_empty_body
@@ -424,9 +424,7 @@ class _Guppy:
                 module.load(**defs)
         return module
 
-    def compile_module(
-        self, id: ModuleIdentifier | None = None
-    ) -> hugr.package.Package:
+    def compile_module(self, id: ModuleIdentifier | None = None) -> ModulePointer:
         """Compiles the local module into a Hugr."""
         module = self.get_module(id)
         if not module:

--- a/guppylang/decorator.py
+++ b/guppylang/decorator.py
@@ -446,9 +446,9 @@ class _Guppy:
         if not module:
             raise GuppyError("Function definition must belong to a module")
         compiled_module = module.compile()
-        globs = module._compiled_globals
+        assert module._compiled is not None, "Module should be compiled"
+        globs = module._compiled.globs
         assert globs is not None
-        # print(list(globs.compiled.keys()))
         compiled_def = globs[f_def.id]
         assert isinstance(compiled_def, CompiledFunctionDef)
         node = compiled_def.func_def.parent_node

--- a/guppylang/definition/common.py
+++ b/guppylang/definition/common.py
@@ -6,8 +6,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, ClassVar, TypeAlias
 
 from hugr.build.dfg import DefinitionBuilder, OpVar
-from hugr.ops import FuncDecl, FuncDefn
-from hugr.package import FuncDeclPointer, FuncDefnPointer
 
 if TYPE_CHECKING:
     from guppylang.checker.core import Globals
@@ -74,21 +72,21 @@ class Definition(ABC):
         a function, but got {description of this definition} instead".
         """
 
-    def compile(self) -> FuncDefnPointer | FuncDeclPointer:
-        assert self.id.module is not None
-        module = self.id.module.compile()
-        hugr = module.module
+    # def compile(self) -> ModulePointer:
+    #     assert self.id.module is not None
+    #     return self.id.module.compile()
+    #     hugr = module.module
 
-        for node in hugr:
-            op = hugr[node].op
-            match op:
-                case FuncDefn(f_name=self.name):
-                    return FuncDefnPointer(module.package, module.module_index, node)
-                case FuncDecl(f_name=self.name):
-                    return FuncDeclPointer(module.package, module.module_index, node)
-                case _:
-                    continue
-        raise ValueError(f"Unexpected op {op}")
+    #     for node in hugr:
+    #         op = hugr[node].op
+    #         match op:
+    #             case FuncDefn(f_name=self.name):
+    #                 return FuncDefnPointer(module.package, module.module_index, node)
+    #             case FuncDecl(f_name=self.name):
+    #                 return FuncDeclPointer(module.package, module.module_index, node)
+    #             case _:
+    #                 continue
+    #     raise ValueError(f"Unexpected op {op}")
 
 
 class ParsableDef(Definition):

--- a/guppylang/definition/common.py
+++ b/guppylang/definition/common.py
@@ -72,22 +72,6 @@ class Definition(ABC):
         a function, but got {description of this definition} instead".
         """
 
-    # def compile(self) -> ModulePointer:
-    #     assert self.id.module is not None
-    #     return self.id.module.compile()
-    #     hugr = module.module
-
-    #     for node in hugr:
-    #         op = hugr[node].op
-    #         match op:
-    #             case FuncDefn(f_name=self.name):
-    #                 return FuncDefnPointer(module.package, module.module_index, node)
-    #             case FuncDecl(f_name=self.name):
-    #                 return FuncDeclPointer(module.package, module.module_index, node)
-    #             case _:
-    #                 continue
-    #     raise ValueError(f"Unexpected op {op}")
-
 
 class ParsableDef(Definition):
     """Abstract base class for raw definitions that still require parsing.

--- a/guppylang/definition/common.py
+++ b/guppylang/definition/common.py
@@ -6,7 +6,8 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, ClassVar, TypeAlias
 
 from hugr.build.dfg import DefinitionBuilder, OpVar
-from hugr.package import Package
+from hugr.ops import FuncDecl, FuncDefn
+from hugr.package import FuncDeclPointer, FuncDefnPointer
 
 if TYPE_CHECKING:
     from guppylang.checker.core import Globals
@@ -73,9 +74,21 @@ class Definition(ABC):
         a function, but got {description of this definition} instead".
         """
 
-    def compile(self) -> Package:
+    def compile(self) -> FuncDefnPointer | FuncDeclPointer:
         assert self.id.module is not None
-        return self.id.module.compile()
+        module = self.id.module.compile()
+        hugr = module.module
+
+        for node in hugr:
+            op = hugr[node].op
+            match op:
+                case FuncDefn(f_name=self.name):
+                    return FuncDefnPointer(module.package, module.module_index, node)
+                case FuncDecl(f_name=self.name):
+                    return FuncDeclPointer(module.package, module.module_index, node)
+                case _:
+                    continue
+        raise ValueError(f"Unexpected op {op}")
 
 
 class ParsableDef(Definition):

--- a/guppylang/definition/function.py
+++ b/guppylang/definition/function.py
@@ -9,6 +9,7 @@ import hugr.build.function as hf
 import hugr.tys as ht
 from hugr import Wire
 from hugr.build.dfg import DefinitionBuilder, OpVar
+from hugr.package import FuncDefnPointer
 
 from guppylang.ast_util import AstNode, annotate_location, with_loc
 from guppylang.checker.cfg_checker import CheckedCFG
@@ -64,6 +65,11 @@ class RawFunctionDef(ParsableDef):
         return ParsedFunctionDef(
             self.id, self.name, func_ast, ty, self.python_scope, docstring
         )
+
+    def compile(self) -> FuncDefnPointer:
+        from guppylang.decorator import guppy
+
+        return guppy.compile_function(self)
 
 
 @dataclass(frozen=True)

--- a/guppylang/module.py
+++ b/guppylang/module.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from hugr import Hugr, ops
 from hugr.build.function import Module
-from hugr.package import Package
+from hugr.package import ModulePointer, Package
 
 import guppylang.compiler.hugr_extension
 from guppylang import decorator
@@ -48,7 +48,7 @@ class GuppyModule:
 
     # If the hugr has already been compiled, keeps a reference that can be returned
     # from `compile`.
-    _compiled_hugr: Package | None
+    _compiled_hugr: ModulePointer | None
 
     # Map of raw definitions in this module
     _raw_defs: dict[DefId, RawDef]
@@ -301,12 +301,10 @@ class GuppyModule:
         """Compiles the module and returns the final Hugr."""
         # This function does not use the `pretty_errors` decorator since it is
         # is wrapping around `compile_package` which does use it already.
-        package = self.compile()
-        hugr = package.modules[0]
-        return hugr
+        return self.compile().module
 
     @pretty_errors
-    def compile(self) -> Package:
+    def compile(self) -> ModulePointer:
         """Compiles the module and returns the final Hugr package.
 
         The package contains the single Hugr graph as well as the required
@@ -342,11 +340,11 @@ class GuppyModule:
 
         extensions = [*TKET2_EXTENSIONS, guppylang.compiler.hugr_extension.EXTENSION]
 
-        package = Package(modules=[hugr], extensions=extensions)
+        module = ModulePointer(Package(modules=[hugr], extensions=extensions), 0)
         self._compiled = True
-        self._compiled_hugr = package
+        self._compiled_hugr = module
 
-        return package
+        return module
 
     def contains(self, name: str) -> bool:
         """Returns 'True' if the module contains an object with the given name."""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,5 +1,5 @@
 from hugr import Hugr
-from hugr.package import Package
+from hugr.package import Package, PackagePointer, ModulePointer
 
 from pathlib import Path
 import pytest
@@ -50,7 +50,9 @@ def validate(request, export_test_cases_dir: Path):
         if p.returncode != 0:
             raise RuntimeError(f"{p.stderr}")
 
-    def validate_impl(hugr: Package | Hugr, name=None):
+    def validate_impl(hugr: Package | PackagePointer | Hugr, name=None):
+        if isinstance(hugr, PackagePointer):
+            hugr = hugr.package
         # Validate via the json encoding
         js = hugr.to_json()
 
@@ -69,7 +71,7 @@ class LLVMException(Exception):
 
 
 def _run_fn(run_fn_name: str):
-    def f(hugr: Package, expected: Any, fn_name: str = "main"):
+    def f(module: ModulePointer, expected: Any, fn_name: str = "main"):
         try:
             import execute_llvm
 
@@ -77,7 +79,7 @@ def _run_fn(run_fn_name: str):
             if not fn:
                 pytest.skip("Skipping llvm execution")
 
-            hugr_json: str = hugr.modules[0].to_json()
+            hugr_json: str = module.module.to_json()
             res = fn(hugr_json, fn_name)
             if res != expected:
                 raise LLVMException(
@@ -89,7 +91,6 @@ def _run_fn(run_fn_name: str):
             pytest.skip("Skipping llvm execution")
 
     return f
-
 
 
 @pytest.fixture

--- a/tests/integration/test_array.py
+++ b/tests/integration/test_array.py
@@ -20,7 +20,7 @@ def test_len(validate):
     package = module.compile()
     validate(package)
 
-    hg = package.modules[0]
+    hg = package.module
     [val] = [data.op for node, data in hg.nodes() if isinstance(data.op, ops.Const)]
     assert isinstance(val, ops.Const)
     assert isinstance(val.val, IntVal)

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -92,7 +92,7 @@ def test_compile_again():
     def identity(x: int) -> int:
         return x
 
-    hugr = module.compile().module
+    hugr = module.compile()
 
     # Compiling again should return the same Hugr
-    assert hugr is module.compile().module
+    assert hugr is module.compile()

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -68,13 +68,7 @@ def test_func_def_name():
     def func_name() -> None:
         return
 
-    [def_op] = [
-        data.op
-        for n, data in func_name.modules[0].nodes()
-        if isinstance(data.op, ops.FuncDefn)
-    ]
-    assert isinstance(def_op, ops.FuncDefn)
-    assert def_op.f_name == "func_name"
+    assert func_name.func_defn.f_name == "func_name"
 
 
 def test_func_decl_name():

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -92,7 +92,7 @@ def test_compile_again():
     def identity(x: int) -> int:
         return x
 
-    hugr = module.compile()
+    hugr = module.compile().module
 
     # Compiling again should return the same Hugr
-    assert hugr is module.compile()
+    assert hugr is module.compile().module

--- a/tests/integration/test_extern.py
+++ b/tests/integration/test_extern.py
@@ -17,7 +17,7 @@ def test_extern_float(validate):
     package = module.compile()
     validate(package)
 
-    hg = package.modules[0]
+    hg = package.module
     [c] = [data.op for n, data in hg.nodes() if isinstance(data.op, ops.Const)]
     assert isinstance(c.val, val.Extension)
     assert c.val.val["symbol"] == "ext"
@@ -35,7 +35,7 @@ def test_extern_alt_symbol(validate):
     package = module.compile()
     validate(package)
 
-    hg = package.modules[0]
+    hg = package.module
     [c] = [data.op for n, data in hg.nodes() if isinstance(data.op, ops.Const)]
     assert isinstance(c.val, val.Extension)
     assert c.val.val["symbol"] == "foo"

--- a/tests/integration/test_quantum.py
+++ b/tests/integration/test_quantum.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from hugr.package import Package
+from hugr.package import ModulePointer
 
 import guppylang.decorator
 from guppylang.decorator import guppy
@@ -42,7 +42,7 @@ from guppylang.prelude.quantum_functional import (
 )
 
 
-def compile_quantum_guppy(fn) -> Package:
+def compile_quantum_guppy(fn) -> ModulePointer:
     """A decorator that combines @guppy with HUGR compilation.
 
     Modified version of `tests.util.compile_guppy` that loads the quantum module.

--- a/tests/util.py
+++ b/tests/util.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from hugr.package import Package
+from hugr.package import FuncDefnPointer, ModulePointer
 
 import guppylang
 from guppylang.module import GuppyModule
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
         Tk2Circuit = Any
 
 
-def compile_guppy(fn) -> Package:
+def compile_guppy(fn) -> FuncDefnPointer:
     """A decorator that combines @guppy with HUGR compilation.
 
     Creates a temporary module that only contains the defined function.
@@ -35,10 +35,10 @@ def compile_guppy(fn) -> Package:
     return defn.compile()
 
 
-def dump_llvm(hugr: Hugr | Package):
+def dump_llvm(hugr: Hugr | ModulePointer):
     # TODO: Support multiple modules?
-    if isinstance(hugr, Package):
-        hugr = hugr.modules[0]
+    if isinstance(hugr, ModulePointer):
+        hugr = hugr.module
 
     try:
         from execute_llvm import compile_module_to_string


### PR DESCRIPTION
Closes #559 
Is it valid to assume there is always a top-level funcdef or funcdecl for a Definition.compile()?

BREAKING CHANGE: decorator `compile_module` and `GuppyModule.compile` return `ModulePointer` rather than `Package` (package can be retrieved using `ModulePointer.package`. `Definition.compile` returns a `Func{Defn/Decl}Pointer`. 