### PR TITLE
refactor: use `OutcomeArray.from_ints` in `HShots.to_pytket`

### DIFF
--- a/guppylang/hresult.py
+++ b/guppylang/hresult.py
@@ -194,14 +194,17 @@ class HShots:
             raise ImportError(
                 "Pytket is an optional dependency, install with the `pytket` extra"
             ) from e
-        counts = self.register_bitstrings(strict_lengths=True, strict_names=True)
+        reg_shots = self.register_bitstrings(strict_lengths=True, strict_names=True)
         reg_sizes: dict[str, int] = {
-            reg: len(next(iter(counts[reg]), "")) for reg in counts
+            reg: len(next(iter(reg_shots[reg]), "")) for reg in reg_shots
         }
-        registers = list(counts.keys())
+        registers = list(reg_shots.keys())
         bits = [Bit(reg, i) for reg in registers for i in range(reg_sizes[reg])]
+
         int_shots = [
-            [ord(bitval) - 48 for reg in registers for bitval in counts[reg][i]]
+            int("".join(reg_shots[reg][i] for reg in registers), 2)
             for i in range(len(self.results))
         ]
-        return BackendResult(shots=OutcomeArray.from_readouts(int_shots), c_bits=bits)
+        return BackendResult(
+            shots=OutcomeArray.from_ints(int_shots, width=len(bits)), c_bits=bits
+        )

--- a/tests/test_hresult.py
+++ b/tests/test_hresult.py
@@ -97,17 +97,19 @@ def test_pytket():
     shot results."""
     pytest.importorskip("pytket", reason="pytket not installed")
 
-    hsim_shots = HShots(([("c", [1, 0]), ("d", [1, 0])], [("c", [0, 0]), ("d", [1, 0])]))
+    hsim_shots = HShots(
+        ([("c", [1, 0]), ("d", [1, 0, 0])], [("c", [0, 0]), ("d", [1, 0, 1])])
+    )
 
     pytket_result = hsim_shots.to_pytket()
-
     from pytket._tket.unit_id import Bit
     from pytket.backends.backendresult import BackendResult
     from pytket.utils.outcomearray import OutcomeArray
 
-    bits = [Bit("c", 0), Bit("c", 1), Bit("d", 0), Bit("d", 1)]
+    bits = [Bit("c", 0), Bit("c", 1), Bit("d", 0), Bit("d", 1), Bit("d", 2)]
     expected = BackendResult(
-        c_bits=bits, shots=OutcomeArray.from_readouts([[1, 0, 1, 0], [0, 0, 1, 0]])
+        c_bits=bits,
+        shots=OutcomeArray.from_readouts([[1, 0, 1, 0, 0], [0, 0, 1, 0, 1]]),
     )
 
     assert pytket_result == expected

--- a/uv.lock
+++ b/uv.lock
@@ -541,7 +541,7 @@ wheels = [
 
 [[package]]
 name = "guppylang"
-version = "0.12.2"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "graphviz" },


### PR DESCRIPTION
just a drive by I happened to do while debugging something else. Performance gains are not a bottleneck but it is more readable so might as well.