### PR TITLE
feat!: qsystem std functions with updated primitives

### DIFF
--- a/guppylang/std/_internal/compiler/quantum.py
+++ b/guppylang/std/_internal/compiler/quantum.py
@@ -5,6 +5,7 @@ multiple nodes.
 from __future__ import annotations
 
 from hugr import Wire, ops
+from hugr import ext as he
 from hugr import tys as ht
 from hugr.std.float import FLOAT_T
 from tket2_exts import futures, qsystem, quantum, result, rotation
@@ -46,15 +47,25 @@ def from_halfturns_unchecked() -> ops.ExtOp:
 # ------------------------------------------------------
 
 
-class ProjectiveMeasureCompiler(CustomInoutCallCompiler):
-    """Compiler for the `measure_return` function."""
+class InoutMeasureCompiler(CustomInoutCallCompiler):
+    """Compiler for the measure functions with an inout qubit
+    such as the `project_z` function."""
+
+    opname: str
+    ext: he.Extension
+
+    def __init__(self, opname: str | None = None, ext: he.Extension | None = None):
+        self.opname = opname or "Measure"
+        self.ext = ext or QUANTUM_EXTENSION
 
     def compile_with_inouts(self, args: list[Wire]) -> CallReturnWires:
         from guppylang.std._internal.util import quantum_op
 
         [q] = args
         [q, bit] = self.builder.add_op(
-            quantum_op("Measure")(ht.FunctionType([ht.Qubit], [ht.Qubit, ht.Bool]), []),
+            quantum_op(self.opname, ext=self.ext)(
+                ht.FunctionType([ht.Qubit], [ht.Qubit, ht.Bool]), []
+            ),
             q,
         )
         return CallReturnWires(regular_returns=[bit], inout_returns=[q])

--- a/guppylang/std/_internal/compiler/quantum.py
+++ b/guppylang/std/_internal/compiler/quantum.py
@@ -46,7 +46,7 @@ def from_halfturns_unchecked() -> ops.ExtOp:
 # ------------------------------------------------------
 
 
-class MeasureReturnCompiler(CustomInoutCallCompiler):
+class ProjectiveMeasureCompiler(CustomInoutCallCompiler):
     """Compiler for the `measure_return` function."""
 
     def compile_with_inouts(self, args: list[Wire]) -> CallReturnWires:

--- a/guppylang/std/_internal/compiler/quantum.py
+++ b/guppylang/std/_internal/compiler/quantum.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from hugr import Wire, ops
 from hugr import tys as ht
 from hugr.std.float import FLOAT_T
-from tket2_exts import futures, hseries, quantum, result, rotation
+from tket2_exts import futures, qsystem, quantum, result, rotation
 
 from guppylang.definition.custom import CustomInoutCallCompiler
 from guppylang.definition.value import CallReturnWires
@@ -17,7 +17,7 @@ from guppylang.definition.value import CallReturnWires
 # ----------------------------------------------
 
 FUTURES_EXTENSION = futures()
-HSERIES_EXTENSION = hseries()
+QSYSTEM_EXTENSION = qsystem()
 QUANTUM_EXTENSION = quantum()
 RESULT_EXTENSION = result()
 ROTATION_EXTENSION = rotation()
@@ -27,7 +27,7 @@ ROTATION_T = ht.ExtType(ROTATION_T_DEF)
 
 TKET2_EXTENSIONS = [
     FUTURES_EXTENSION,
-    HSERIES_EXTENSION,
+    QSYSTEM_EXTENSION,
     QUANTUM_EXTENSION,
     RESULT_EXTENSION,
     ROTATION_EXTENSION,

--- a/guppylang/std/qsystem/__init__.py
+++ b/guppylang/std/qsystem/__init__.py
@@ -9,6 +9,7 @@ from guppylang.std._internal.compiler.quantum import (
 )
 from guppylang.std._internal.util import quantum_op
 from guppylang.std.angles import angle
+from guppylang.std.builtins import owned
 from guppylang.std.quantum import qubit
 
 qsystem = GuppyModule("qsystem")
@@ -25,6 +26,11 @@ def phased_x(q: qubit, angle1: angle, angle2: angle) -> None:
     _phased_x(q, f1, f2)
 
 
+@guppy.hugr_op(quantum_op("ZZMax", ext=QSYSTEM_EXTENSION), module=qsystem)
+@no_type_check
+def zz_max(q1: qubit, q2: qubit) -> None: ...
+
+
 @guppy(qsystem)
 @no_type_check
 def zz_phase(q1: qubit, q2: qubit, angle: angle) -> None:
@@ -32,10 +38,39 @@ def zz_phase(q1: qubit, q2: qubit, angle: angle) -> None:
     _zz_phase(q1, q2, f)
 
 
+@guppy(qsystem)
+@no_type_check
+def rz(q: qubit, angle: angle) -> None:
+    f1 = float(angle)
+    _rz(q, f1)
+
+
+@guppy.hugr_op(quantum_op("Measure", ext=QSYSTEM_EXTENSION), module=qsystem)
+@no_type_check
+def measure(q: qubit @ owned) -> bool: ...
+
+
 @guppy.custom(InoutMeasureCompiler("MeasureReset", QSYSTEM_EXTENSION), module=qsystem)
 @no_type_check
 def measure_and_reset(q: qubit) -> bool:
     """MeasureReset operation from the qsystem extension."""
+
+
+@guppy.hugr_op(quantum_op("Reset", ext=QSYSTEM_EXTENSION), module=qsystem)
+@no_type_check
+def reset(q: qubit) -> None: ...
+
+
+# TODO
+# @guppy.hugr_op(quantum_op("TryQAlloc", ext=QSYSTEM_EXTENSION), module=qsystem)
+# @no_type_check
+# def _try_qalloc() -> Option[qubit]:
+#     ..
+
+
+@guppy.hugr_op(quantum_op("QFree", ext=QSYSTEM_EXTENSION), module=qsystem)
+@no_type_check
+def qfree(q: qubit @ owned) -> None: ...
 
 
 # ------------------------------------------------------
@@ -59,5 +94,15 @@ def _zz_phase(q1: qubit, q2: qubit, angle: float) -> None:
     """ZZPhase operation from the qsystem extension.
 
     See `guppylang.std.qsystem.phased_x` for a public definition that
+    accepts angle parameters.
+    """
+
+
+@guppy.hugr_op(quantum_op("Rz", ext=QSYSTEM_EXTENSION), module=qsystem)
+@no_type_check
+def _rz(q: qubit, angle: float) -> None:
+    """Rz operation from the qsystem extension.
+
+    See `guppylang.std.qsystem.rz` for a public definition that
     accepts angle parameters.
     """

--- a/guppylang/std/qsystem/__init__.py
+++ b/guppylang/std/qsystem/__init__.py
@@ -3,7 +3,10 @@ from typing import no_type_check
 from guppylang.decorator import guppy
 from guppylang.module import GuppyModule
 from guppylang.std import angles
-from guppylang.std._internal.compiler.quantum import QSYSTEM_EXTENSION
+from guppylang.std._internal.compiler.quantum import (
+    QSYSTEM_EXTENSION,
+    InoutMeasureCompiler,
+)
 from guppylang.std._internal.util import quantum_op
 from guppylang.std.angles import angle
 from guppylang.std.quantum import qubit
@@ -29,6 +32,12 @@ def zz_phase(q1: qubit, q2: qubit, angle: angle) -> None:
     _zz_phase(q1, q2, f)
 
 
+@guppy.custom(InoutMeasureCompiler("MeasureReset", QSYSTEM_EXTENSION), module=qsystem)
+@no_type_check
+def measure_and_reset(q: qubit) -> bool:
+    """MeasureReset operation from the qsystem extension."""
+
+
 # ------------------------------------------------------
 # --------- Internal definitions -----------------------
 # ------------------------------------------------------
@@ -39,7 +48,7 @@ def zz_phase(q1: qubit, q2: qubit, angle: angle) -> None:
 def _phased_x(q: qubit, angle1: float, angle2: float) -> None:
     """PhasedX operation from the qsystem extension.
 
-    See `guppylang.prelude.quantum.phased_x` for a public definition that
+    See `guppylang.std.qsystem.phased_x` for a public definition that
     accepts angle parameters.
     """
 
@@ -49,6 +58,6 @@ def _phased_x(q: qubit, angle1: float, angle2: float) -> None:
 def _zz_phase(q1: qubit, q2: qubit, angle: float) -> None:
     """ZZPhase operation from the qsystem extension.
 
-    See `guppylang.prelude.quantum.phased_x` for a public definition that
+    See `guppylang.std.qsystem.phased_x` for a public definition that
     accepts angle parameters.
     """

--- a/guppylang/std/qsystem/__init__.py
+++ b/guppylang/std/qsystem/__init__.py
@@ -1,0 +1,54 @@
+from typing import no_type_check
+
+from guppylang.decorator import guppy
+from guppylang.module import GuppyModule
+from guppylang.std import angles
+from guppylang.std._internal.compiler.quantum import QSYSTEM_EXTENSION
+from guppylang.std._internal.util import quantum_op
+from guppylang.std.angles import angle
+from guppylang.std.quantum import qubit
+
+qsystem = GuppyModule("qsystem")
+
+qsystem.load(qubit)
+qsystem.load_all(angles)
+
+
+@guppy(qsystem)
+@no_type_check
+def phased_x(q: qubit, angle1: angle, angle2: angle) -> None:
+    f1 = float(angle1)
+    f2 = float(angle2)
+    _phased_x(q, f1, f2)
+
+
+@guppy(qsystem)
+@no_type_check
+def zz_phase(q1: qubit, q2: qubit, angle: angle) -> None:
+    f = float(angle)
+    _zz_phase(q1, q2, f)
+
+
+# ------------------------------------------------------
+# --------- Internal definitions -----------------------
+# ------------------------------------------------------
+
+
+@guppy.hugr_op(quantum_op("PhasedX", ext=QSYSTEM_EXTENSION), module=qsystem)
+@no_type_check
+def _phased_x(q: qubit, angle1: float, angle2: float) -> None:
+    """PhasedX operation from the qsystem extension.
+
+    See `guppylang.prelude.quantum.phased_x` for a public definition that
+    accepts angle parameters.
+    """
+
+
+@guppy.hugr_op(quantum_op("ZZPhase", ext=QSYSTEM_EXTENSION), module=qsystem)
+@no_type_check
+def _zz_phase(q1: qubit, q2: qubit, angle: float) -> None:
+    """ZZPhase operation from the qsystem extension.
+
+    See `guppylang.prelude.quantum.phased_x` for a public definition that
+    accepts angle parameters.
+    """

--- a/guppylang/std/qsystem/functional.py
+++ b/guppylang/std/qsystem/functional.py
@@ -1,0 +1,27 @@
+from typing import no_type_check
+
+from guppylang.decorator import guppy
+from guppylang.module import GuppyModule
+from guppylang.std import angles, qsystem
+from guppylang.std.angles import angle
+from guppylang.std.builtins import owned
+from guppylang.std.quantum import qubit
+
+qsystem_functional = GuppyModule("qsystem_functional")
+
+qsystem_functional.load(qubit, qsystem)
+qsystem_functional.load_all(angles)
+
+
+@guppy(qsystem_functional)
+@no_type_check
+def phased_x(q: qubit @ owned, angle1: angle, angle2: angle) -> qubit:
+    qsystem.phased_x(q, angle1, angle2)
+    return q
+
+
+@guppy(qsystem_functional)
+@no_type_check
+def zz_phase(q1: qubit @ owned, q2: qubit @ owned, angle: angle) -> tuple[qubit, qubit]:
+    qsystem.zz_phase(q1, q2, angle)
+    return q1, q2

--- a/guppylang/std/qsystem/functional.py
+++ b/guppylang/std/qsystem/functional.py
@@ -25,3 +25,10 @@ def phased_x(q: qubit @ owned, angle1: angle, angle2: angle) -> qubit:
 def zz_phase(q1: qubit @ owned, q2: qubit @ owned, angle: angle) -> tuple[qubit, qubit]:
     qsystem.zz_phase(q1, q2, angle)
     return q1, q2
+
+
+@guppy(qsystem_functional)
+@no_type_check
+def measure_and_reset(q: qubit @ owned) -> tuple[qubit, bool]:
+    b = qsystem.measure_and_reset(q)
+    return q, b

--- a/guppylang/std/qsystem/functional.py
+++ b/guppylang/std/qsystem/functional.py
@@ -32,3 +32,37 @@ def zz_phase(q1: qubit @ owned, q2: qubit @ owned, angle: angle) -> tuple[qubit,
 def measure_and_reset(q: qubit @ owned) -> tuple[qubit, bool]:
     b = qsystem.measure_and_reset(q)
     return q, b
+
+
+@guppy(qsystem_functional)
+@no_type_check
+def zz_max(q1: qubit @ owned, q2: qubit @ owned) -> tuple[qubit, qubit]:
+    qsystem.zz_max(q1, q2)
+    return q1, q2
+
+
+@guppy(qsystem_functional)
+@no_type_check
+def rz(q: qubit @ owned, angle: angle) -> qubit:
+    qsystem.rz(q, angle)
+    return q
+
+
+@guppy(qsystem_functional)
+@no_type_check
+def measure(q: qubit @ owned) -> bool:
+    result = qsystem.measure(q)
+    return result
+
+
+@guppy(qsystem_functional)
+@no_type_check
+def qfree(q: qubit @ owned) -> None:
+    qsystem.qfree(q)
+
+
+@guppy(qsystem_functional)
+@no_type_check
+def reset(q: qubit @ owned) -> qubit:
+    qsystem.reset(q)
+    return q

--- a/guppylang/std/quantum.py
+++ b/guppylang/std/quantum.py
@@ -159,46 +159,6 @@ def measure(q: qubit @ owned) -> bool:
     return res
 
 
-@guppy
-@no_type_check
-def phased_x(q: qubit, angle1: angle, angle2: angle) -> None:
-    f1 = float(angle1)
-    f2 = float(angle2)
-    _phased_x(q, f1, f2)
-
-
-@guppy
-@no_type_check
-def zz_phase(q1: qubit, q2: qubit, angle: angle) -> None:
-    f = float(angle)
-    _zz_phase(q1, q2, f)
-
-
 @guppy.hugr_op(quantum_op("Reset"))
 @no_type_check
 def reset(q: qubit) -> None: ...
-
-
-# ------------------------------------------------------
-# --------- Internal definitions -----------------------
-# ------------------------------------------------------
-
-
-@guppy.hugr_op(quantum_op("PhasedX", ext=QSYSTEM_EXTENSION))
-@no_type_check
-def _phased_x(q: qubit, angle1: float, angle2: float) -> None:
-    """PhasedX operation from the hseries extension.
-
-    See `guppylang.prelude.quantum.phased_x` for a public definition that
-    accepts angle parameters.
-    """
-
-
-@guppy.hugr_op(quantum_op("ZZPhase", ext=QSYSTEM_EXTENSION))
-@no_type_check
-def _zz_phase(q1: qubit, q2: qubit, angle: float) -> None:
-    """ZZPhase operation from the hseries extension.
-
-    See `guppylang.prelude.quantum.phased_x` for a public definition that
-    accepts angle parameters.
-    """

--- a/guppylang/std/quantum.py
+++ b/guppylang/std/quantum.py
@@ -8,7 +8,6 @@ from hugr import tys as ht
 
 from guppylang.decorator import guppy
 from guppylang.std._internal.compiler.quantum import (
-    QSYSTEM_EXTENSION,
     InoutMeasureCompiler,
     RotationCompiler,
 )
@@ -104,11 +103,6 @@ def tdg(q: qubit) -> None: ...
 @guppy.hugr_op(quantum_op("Sdg"))
 @no_type_check
 def sdg(q: qubit) -> None: ...
-
-
-@guppy.hugr_op(quantum_op("ZZMax", ext=QSYSTEM_EXTENSION))
-@no_type_check
-def zz_max(q1: qubit, q2: qubit) -> None: ...
 
 
 @guppy.custom(RotationCompiler("Rz"))

--- a/guppylang/std/quantum.py
+++ b/guppylang/std/quantum.py
@@ -151,13 +151,9 @@ def project_z(q: qubit) -> bool: ...
 def discard(q: qubit @ owned) -> None: ...
 
 
-@guppy
+@guppy.hugr_op(quantum_op("MeasureFree"))
 @no_type_check
-def measure(q: qubit @ owned) -> bool:
-    res = project_z(q)
-    discard(q)
-    return res
-
+def measure(q: qubit @ owned) -> bool: ...
 
 @guppy.hugr_op(quantum_op("Reset"))
 @no_type_check

--- a/guppylang/std/quantum.py
+++ b/guppylang/std/quantum.py
@@ -9,7 +9,7 @@ from hugr import tys as ht
 from guppylang.decorator import guppy
 from guppylang.std._internal.compiler.quantum import (
     QSYSTEM_EXTENSION,
-    ProjectiveMeasureCompiler,
+    InoutMeasureCompiler,
     RotationCompiler,
 )
 from guppylang.std._internal.util import quantum_op
@@ -141,7 +141,7 @@ def toffoli(control1: qubit, control2: qubit, target: qubit) -> None: ...
 def dirty_qubit() -> qubit: ...
 
 
-@guppy.custom(ProjectiveMeasureCompiler())
+@guppy.custom(InoutMeasureCompiler())
 @no_type_check
 def project_z(q: qubit) -> bool: ...
 
@@ -154,6 +154,7 @@ def discard(q: qubit @ owned) -> None: ...
 @guppy.hugr_op(quantum_op("MeasureFree"))
 @no_type_check
 def measure(q: qubit @ owned) -> bool: ...
+
 
 @guppy.hugr_op(quantum_op("Reset"))
 @no_type_check

--- a/guppylang/std/quantum.py
+++ b/guppylang/std/quantum.py
@@ -9,7 +9,7 @@ from hugr import tys as ht
 from guppylang.decorator import guppy
 from guppylang.std._internal.compiler.quantum import (
     QSYSTEM_EXTENSION,
-    MeasureReturnCompiler,
+    ProjectiveMeasureCompiler,
     RotationCompiler,
 )
 from guppylang.std._internal.util import quantum_op
@@ -34,7 +34,7 @@ class qubit:
     @guppy
     @no_type_check
     def measure_return(self: "qubit") -> bool:
-        return measure_return(self)
+        return project_z(self)
 
     @guppy
     @no_type_check
@@ -141,9 +141,9 @@ def toffoli(control1: qubit, control2: qubit, target: qubit) -> None: ...
 def dirty_qubit() -> qubit: ...
 
 
-@guppy.custom(MeasureReturnCompiler())
+@guppy.custom(ProjectiveMeasureCompiler())
 @no_type_check
-def measure_return(q: qubit) -> bool: ...
+def project_z(q: qubit) -> bool: ...
 
 
 @guppy.hugr_op(quantum_op("QFree"))
@@ -154,7 +154,7 @@ def discard(q: qubit @ owned) -> None: ...
 @guppy
 @no_type_check
 def measure(q: qubit @ owned) -> bool:
-    res = measure_return(q)
+    res = project_z(q)
     discard(q)
     return res
 

--- a/guppylang/std/quantum.py
+++ b/guppylang/std/quantum.py
@@ -32,17 +32,8 @@ class qubit:
 
     @guppy
     @no_type_check
-    def measure_return(self: "qubit") -> bool:
+    def project_z(self: "qubit") -> bool:
         return project_z(self)
-
-    @guppy
-    @no_type_check
-    def measure_reset(self: "qubit") -> bool:
-        """Projective measure and reset without discarding the qubit."""
-        res = self.measure_return()
-        if res:
-            x(self)
-        return res
 
     @guppy
     @no_type_check

--- a/guppylang/std/quantum.py
+++ b/guppylang/std/quantum.py
@@ -8,7 +8,7 @@ from hugr import tys as ht
 
 from guppylang.decorator import guppy
 from guppylang.std._internal.compiler.quantum import (
-    HSERIES_EXTENSION,
+    QSYSTEM_EXTENSION,
     MeasureReturnCompiler,
     RotationCompiler,
 )
@@ -106,7 +106,7 @@ def tdg(q: qubit) -> None: ...
 def sdg(q: qubit) -> None: ...
 
 
-@guppy.hugr_op(quantum_op("ZZMax", ext=HSERIES_EXTENSION))
+@guppy.hugr_op(quantum_op("ZZMax", ext=QSYSTEM_EXTENSION))
 @no_type_check
 def zz_max(q1: qubit, q2: qubit) -> None: ...
 
@@ -184,7 +184,7 @@ def reset(q: qubit) -> None: ...
 # ------------------------------------------------------
 
 
-@guppy.hugr_op(quantum_op("PhasedX", ext=HSERIES_EXTENSION))
+@guppy.hugr_op(quantum_op("PhasedX", ext=QSYSTEM_EXTENSION))
 @no_type_check
 def _phased_x(q: qubit, angle1: float, angle2: float) -> None:
     """PhasedX operation from the hseries extension.
@@ -194,7 +194,7 @@ def _phased_x(q: qubit, angle1: float, angle2: float) -> None:
     """
 
 
-@guppy.hugr_op(quantum_op("ZZPhase", ext=HSERIES_EXTENSION))
+@guppy.hugr_op(quantum_op("ZZPhase", ext=QSYSTEM_EXTENSION))
 @no_type_check
 def _zz_phase(q1: qubit, q2: qubit, angle: float) -> None:
     """ZZPhase operation from the hseries extension.

--- a/guppylang/std/quantum_functional.py
+++ b/guppylang/std/quantum_functional.py
@@ -143,20 +143,6 @@ def toffoli(
 
 @guppy(quantum_functional)
 @no_type_check
-def phased_x(q: qubit @ owned, angle1: angle, angle2: angle) -> qubit:
-    quantum.phased_x(q, angle1, angle2)
-    return q
-
-
-@guppy(quantum_functional)
-@no_type_check
-def zz_phase(q1: qubit @ owned, q2: qubit @ owned, angle: angle) -> tuple[qubit, qubit]:
-    quantum.zz_phase(q1, q2, angle)
-    return q1, q2
-
-
-@guppy(quantum_functional)
-@no_type_check
 def reset(q: qubit @ owned) -> qubit:
     quantum.reset(q)
     return q

--- a/guppylang/std/quantum_functional.py
+++ b/guppylang/std/quantum_functional.py
@@ -151,5 +151,5 @@ def reset(q: qubit @ owned) -> qubit:
 @guppy(quantum_functional)
 @no_type_check
 def measure_return(q: qubit @ owned) -> tuple[qubit, bool]:
-    b = quantum.measure_return(q)
+    b = quantum.project_z(q)
     return q, b

--- a/guppylang/std/quantum_functional.py
+++ b/guppylang/std/quantum_functional.py
@@ -143,6 +143,6 @@ def reset(q: qubit @ owned) -> qubit:
 
 @guppy(quantum_functional)
 @no_type_check
-def measure_return(q: qubit @ owned) -> tuple[qubit, bool]:
+def project_z(q: qubit @ owned) -> tuple[qubit, bool]:
     b = quantum.project_z(q)
     return q, b

--- a/guppylang/std/quantum_functional.py
+++ b/guppylang/std/quantum_functional.py
@@ -97,13 +97,6 @@ def sdg(q: qubit @ owned) -> qubit:
 
 @guppy(quantum_functional)
 @no_type_check
-def zz_max(q1: qubit @ owned, q2: qubit @ owned) -> tuple[qubit, qubit]:
-    quantum.zz_max(q1, q2)
-    return q1, q2
-
-
-@guppy(quantum_functional)
-@no_type_check
 def rz(q: qubit @ owned, angle: angle) -> qubit:
     quantum.rz(q, angle)
     return q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,8 @@ execute-llvm = { workspace = true }
 
 # Uncomment these to test the latest dependency version during development
 #hugr = { git = "https://github.com/CQCL/hugr", subdirectory = "hugr-py", rev = "4cbe890ab4e72090708ff83592c0771caf2335df" }
-#tket2 = { git = "https://github.com/CQCL/tket2", subdirectory = "tket2-py", rev = "e3f9da1abe28f31cb249de2e06be846ab48d9708" }
+tket2-exts = { git = "https://github.com/CQCL/tket2", subdirectory = "tket2-exts", branch = "ss/rename" }
+
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "pydantic >=2.7.0b1,<3",
     "typing-extensions >=4.9.0,<5",
     "hugr >=0.9.0,<0.10",
-    "tket2-exts>=0.1.0,<0.2",
+    "tket2-exts>=0.2.0,<0.3",
 ]
 
 [project.optional-dependencies]
@@ -65,7 +65,7 @@ execute-llvm = { workspace = true }
 
 # Uncomment these to test the latest dependency version during development
 #hugr = { git = "https://github.com/CQCL/hugr", subdirectory = "hugr-py", rev = "4cbe890ab4e72090708ff83592c0771caf2335df" }
-tket2-exts = { git = "https://github.com/CQCL/tket2", subdirectory = "tket2-exts", branch = "ss/rename" }
+# tket2-exts = { git = "https://github.com/CQCL/tket2", subdirectory = "tket2-exts", branch = "ss/rename" }
 
 
 [build-system]

--- a/tests/integration/test_inout.py
+++ b/tests/integration/test_inout.py
@@ -370,8 +370,7 @@ def test_self_qubit(validate):
     def test() -> bool:
         q0 = qubit()
 
-        result = q0.measure_reset()
-        q0.measure_return()
+        result = q0.project_z()
         q0.measure()
         qubit().discard()
         return result

--- a/tests/integration/test_linear.py
+++ b/tests/integration/test_linear.py
@@ -4,7 +4,7 @@ from guppylang.std.builtins import owned
 from guppylang.std.quantum import qubit, measure
 
 import guppylang.std.quantum_functional as quantum_functional
-from guppylang.std.quantum_functional import cx, t, h, measure_return
+from guppylang.std.quantum_functional import cx, t, h, project_z
 from guppylang.tys.ty import NoneType
 
 import pytest
@@ -44,7 +44,7 @@ def test_linear_return_order(validate):
 
     @guppy(module)
     def test(q: qubit @owned) -> tuple[qubit, bool]:
-        return measure_return(q)
+        return project_z(q)
 
     validate(module.compile())
 

--- a/tests/integration/test_qsystem.py
+++ b/tests/integration/test_qsystem.py
@@ -1,0 +1,53 @@
+from hugr.package import ModulePointer
+
+import guppylang.decorator
+from guppylang.module import GuppyModule
+from guppylang.std.angles import angle
+
+from guppylang.std.builtins import owned
+from guppylang.std.quantum import qubit
+from guppylang.std.qsystem.functional import (
+    phased_x,
+    zz_phase,
+    qsystem_functional,
+    measure_and_reset,
+    zz_max,
+    rz,
+    measure,
+    qfree,
+)
+
+
+def compile_qsystem_guppy(fn) -> ModulePointer:
+    """A decorator that combines @guppy with HUGR compilation.
+
+    Modified version of `tests.util.compile_guppy` that loads the qsytem module.
+    """
+    assert not isinstance(
+        fn,
+        GuppyModule,
+    ), "`@compile_qsystem_guppy` does not support extra arguments."
+
+    module = GuppyModule("module")
+    module.load(angle, qubit)
+    module.load_all(qsystem_functional)
+    guppylang.decorator.guppy(module)(fn)
+    return module.compile()
+
+
+def test_qsystem(validate):
+    """Compile various operations from the qsystem extension."""
+
+    @compile_qsystem_guppy
+    def test(q1: qubit @ owned, q2: qubit @ owned, a1: angle) -> bool:
+        q1 = phased_x(q1, a1, a1)
+        q1, q2 = zz_phase(q1, q2, a1)
+        q1 = rz(q1, a1)
+        q1, q2 = zz_max(q1, q2)
+        q1, b = measure_and_reset(q1)
+        q1 = reset(q1)
+        b = measure(q1)
+        qfree(q2)
+        return b
+
+    validate(test)

--- a/tests/integration/test_quantum.py
+++ b/tests/integration/test_quantum.py
@@ -10,6 +10,7 @@ from guppylang.module import GuppyModule
 from guppylang.std.angles import angle
 
 from guppylang.std.builtins import owned, py
+from guppylang.std.qsystem.functional import phased_x, zz_phase, qsystem_functional
 from guppylang.std.quantum import (
     dirty_qubit,
     discard,
@@ -29,13 +30,11 @@ from guppylang.std.quantum_functional import (
     tdg,
     sdg,
     zz_max,
-    phased_x,
     rx,
     ry,
     rz,
     crz,
     toffoli,
-    zz_phase,
     reset,
     quantum_functional,
     measure_return,
@@ -55,6 +54,7 @@ def compile_quantum_guppy(fn) -> ModulePointer:
     module = GuppyModule("module")
     module.load(angle, qubit, dirty_qubit, discard, measure)
     module.load_all(quantum_functional)
+    module.load_all(qsystem_functional)
     guppylang.decorator.guppy(module)(fn)
     return module.compile()
 

--- a/tests/integration/test_quantum.py
+++ b/tests/integration/test_quantum.py
@@ -28,7 +28,7 @@ from guppylang.std.quantum_functional import (
     toffoli,
     reset,
     quantum_functional,
-    measure_return,
+    project_z,
 )
 
 
@@ -102,7 +102,7 @@ def test_measure_ops(validate):
 
     @compile_quantum_guppy
     def test(q1: qubit @ owned, q2: qubit @ owned) -> tuple[bool, bool]:
-        q1, b1 = measure_return(q1)
+        q1, b1 = project_z(q1)
         q1 = discard(q1)
         q2 = reset(q2)
         b2 = measure(q2)

--- a/tests/integration/test_quantum.py
+++ b/tests/integration/test_quantum.py
@@ -10,13 +10,13 @@ from guppylang.module import GuppyModule
 from guppylang.std.angles import angle
 
 from guppylang.std.builtins import owned, py
-from guppylang.std.qsystem.functional import phased_x, zz_phase, qsystem_functional
-from guppylang.std.quantum import (
-    dirty_qubit,
-    discard,
-    measure,
-    qubit
+from guppylang.std.qsystem.functional import (
+    phased_x,
+    zz_phase,
+    qsystem_functional,
+    measure_and_reset,
 )
+from guppylang.std.quantum import dirty_qubit, discard, measure, qubit
 from guppylang.std.quantum_functional import (
     cx,
     cy,
@@ -71,7 +71,7 @@ def test_dirty_qubit(validate):
 
 def test_1qb_op(validate):
     @compile_quantum_guppy
-    def test(q: qubit @owned) -> qubit:
+    def test(q: qubit @ owned) -> qubit:
         q = h(q)
         q = t(q)
         q = s(q)
@@ -87,7 +87,7 @@ def test_1qb_op(validate):
 
 def test_2qb_op(validate):
     @compile_quantum_guppy
-    def test(q1: qubit @owned, q2: qubit @owned) -> tuple[qubit, qubit]:
+    def test(q1: qubit @ owned, q2: qubit @ owned) -> tuple[qubit, qubit]:
         q1, q2 = cx(q1, q2)
         q1, q2 = cy(q1, q2)
         q1, q2 = cz(q1, q2)
@@ -99,7 +99,9 @@ def test_2qb_op(validate):
 
 def test_3qb_op(validate):
     @compile_quantum_guppy
-    def test(q1: qubit @owned, q2: qubit @owned, q3: qubit @owned) -> tuple[qubit, qubit, qubit]:
+    def test(
+        q1: qubit @ owned, q2: qubit @ owned, q3: qubit @ owned
+    ) -> tuple[qubit, qubit, qubit]:
         q1, q2, q3 = toffoli(q1, q2, q3)
         return (q1, q2, q3)
 
@@ -110,10 +112,11 @@ def test_measure_ops(validate):
     """Compile various measurement-related operations."""
 
     @compile_quantum_guppy
-    def test(q1: qubit @owned, q2: qubit @owned) -> tuple[bool, bool]:
+    def test(q1: qubit @ owned, q2: qubit @ owned) -> tuple[bool, bool]:
         q1, b1 = measure_return(q1)
         q1 = discard(q1)
         q2 = reset(q2)
+        q2, b2 = measure_and_reset(q2)
         b2 = measure(q2)
         return (b1, b2)
 
@@ -124,7 +127,9 @@ def test_parametric(validate):
     """Compile various parametric operations."""
 
     @compile_quantum_guppy
-    def test(q1: qubit @owned, q2: qubit @owned, a1: angle, a2: angle, a3: angle) -> tuple[qubit, qubit]:
+    def test(
+        q1: qubit @ owned, q2: qubit @ owned, a1: angle, a2: angle, a3: angle
+    ) -> tuple[qubit, qubit]:
         q1 = rx(q1, a1)
         q1 = ry(q1, a1)
         q2 = rz(q2, a3)

--- a/tests/integration/test_quantum.py
+++ b/tests/integration/test_quantum.py
@@ -1,21 +1,13 @@
 """Various tests for the functions defined in `guppylang.prelude.quantum`."""
 
-import pytest
-
 from hugr.package import ModulePointer
 
 import guppylang.decorator
-from guppylang.decorator import guppy
 from guppylang.module import GuppyModule
 from guppylang.std.angles import angle
 
-from guppylang.std.builtins import owned, py
-from guppylang.std.qsystem.functional import (
-    phased_x,
-    zz_phase,
-    qsystem_functional,
-    measure_and_reset,
-)
+from guppylang.std.builtins import owned
+
 from guppylang.std.quantum import dirty_qubit, discard, measure, qubit
 from guppylang.std.quantum_functional import (
     cx,
@@ -29,7 +21,6 @@ from guppylang.std.quantum_functional import (
     z,
     tdg,
     sdg,
-    zz_max,
     rx,
     ry,
     rz,
@@ -54,7 +45,6 @@ def compile_quantum_guppy(fn) -> ModulePointer:
     module = GuppyModule("module")
     module.load(angle, qubit, dirty_qubit, discard, measure)
     module.load_all(quantum_functional)
-    module.load_all(qsystem_functional)
     guppylang.decorator.guppy(module)(fn)
     return module.compile()
 
@@ -91,7 +81,6 @@ def test_2qb_op(validate):
         q1, q2 = cx(q1, q2)
         q1, q2 = cy(q1, q2)
         q1, q2 = cz(q1, q2)
-        q1, q2 = zz_max(q1, q2)
         return (q1, q2)
 
     validate(test)
@@ -116,7 +105,6 @@ def test_measure_ops(validate):
         q1, b1 = measure_return(q1)
         q1 = discard(q1)
         q2 = reset(q2)
-        q2, b2 = measure_and_reset(q2)
         b2 = measure(q2)
         return (b1, b2)
 
@@ -133,7 +121,5 @@ def test_parametric(validate):
         q1 = rx(q1, a1)
         q1 = ry(q1, a1)
         q2 = rz(q2, a3)
-        q1 = phased_x(q1, a1, a2)
-        q1, q2 = zz_phase(q1, q2, a1)
         q1, q2 = crz(q1, q2, a3)
         return (q1, q2)

--- a/tests/integration/test_tket.py
+++ b/tests/integration/test_tket.py
@@ -12,17 +12,17 @@ https://github.com/CQCL/tket2/issues/new
 
 from importlib.util import find_spec
 
-import math
 import pytest
 
 from guppylang.decorator import guppy
 from guppylang.module import GuppyModule
 from guppylang.std.angles import pi
-from guppylang.std.builtins import owned, py
+from guppylang.std.builtins import owned
 from guppylang.std import quantum
 from guppylang.std.qsystem.functional import phased_x
 from guppylang.std.quantum import measure, qubit
-from guppylang.std.quantum_functional import rz, zz_max
+from guppylang.std.quantum_functional import rz
+from guppylang.std.qsystem.functional import zz_max
 from tests.util import guppy_to_circuit
 
 tket2_installed = find_spec("tket2") is not None

--- a/tests/integration/test_tket.py
+++ b/tests/integration/test_tket.py
@@ -20,8 +20,9 @@ from guppylang.module import GuppyModule
 from guppylang.std.angles import pi
 from guppylang.std.builtins import owned, py
 from guppylang.std import quantum
+from guppylang.std.qsystem.functional import phased_x
 from guppylang.std.quantum import measure, qubit
-from guppylang.std.quantum_functional import phased_x, rz, zz_max
+from guppylang.std.quantum_functional import rz, zz_max
 from tests.util import guppy_to_circuit
 
 tket2_installed = find_spec("tket2") is not None

--- a/uv.lock
+++ b/uv.lock
@@ -618,7 +618,7 @@ requires-dist = [
     { name = "pytket", marker = "extra == 'pytket'", specifier = ">=1.34" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=7.2.6,<9" },
     { name = "sphinx-book-theme", marker = "extra == 'docs'", specifier = ">=1.1.2,<2" },
-    { name = "tket2-exts", specifier = ">=0.1.0,<0.2" },
+    { name = "tket2-exts", git = "https://github.com/CQCL/tket2?subdirectory=tket2-exts&branch=ss%2Frename" },
     { name = "typing-extensions", specifier = ">=4.9.0,<5" },
 ]
 
@@ -2243,14 +2243,10 @@ wheels = [
 
 [[package]]
 name = "tket2-exts"
-version = "0.1.0"
-source = { registry = "https://pypi.org/simple" }
+version = "0.1.1"
+source = { git = "https://github.com/CQCL/tket2?subdirectory=tket2-exts&branch=ss%2Frename#791439459cff303a6b0c86214d38c4f6d766fddc" }
 dependencies = [
     { name = "hugr" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/bf/4f3bc7dd20df43189eb228e446f8e5094dbf3120604707487dc4fe2194b2/tket2_exts-0.1.0.tar.gz", hash = "sha256:6ab2117ec776d61efab3e7dd5ccfa5e619ad8c2b971f954e930a89ced3381cd0", size = 8727 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/81/4c76678510a3168fe036e33a1d4e8a6f72b56421de10bf40851485f9ed4d/tket2_exts-0.1.0-py3-none-any.whl", hash = "sha256:2ab0253c7f8bfea908578a2ae800b7468f093217c3fb998c3a4e1c109e673163", size = 14317 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -618,7 +618,7 @@ requires-dist = [
     { name = "pytket", marker = "extra == 'pytket'", specifier = ">=1.34" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=7.2.6,<9" },
     { name = "sphinx-book-theme", marker = "extra == 'docs'", specifier = ">=1.1.2,<2" },
-    { name = "tket2-exts", git = "https://github.com/CQCL/tket2?subdirectory=tket2-exts&branch=ss%2Frename" },
+    { name = "tket2-exts", specifier = ">=0.2.0,<0.3" },
     { name = "typing-extensions", specifier = ">=4.9.0,<5" },
 ]
 
@@ -2243,10 +2243,14 @@ wheels = [
 
 [[package]]
 name = "tket2-exts"
-version = "0.1.1"
-source = { git = "https://github.com/CQCL/tket2?subdirectory=tket2-exts&branch=ss%2Frename#791439459cff303a6b0c86214d38c4f6d766fddc" }
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "hugr" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/56/d9435d4f4fc56af1193b50195e0fe9ff8192919caff0c978ce915d41ecae/tket2_exts-0.2.0.tar.gz", hash = "sha256:bbff2b27ab795fa045efb4c58d4fcdf0e9c94137d1aa5c49677cc8315b5ecfb8", size = 9306 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/82/4865a9d308b039f89c85020b6537b940d84ab6160d6c7520b911123dd459/tket2_exts-0.2.0-py3-none-any.whl", hash = "sha256:e9c207c90ff03e60faa1e4a1950f5bdf3ddfea8775e5f6f4bf80840d38a807a2", size = 14575 },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #625 Closes #645
- hseries renamed to qsystem



BREAKING CHANGE: hseries primitive functions moved to std.qsystem
BREAKING CHANGE: measure_return renamed to `project_z`