### PR TITLE
ci: Open an issue when building docs fails on `main`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,6 +45,22 @@ jobs:
         with:
           path: ./docs/build/
 
+  # Create an issue if building docs fails.
+  create-issue:
+    uses: CQCL/hugrverse-actions/.github/workflows/create-issue.yml@main
+    needs: build
+    if: always() && needs.build.result == 'failure' && github.event_name == 'push'
+    secrets:
+        GITHUB_PAT: ${{ secrets.HUGRBOT_PAT }}
+    with:
+        title: "💥 Docs building is fails on main"
+        body: |
+            The doc building workflow has failed on the main branch.
+
+            [https://github.com/CQCL/guppylang/actions/runs/${{ github.run_id }}](Please investigate).
+        unique-label: "docs-fail"
+        other-labels: "bug"
+
   publish:
     name: Publish docs.
     environment:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,7 +53,7 @@ jobs:
     secrets:
         GITHUB_PAT: ${{ secrets.HUGRBOT_PAT }}
     with:
-        title: "💥 Docs building is fails on main"
+        title: "💥 Doc builds fail on main"
         body: |
             The doc building workflow has failed on the main branch.
 


### PR DESCRIPTION
Based on hugr's [unsoundness check](https://github.com/CQCL/hugr/blob/main/.github/workflows/unsoundness.yml#L43-L56) notification.