### PR TITLE
fix: Stop throwing NotImplementedError for unsupported expressions

### DIFF
--- a/guppylang/checker/expr_checker.py
+++ b/guppylang/checker/expr_checker.py
@@ -753,6 +753,10 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
             f"`{ast.unparse(node)}`"
         )
 
+    def generic_visit(self, node: ast.expr) -> NoReturn:
+        """Called if no explicit visitor function exists for a node."""
+        raise GuppyError(UnsupportedError(node, "This expression", singular=True))
+
 
 def check_type_against(
     act: Type, exp: Type, node: AstNode, kind: str = "expression"

--- a/tests/error/misc_errors/unsupported_expr.err
+++ b/tests/error/misc_errors/unsupported_expr.err
@@ -1,0 +1,8 @@
+Error: Unsupported (at $FILE:7:14)
+  | 
+5 | @compile_guppy
+6 | def foo(xs: array[int, 1]) -> tuple[int, int]:
+7 |     return 0, *xs
+  |               ^^^ This expression is not supported
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/misc_errors/unsupported_expr.py
+++ b/tests/error/misc_errors/unsupported_expr.py
@@ -1,0 +1,7 @@
+from guppylang.std.builtins import array
+from tests.util import compile_guppy
+
+
+@compile_guppy
+def foo(xs: array[int, 1]) -> tuple[int, int]:
+    return 0, *xs


### PR DESCRIPTION
Fixes #691