### PR TITLE
fix: Fix pytest hanging

### DIFF
--- a/guppylang/checker/core.py
+++ b/guppylang/checker/core.py
@@ -2,7 +2,7 @@ import ast
 import copy
 import itertools
 from collections.abc import Iterable, Iterator
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from functools import cached_property
 from typing import (
     TYPE_CHECKING,
@@ -225,7 +225,7 @@ class Globals:
 
     names: dict[str, DefId]
     impls: dict[DefId, dict[str, DefId]]
-    python_scope: PyScope
+    python_scope: PyScope = field(repr=False)
 
     @staticmethod
     def default() -> "Globals":

--- a/guppylang/definition/declaration.py
+++ b/guppylang/definition/declaration.py
@@ -43,7 +43,7 @@ class RawFunctionDecl(ParsableDef):
     """
 
     python_func: PyFunc
-    python_scope: PyScope
+    python_scope: PyScope = field(repr=False)
     description: str = field(default="function", init=False)
 
     def parse(self, globals: Globals, sources: SourceMap) -> "CheckedFunctionDecl":

--- a/guppylang/definition/function.py
+++ b/guppylang/definition/function.py
@@ -58,7 +58,7 @@ class RawFunctionDef(ParsableDef):
     """
 
     python_func: PyFunc
-    python_scope: PyScope
+    python_scope: PyScope = field(repr=False)
 
     description: str = field(default="function", init=False)
 
@@ -92,7 +92,7 @@ class ParsedFunctionDef(CheckableDef, CallableDef):
         docstring: The docstring of the function.
     """
 
-    python_scope: PyScope
+    python_scope: PyScope = field(repr=False)
     defined_at: ast.FunctionDef
     ty: FunctionType
     docstring: str | None

--- a/guppylang/definition/pytket_circuits.py
+++ b/guppylang/definition/pytket_circuits.py
@@ -56,7 +56,7 @@ class RawPytketDef(ParsableDef):
     """
 
     python_func: PyFunc
-    python_scope: PyScope
+    python_scope: PyScope = field(repr=False)
     input_circuit: Any
 
     description: str = field(default="pytket circuit", init=False)

--- a/guppylang/definition/struct.py
+++ b/guppylang/definition/struct.py
@@ -2,7 +2,7 @@ import ast
 import inspect
 import textwrap
 from collections.abc import Sequence
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from typing import Any, ClassVar
 
 from hugr import Wire, ops
@@ -89,7 +89,7 @@ class RawStructDef(TypeDef, ParsableDef):
     """A raw struct type definition that has not been parsed yet."""
 
     python_class: type
-    python_scope: PyScope
+    python_scope: PyScope = field(repr=False)
 
     def __getitem__(self, item: Any) -> "RawStructDef":
         """Dummy implementation to enable subscripting in the Python runtime.
@@ -177,7 +177,7 @@ class ParsedStructDef(TypeDef, CheckableDef):
     defined_at: ast.ClassDef
     params: Sequence[Parameter]
     fields: Sequence[UncheckedStructField]
-    python_scope: PyScope
+    python_scope: PyScope = field(repr=False)
 
     def check(self, globals: Globals) -> "CheckedStructDef":
         """Checks that all struct fields have valid types."""
@@ -360,5 +360,5 @@ def check_not_recursive(
         defn.id: DummyStructDef(defn.id, defn.name, defn.defined_at),
     }
     dummy_globals = replace(globals, defs=globals.defs | dummy_defs)
-    for field in defn.fields:
-        type_from_ast(field.type_ast, dummy_globals, param_var_mapping)
+    for fld in defn.fields:
+        type_from_ast(fld.type_ast, dummy_globals, param_var_mapping)

--- a/tests/test_pytest_hang.py
+++ b/tests/test_pytest_hang.py
@@ -1,0 +1,19 @@
+import pytest
+
+from guppylang import GuppyModule, guppy
+
+
+@pytest.mark.xfail
+def test_hand(validate):
+    """Regression test ensuring that pytest terminates, even if the Guppy compiler
+    throws an error.
+
+    See https://github.com/CQCL/guppylang/issues/569
+    """
+    module = GuppyModule("test")
+
+    @guppy(module)
+    def test() -> int:
+        return a  # Intentional use of an undefined variable
+
+    validate(module.compile())


### PR DESCRIPTION
Fixes #569.

Ensure termination of `repr` calls on objects in the compiler by excluding `python_scope` fields due to cyclic references.

See https://github.com/CQCL/guppylang/issues/569#issuecomment-2573157994 for a more detailed description of how this fixes the pytest issue.