### PR TITLE
docs: Fix docs build

### DIFF
--- a/guppylang/decorator.py
+++ b/guppylang/decorator.py
@@ -470,6 +470,8 @@ class _GuppyDummy:
     builds to mock the decorator.
     """
 
+    _sources = SourceMap()
+
     def __call__(self, arg: PyFunc | GuppyModule) -> Any:
         if isinstance(arg, GuppyModule):
             return lambda f: f


### PR DESCRIPTION
See failing run here https://github.com/CQCL/guppylang/actions/runs/11782620057/job/32818047506

The problem was that `_GuppyDummy` was missing the `_sources` field, so it didn't mock `_Guppy` correctly