### PR TITLE
fix: Properly report errors for unsupported subscript assignments

### DIFF
--- a/guppylang/checker/stmt_checker.py
+++ b/guppylang/checker/stmt_checker.py
@@ -150,6 +150,12 @@ class StmtChecker(AstVisitor[BBStatement]):
         return with_loc(lhs, with_type(rhs_ty, PlaceNode(place=place)))
 
     @_check_assign.register
+    def _check_subscript_assign(
+        self, lhs: ast.Subscript, rhs: ast.expr, rhs_ty: Type
+    ) -> AnyUnpack:
+        raise GuppyError(UnsupportedError(lhs, "Subscript assignments"))
+
+    @_check_assign.register
     def _check_tuple_assign(
         self, lhs: ast.Tuple, rhs: ast.expr, rhs_ty: Type
     ) -> AnyUnpack:

--- a/tests/error/array_errors/mutate.err
+++ b/tests/error/array_errors/mutate.err
@@ -1,0 +1,8 @@
+Error: Unsupported (at $FILE:11:4)
+   | 
+ 9 | @guppy(module)
+10 | def main(xs: array[int, 10]) -> None:
+11 |     xs[0] = 1
+   |     ^^^^^ Subscript assignments are not supported
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/array_errors/mutate.py
+++ b/tests/error/array_errors/mutate.py
@@ -1,0 +1,14 @@
+from guppylang.decorator import guppy
+from guppylang.module import GuppyModule
+from guppylang.std.builtins import array, owned
+
+
+module = GuppyModule("test")
+
+
+@guppy(module)
+def main(xs: array[int, 10]) -> None:
+    xs[0] = 1
+
+
+module.compile()


### PR DESCRIPTION
Fixes #736