### PR TITLE
fix: Fix lowering of list.__len__

### DIFF
--- a/guppylang/prelude/builtins.py
+++ b/guppylang/prelude/builtins.py
@@ -35,6 +35,7 @@ from guppylang.prelude._internal.compiler.array import (
 )
 from guppylang.prelude._internal.compiler.list import (
     ListGetitemCompiler,
+    ListLengthCompiler,
     ListPopCompiler,
     ListPushCompiler,
     ListSetitemCompiler,
@@ -515,8 +516,7 @@ class List:
     @guppy.custom(ListSetitemCompiler())
     def __setitem__(self: list[L], idx: int, value: L @ owned) -> None: ...
 
-    # TODO: https://github.com/CQCL/hugr/issues/1543
-    @guppy.hugr_op(unsupported_op("length"))
+    @guppy.custom(ListLengthCompiler())
     def __len__(self: list[L]) -> int: ...
 
     @guppy.custom(checker=UnsupportedChecker(), higher_order_value=False)


### PR DESCRIPTION
Now that https://github.com/CQCL/hugr/issues/1543 is fixed, we can use the correct op for list length lowering