### PR TITLE
feat: Allow sub-diagnostic labels to refer to fields of their parent

### DIFF
--- a/tests/diagnostics/snapshots/test_advanced_formatting.txt
+++ b/tests/diagnostics/snapshots/test_advanced_formatting.txt
@@ -1,0 +1,7 @@
+Error: Can't compare apples with oranges (at <unknown>:1:0)
+  | 
+1 | apple == orange
+  | ^^^^^ This is an apple
+  | 
+1 | apple == orange
+  |          ------ This is not an apple

--- a/tests/diagnostics/test_diagnostics_rendering.py
+++ b/tests/diagnostics/test_diagnostics_rendering.py
@@ -96,6 +96,38 @@ def test_three_labels_formatted(snapshot, request):
     run_test(source, diagnostic, snapshot, request)
 
 
+def test_advanced_formatting(snapshot, request):
+    @dataclass(frozen=True)
+    class MyDiagnostic(Error):
+        title: ClassVar[str] = "Can't compare apples with oranges"
+        span_label: ClassVar[str] = "This is an {a}{pp}{le}"
+        a: str
+
+        @property
+        def pp(self) -> str:
+            return "pp"
+
+        @property
+        def le(self) -> str:
+            return "le"
+
+    @dataclass(frozen=True)
+    class MySubDiagnostic(Note):
+        span_label: ClassVar[str] = "This is not an {a}{pp}{p}{le}"
+        p: str
+
+        @property
+        def pp(self) -> str:
+            return "p"
+
+    source = "apple == orange"
+    span_apple = Span(Loc(file, 1, 0), Loc(file, 1, 5))
+    span_orange = Span(Loc(file, 1, 9), Loc(file, 1, 15))
+    diagnostic = MyDiagnostic(span_apple, "a")
+    diagnostic.add_sub_diagnostic(MySubDiagnostic(span_orange, "p"))
+    run_test(source, diagnostic, snapshot, request)
+
+
 def test_long_label(snapshot, request):
     @dataclass(frozen=True)
     class MyDiagnostic(Error):


### PR DESCRIPTION
Sub-diagnostics now store a pointer to their parent main diagnostic that is used to look up field values when formatting labels and messages.

This is achieved by subclassing `string.Formatter` to implement the custom lookup