### PR TITLE
ci: Fix docs fail issue formatting

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,7 +57,7 @@ jobs:
         body: |
             The doc building workflow has failed on the main branch.
 
-            [https://github.com/CQCL/guppylang/actions/runs/${{ github.run_id }}](Please investigate).
+            [Please investigate](https://github.com/CQCL/guppylang/actions/runs/${{ github.run_id }}).
         unique-label: "docs-fail"
         other-labels: "bug"
 


### PR DESCRIPTION
The message should go before the url.

See pre-edit message in https://github.com/CQCL/guppylang/issues/680.