### PR TITLE
feat!: remove dirty_qubit

### DIFF
--- a/guppylang/std/quantum.py
+++ b/guppylang/std/quantum.py
@@ -18,12 +18,9 @@ from guppylang.std.builtins import owned
 
 @guppy.type(ht.Qubit, linear=True)
 class qubit:
-    @guppy
+    @guppy.hugr_op(quantum_op("QAlloc"))
     @no_type_check
-    def __new__() -> "qubit":
-        q = dirty_qubit()
-        reset(q)
-        return q
+    def __new__() -> "qubit": ...
 
     @guppy
     @no_type_check
@@ -119,11 +116,6 @@ def crz(control: qubit, target: qubit, angle: angle) -> None: ...
 @guppy.hugr_op(quantum_op("Toffoli"))
 @no_type_check
 def toffoli(control1: qubit, control2: qubit, target: qubit) -> None: ...
-
-
-@guppy.hugr_op(quantum_op("QAlloc"))
-@no_type_check
-def dirty_qubit() -> qubit: ...
 
 
 @guppy.custom(InoutMeasureCompiler())

--- a/tests/integration/test_qalloc.py
+++ b/tests/integration/test_qalloc.py
@@ -2,20 +2,20 @@ from guppylang.decorator import guppy
 from guppylang.module import GuppyModule
 from guppylang.std.quantum import qubit
 
-from guppylang.std.quantum import dirty_qubit, measure
+from guppylang.std.quantum import measure
 from guppylang.std.quantum_functional import cx
 
 import guppylang.std.quantum_functional as quantum_functional
 
 
-def test_dirty_qubit(validate):
+def test_qalloc(validate):
     module = GuppyModule("test")
     module.load_all(quantum_functional)
-    module.load(qubit, dirty_qubit, measure)
+    module.load(qubit, measure)
 
     @guppy(module)
     def test() -> tuple[bool, bool]:
-        q1, q2 = qubit(), dirty_qubit()
+        q1, q2 = qubit(), qubit()
         q1, q2 = cx(q1, q2)
         return (measure(q1), measure(q2))
 

--- a/tests/integration/test_quantum.py
+++ b/tests/integration/test_quantum.py
@@ -8,7 +8,7 @@ from guppylang.std.angles import angle
 
 from guppylang.std.builtins import owned
 
-from guppylang.std.quantum import dirty_qubit, discard, measure, qubit
+from guppylang.std.quantum import discard, measure, qubit
 from guppylang.std.quantum_functional import (
     cx,
     cy,
@@ -43,16 +43,16 @@ def compile_quantum_guppy(fn) -> ModulePointer:
     ), "`@compile_quantum_guppy` does not support extra arguments."
 
     module = GuppyModule("module")
-    module.load(angle, qubit, dirty_qubit, discard, measure)
+    module.load(angle, qubit, discard, measure)
     module.load_all(quantum_functional)
     guppylang.decorator.guppy(module)(fn)
     return module.compile()
 
 
-def test_dirty_qubit(validate):
+def test_alloc(validate):
     @compile_quantum_guppy
     def test() -> tuple[bool, bool]:
-        q1, q2 = qubit(), dirty_qubit()
+        q1, q2 = qubit(), qubit()
         q1, q2 = cx(q1, q2)
         return (measure(q1), measure(q2))
 


### PR DESCRIPTION
`tket2.quantum.QAlloc` now guarantees 0 state

BREAKING CHANGE: `dirty_qubit` function removed