### PR TITLE
feat!: Turn py expression lists into arrays

### DIFF
--- a/guppylang/checker/expr_checker.py
+++ b/guppylang/checker/expr_checker.py
@@ -106,6 +106,7 @@ from guppylang.nodes import (
 from guppylang.span import Span, to_span
 from guppylang.tys.arg import TypeArg
 from guppylang.tys.builtin import (
+    array_type,
     bool_type,
     get_element_type,
     is_bool_type,
@@ -1171,7 +1172,7 @@ def _python_list_to_guppy_type(
     representable in Guppy.
     """
     if len(vs) == 0:
-        return list_type(ExistentialTypeVar.fresh("T", False))
+        return array_type(ExistentialTypeVar.fresh("T", False), 0)
 
     # All the list elements must have a unifiable types
     v, *rest = vs
@@ -1185,4 +1186,4 @@ def _python_list_to_guppy_type(
         if (subst := unify(ty, el_ty, {})) is None:
             raise GuppyError(PyExprIncoherentListError(node))
         el_ty = el_ty.substitute(subst)
-    return list_type(el_ty)
+    return array_type(el_ty, len(vs))

--- a/tests/error/py_errors/list_empty.err
+++ b/tests/error/py_errors/list_empty.err
@@ -4,6 +4,6 @@ Error: Cannot infer type (at $FILE:6:9)
 5 | def foo() -> None:
 6 |     xs = py([])
   |          ^^^^^^ Cannot infer type variables in expression of type
-  |                 `list[?T]`
+  |                 `array[?T, 0]`
 
 Guppy compilation failed due to 1 previous error

--- a/tests/integration/test_py.py
+++ b/tests/integration/test_py.py
@@ -76,7 +76,7 @@ def test_tuple_implicit(validate):
 
 def test_list_basic(validate):
     @compile_guppy
-    def foo() -> list[int]:
+    def foo() -> array[int, 3]:
         xs = py([1, 2, 3])
         return xs
 
@@ -85,7 +85,7 @@ def test_list_basic(validate):
 
 def test_list_empty(validate):
     @compile_guppy
-    def foo() -> list[int]:
+    def foo() -> array[int, 0]:
         return py([])
 
     validate(foo)
@@ -94,7 +94,7 @@ def test_list_empty(validate):
 def test_list_empty_nested(validate):
     @compile_guppy
     def foo() -> None:
-        xs: list[tuple[int, list[bool]]] = py([(42, [])])
+        xs: array[tuple[int, array[bool, 0]], 1] = py([(42, [])])
 
     validate(foo)
 
@@ -102,7 +102,7 @@ def test_list_empty_nested(validate):
 def test_list_empty_multiple(validate):
     @compile_guppy
     def foo() -> None:
-        xs: tuple[list[int], list[bool]] = py([], [])
+        xs: tuple[array[int, 0], array[bool, 0]] = py([], [])
 
     validate(foo)
 


### PR DESCRIPTION
Closes #545.

BREAKING CHANGE: Lists in `py(...)` expressions are now turned into Guppy arrays instead of lists.