### PR TITLE
chore: Manually set last release commit

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,5 @@
 {
+  "last-release-sha": "2a7522f2b5c982962cb9a88e9b98145e0b7d39a2",
   "packages": {
     ".": {
       "release-type": "python",


### PR DESCRIPTION
Manual config required after the out-of-branch `0.12.2` release.
We'll need to remove this change in the release PR.

Release-As: 0.13.0