### PR TITLE
feat: Add method to load pytket circuit without function stub

### DIFF
--- a/tests/integration/test_pytket_circuits.py
+++ b/tests/integration/test_pytket_circuits.py
@@ -118,7 +118,6 @@ def test_measure_not_last(validate):
 
 
 @pytest.mark.skipif(not tket2_installed, reason="Tket2 is not installed")
-@pytest.mark.skip("Not implemented")
 def test_load_circuit(validate):
     from pytket import Circuit
 
@@ -133,5 +132,30 @@ def test_load_circuit(validate):
     @guppy(module)
     def foo(q: qubit) -> None:
         guppy_circ(q)
+
+    validate(module.compile())
+
+
+@pytest.mark.skipif(not tket2_installed, reason="Tket2 is not installed")
+def test_load_circuits(validate):
+    from pytket import Circuit
+
+    circ1 = Circuit(1)
+    circ1.H(0)
+
+    circ2 = Circuit(2)
+    circ2.CX(0, 1)
+    circ2.measure_all()
+
+    module = GuppyModule("test")
+    module.load_all(quantum)
+
+    guppy.load_pytket("guppy_circ1", circ1, module)
+    guppy.load_pytket("guppy_circ2", circ2, module)
+
+    @guppy(module)
+    def foo(q1: qubit, q2: qubit, q3: qubit) -> tuple[bool, bool]:
+        guppy_circ1(q1)
+        return  guppy_circ2(q2, q3)
 
     validate(module.compile())


### PR DESCRIPTION
Closes #670 

Both finding the call location and then having either a node or a span for errors feels a bit hacky but I haven't been able to think of something better so far and it seems to work.