### PR TITLE
feat: Add `SizedIter` wrapper type

### DIFF
--- a/guppylang/checker/core.py
+++ b/guppylang/checker/core.py
@@ -29,6 +29,7 @@ from guppylang.tys.builtin import (
     list_type_def,
     nat_type_def,
     none_type_def,
+    sized_iter_type_def,
     tuple_type_def,
 )
 from guppylang.tys.ty import (
@@ -222,6 +223,7 @@ class Globals:
             float_type_def,
             list_type_def,
             array_type_def,
+            sized_iter_type_def,
         ]
         defs = {defn.id: defn for defn in builtins}
         names = {defn.name: defn.id for defn in builtins}

--- a/guppylang/definition/custom.py
+++ b/guppylang/definition/custom.py
@@ -261,12 +261,16 @@ class CustomCallChecker(ABC):
         self.node = node
         self.func = func
 
-    @abstractmethod
     def check(self, args: list[ast.expr], ty: Type) -> tuple[ast.expr, Subst]:
         """Checks the return value against a given type.
 
         Returns a (possibly) transformed and annotated AST node for the call.
         """
+        from guppylang.checker.expr_checker import check_type_against
+
+        expr, res_ty = self.synthesize(args)
+        subst, _ = check_type_against(res_ty, ty, self.node)
+        return expr, subst
 
     @abstractmethod
     def synthesize(self, args: list[ast.expr]) -> tuple[ast.expr, Type]:

--- a/guppylang/prelude/_internal/checker.py
+++ b/guppylang/prelude/_internal/checker.py
@@ -1,6 +1,7 @@
 import ast
+from typing import cast
 
-from guppylang.ast_util import AstNode, with_loc
+from guppylang.ast_util import AstNode, with_loc, with_type
 from guppylang.checker.core import Context
 from guppylang.checker.expr_checker import (
     ExprChecker,
@@ -15,6 +16,7 @@ from guppylang.definition.custom import (
     CustomFunctionDef,
     DefaultCallChecker,
 )
+from guppylang.definition.struct import CheckedStructDef, RawStructDef
 from guppylang.definition.value import CallableDef
 from guppylang.error import GuppyError, GuppyTypeError, InternalGuppyError
 from guppylang.nodes import GlobalCall, ResultExpr
@@ -25,6 +27,7 @@ from guppylang.tys.builtin import (
     int_type,
     is_array_type,
     is_bool_type,
+    sized_iter_type,
 )
 from guppylang.tys.const import Const, ConstValue
 from guppylang.tys.subst import Inst, Subst
@@ -32,6 +35,7 @@ from guppylang.tys.ty import (
     FunctionType,
     NoneType,
     NumericType,
+    StructType,
     Type,
     unify,
 )
@@ -279,3 +283,41 @@ class ResultChecker(CustomCallChecker):
     @staticmethod
     def _is_numeric_or_bool_type(ty: Type) -> bool:
         return isinstance(ty, NumericType) or is_bool_type(ty)
+
+
+class RangeChecker(CustomCallChecker):
+    """Call checker for the `range` function."""
+
+    def synthesize(self, args: list[ast.expr]) -> tuple[ast.expr, Type]:
+        check_num_args(1, len(args), self.node)
+        [stop] = args
+        stop, _ = ExprChecker(self.ctx).check(stop, int_type(), "argument")
+        range_iter, range_ty = self.make_range(stop)
+        if isinstance(stop, ast.Constant):
+            return to_sized_iter(range_iter, range_ty, stop.value, self.ctx)
+        return range_iter, range_ty
+
+    def range_ty(self) -> StructType:
+        from guppylang.prelude.builtins import Range
+
+        def_id = cast(RawStructDef, Range).id
+        range_type_def = self.ctx.globals.defs[def_id]
+        assert isinstance(range_type_def, CheckedStructDef)
+        return StructType([], range_type_def)
+
+    def make_range(self, stop: ast.expr) -> tuple[ast.expr, Type]:
+        make_range = self.ctx.globals.get_instance_func(self.range_ty(), "__new__")
+        assert make_range is not None
+        start = with_type(int_type(), with_loc(self.node, ast.Constant(value=0)))
+        return make_range.synthesize_call([start, stop], self.node, self.ctx)
+
+
+def to_sized_iter(
+    iterator: ast.expr, range_ty: Type, size: int, ctx: Context
+) -> tuple[ast.expr, Type]:
+    """Adds a static size annotation to an iterator."""
+    sized_iter_ty = sized_iter_type(range_ty, size)
+    make_sized_iter = ctx.globals.get_instance_func(sized_iter_ty, "__new__")
+    assert make_sized_iter is not None
+    sized_iter, _ = make_sized_iter.check_call([iterator], sized_iter_ty, iterator, ctx)
+    return sized_iter, sized_iter_ty

--- a/guppylang/prelude/builtins.py
+++ b/guppylang/prelude/builtins.py
@@ -569,6 +569,11 @@ class SizedIter:
     Annotating an iterator with an incorrect size is undefined behaviour.
     """
 
+    def __class_getitem__(cls, item: Any) -> type:
+        # Dummy implementation to allow subscripting of the `SizedIter` type in
+        # positions that are evaluated by the Python interpreter
+        return cls
+
     @guppy.custom(NoopCompiler())
     def __new__(iterator: L @ owned) -> "SizedIter[L, n]":  # type: ignore[type-arg]
         """Casts an iterator into a `SizedIter`."""

--- a/tests/integration/test_range.py
+++ b/tests/integration/test_range.py
@@ -1,5 +1,5 @@
 from guppylang.decorator import guppy
-from guppylang.prelude.builtins import nat, range
+from guppylang.prelude.builtins import nat, range, SizedIter, Range
 from guppylang.module import GuppyModule
 from tests.util import compile_guppy
 
@@ -33,3 +33,12 @@ def test_range(validate, run_int_fn):
     run_int_fn(compiled, expected=510)
     run_int_fn(compiled, expected=0, fn_name="negative")
     run_int_fn(compiled, expected=510, fn_name="non_static")
+
+
+def test_static_size(validate):
+    module = GuppyModule("test")
+
+    @guppy(module)
+    def negative() -> SizedIter[Range, 10]:
+        return range(10)
+

--- a/tests/integration/test_range.py
+++ b/tests/integration/test_range.py
@@ -42,3 +42,5 @@ def test_static_size(validate):
     def negative() -> SizedIter[Range, 10]:
         return range(10)
 
+    validate(module.compile())
+

--- a/tests/integration/test_range.py
+++ b/tests/integration/test_range.py
@@ -20,7 +20,16 @@ def test_range(validate, run_int_fn):
             total += 100 + x
         return total
 
+    @guppy(module)
+    def non_static() -> int:
+        total = 0
+        n = 4
+        for x in range(n + 1):
+            total += x + 100  # Make the initial 0 obvious
+        return total
+
     compiled = module.compile()
     validate(compiled)
     run_int_fn(compiled, expected=510)
     run_int_fn(compiled, expected=0, fn_name="negative")
+    run_int_fn(compiled, expected=510, fn_name="non_static")


### PR DESCRIPTION
Adds a new wrapper type `SizedIter` to the standard library that annotates an iterator with a static size hint. This will be used for example in array comprehensions to infer the size of the resulting array. The type gets erased when lowering to Hugr.

Updates the `range` function to emit such a size hint when the range stop is given by a static number. For example the expression `range(10)` is typed as `SizedIter[Range, 10]` whereas `range(n + 1)` is typed as `Range`. Currently, this is implemented via a `CustomCallChecker`, but in the future we could use function overloading and `Literal` types to implement this in Guppy source:

```python
@guppy.overloaded
def range[n: nat](stop: Literal[n]) -> SizedIter[Range, n]:
   return SizedIter(Range(0, stop))

@guppy.overloaded
def range(stop: int) -> Range:
   return Range(0, stop)
```

Closes #610.