### PR TITLE
refactor: Use non-copyable / non-droppable instead of linear in error messages

### DIFF
--- a/examples/demo.ipynb
+++ b/examples/demo.ipynb
@@ -307,13 +307,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Error: Linearity violation (at <In [9]>:6:10)\n",
+      "Error: Copy violation (at <In [9]>:6:10)\n",
       "  | \n",
       "4 | @guppy(bad_module)\n",
       "5 | def bad(q: qubit @owned) -> qubit:\n",
       "6 |     cx(q, q)\n",
-      "  |           ^ Variable `q` with linear type `qubit` cannot be borrowed\n",
-      "  |             ...\n",
+      "  |           ^ Variable `q` with non-copyable type `qubit` cannot be\n",
+      "  |             borrowed ...\n",
       "  | \n",
       "6 |     cx(q, q)\n",
       "  |        - since it was already borrowed here\n",
@@ -356,12 +356,12 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Error: Linearity violation (at <In [10]>:6:4)\n",
+      "Error: Drop violation (at <In [10]>:6:4)\n",
       "  | \n",
       "4 | @guppy(bad_module)\n",
       "5 | def bad(q: qubit @owned) -> qubit:\n",
       "6 |     tmp = qubit()\n",
-      "  |     ^^^ Variable `tmp` with linear type `qubit` is leaked\n",
+      "  |     ^^^ Variable `tmp` with non-droppable type `qubit` is leaked\n",
       "\n",
       "Help: Make sure that `tmp` is consumed or returned to avoid the leak\n",
       "\n",
@@ -584,7 +584,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.5"
+   "version": "3.12.6"
   }
  },
  "nbformat": 4,

--- a/guppylang/checker/errors/linearity.py
+++ b/guppylang/checker/errors/linearity.py
@@ -22,10 +22,10 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class AlreadyUsedError(Error):
-    title: ClassVar[str] = "Linearity violation"
+    title: ClassVar[str] = "Copy violation"
     span_label: ClassVar[str] = (
-        "{place.describe} with {place.ty.ownership_kind} type `{place.ty}` "
-        "cannot be {kind.subjunctive} ..."
+        "{place.describe} with non-copyable type `{place.ty}` cannot be "
+        "{kind.subjunctive} ..."
     )
     place: Place
     kind: UseKind
@@ -38,9 +38,9 @@ class AlreadyUsedError(Error):
 
 @dataclass(frozen=True)
 class ComprAlreadyUsedError(Error):
-    title: ClassVar[str] = "Linearity violation"
+    title: ClassVar[str] = "Copy violation"
     span_label: ClassVar[str] = (
-        "{place.describe} with {place.ty.ownership_kind} type `{place.ty}` would be "
+        "{place.describe} with non-copyable type `{place.ty}` would be "
         "{kind.subjunctive} multiple times when evaluating this comprehension"
     )
     place: Place
@@ -54,12 +54,12 @@ class ComprAlreadyUsedError(Error):
 
 @dataclass(frozen=True)
 class PlaceNotUsedError(Error):
-    title: ClassVar[str] = "Linearity violation"
+    title: ClassVar[str] = "Drop violation"
     place: Place
 
     @property
     def rendered_span_label(self) -> str:
-        s = f"{self.place.describe} with linear type `{self.place.ty}` "
+        s = f"{self.place.describe} with non-droppable type `{self.place.ty}` "
         match self.children:
             case [PlaceNotUsedError.Branch(), *_]:
                 return s + "may be leaked ..."
@@ -80,8 +80,8 @@ class PlaceNotUsedError(Error):
 
 @dataclass(frozen=True)
 class UnnamedExprNotUsedError(Error):
-    title: ClassVar[str] = "Linearity violation"
-    span_label: ClassVar[str] = "Expression with linear type `{ty}` is leaked"
+    title: ClassVar[str] = "Drop violation"
+    span_label: ClassVar[str] = "Expression with non-droppable type `{ty}` is leaked"
     ty: Type
 
     @dataclass(frozen=True)
@@ -91,9 +91,10 @@ class UnnamedExprNotUsedError(Error):
 
 @dataclass(frozen=True)
 class UnnamedFieldNotUsedError(Error):
-    title: ClassVar[str] = "Linearity violation"
+    title: ClassVar[str] = "Drop violation"
     span_label: ClassVar[str] = (
-        "Linear field `{field.name}` of expression with type `{struct_ty}` is leaked"
+        "Non-droppable field `{field.name}` of expression with type `{struct_ty}` is "
+        "leaked"
     )
     field: StructField
     struct_ty: StructType
@@ -109,9 +110,9 @@ class UnnamedFieldNotUsedError(Error):
 
 @dataclass(frozen=True)
 class UnnamedSubscriptNotUsedError(Error):
-    title: ClassVar[str] = "Linearity violation"
+    title: ClassVar[str] = "Drop violation"
     span_label: ClassVar[str] = (
-        "Linear items of expression with type `{container_ty}` are leaked ..."
+        "Non-droppable items of expression with type `{container_ty}` are leaked ..."
     )
     container_ty: Type
 
@@ -160,8 +161,8 @@ class NotOwnedError(Error):
 class MoveOutOfSubscriptError(Error):
     title: ClassVar[str] = "Subscript {kind.subjunctive}"
     span_label: ClassVar[str] = (
-        "Cannot {kind.indicative} a subscript of `{parent}` with "
-        "{parent.ty.ownership_kind} type `{parent.ty}`"
+        "Cannot {kind.indicative} a subscript of `{parent}` with non-copyable type "
+        "`{parent.ty}`"
     )
     kind: UseKind
     parent: Place
@@ -169,8 +170,8 @@ class MoveOutOfSubscriptError(Error):
     @dataclass(frozen=True)
     class Explanation(Note):
         message: ClassVar[str] = (
-            "Subscripts on {parent.ty.ownership_kind} types are only allowed to be "
-            "borrowed, not {kind.subjunctive}"
+            "Subscripts on non-copyable types are only allowed to be borrowed not "
+            "{kind.subjunctive}"
         )
 
 
@@ -187,7 +188,7 @@ class BorrowShadowedError(Error):
 
 @dataclass(frozen=True)
 class BorrowSubPlaceUsedError(Error):
-    title: ClassVar[str] = "Linearity violation"
+    title: ClassVar[str] = "Copy violation"
     span_label: ClassVar[str] = (
         "Borrowed argument {borrowed_var} cannot be returned to the caller ..."
     )
@@ -197,7 +198,7 @@ class BorrowSubPlaceUsedError(Error):
     @dataclass(frozen=True)
     class PrevUse(Note):
         span_label: ClassVar[str] = (
-            "since `{sub_place}` with linear type `{sub_place.ty}` was already "
+            "since `{sub_place}` with non-copyable type `{sub_place.ty}` was already "
             "{kind.subjunctive} here"
         )
         kind: UseKind
@@ -211,9 +212,9 @@ class BorrowSubPlaceUsedError(Error):
 
 @dataclass(frozen=True)
 class DropAfterCallError(Error):
-    title: ClassVar[str] = "Linearity violation"
+    title: ClassVar[str] = "Drop violation"
     span_label: ClassVar[str] = (
-        "Value with linear type `{ty}` would be leaked after {func} returns"
+        "Value with non-droppable type `{ty}` would be leaked after {func} returns"
     )
     ty: Type
     func_name: str | None
@@ -232,10 +233,10 @@ class DropAfterCallError(Error):
 
 @dataclass(frozen=True)
 class NonCopyableCaptureError(Error):
-    title: ClassVar[str] = "Linearity violation"
+    title: ClassVar[str] = "Copy violation"
     span_label: ClassVar[str] = (
-        "{var.describe} with linear type {var.ty} cannot be used here since `{var}` is "
-        "captured from an outer scope"
+        "{var.describe} with non-copyable type {var.ty} cannot be used here since "
+        "`{var}` is captured from an outer scope"
     )
     var: Variable
 
@@ -246,25 +247,26 @@ class NonCopyableCaptureError(Error):
 
 @dataclass(frozen=True)
 class NonCopyablePartialApplyError(Error):
-    title: ClassVar[str] = "Linearity violation"
+    title: ClassVar[str] = "Copy violation"
     span_label: ClassVar[str] = (
-        "This expression implicitly constructs a closure that captures a linear value"
+        "This expression implicitly constructs a closure that captures a non-copyable "
+        "value"
     )
 
     @dataclass(frozen=True)
     class Captured(Note):
         span_label: ClassVar[str] = (
-            "This expression with linear type `{ty}` is implicitly captured"
+            "This expression with non-copyable type `{ty}` is implicitly captured"
         )
         ty: Type
 
 
 @dataclass(frozen=True)
 class NonDroppableForBreakError(Error):
-    title: ClassVar[str] = "Break in linear loop"
-    span_label: ClassVar[str] = "Early exit in linear loops is not allowed"
+    title: ClassVar[str] = "Break in non-droppable loop"
+    span_label: ClassVar[str] = "Early exit in non-droppable loops is not allowed"
 
     @dataclass(frozen=True)
     class NonDroppableIteratorType(Note):
-        span_label: ClassVar[str] = "Iterator has linear type `{ty}`"
+        span_label: ClassVar[str] = "Iterator has non-droppable type `{ty}`"
         ty: Type

--- a/guppylang/checker/errors/linearity.py
+++ b/guppylang/checker/errors/linearity.py
@@ -170,7 +170,7 @@ class MoveOutOfSubscriptError(Error):
     @dataclass(frozen=True)
     class Explanation(Note):
         message: ClassVar[str] = (
-            "Subscripts on non-copyable types are only allowed to be borrowed not "
+            "Subscripts on non-copyable types are only allowed to be borrowed, not "
             "{kind.subjunctive}"
         )
 

--- a/guppylang/tys/ty.py
+++ b/guppylang/tys/ty.py
@@ -49,14 +49,6 @@ class TypeBase(ToHugr[ht.Type], Transformable["Type"], ABC):
         """Whether this type should be treated in an affine way."""
         return not self.copyable and self.droppable
 
-    @property
-    def ownership_kind(self) -> str:
-        if self.linear:
-            return "linear"
-        if self.affine:
-            return "affine"
-        return "classical"
-
     @cached_property
     @abstractmethod
     def hugr_bound(self) -> ht.TypeBound:

--- a/tests/error/array_errors/subscript_after_use.err
+++ b/tests/error/array_errors/subscript_after_use.err
@@ -1,10 +1,10 @@
-Error: Linearity violation (at $FILE:18:19)
+Error: Copy violation (at $FILE:18:19)
    | 
 16 | @guppy(module)
 17 | def main(qs: array[qubit, 42] @owned) -> array[qubit, 42]:
 18 |     return foo(qs, qs[0])
-   |                    ^^ Variable `qs` with linear type `array[qubit, 42]` cannot be
-   |                       borrowed ...
+   |                    ^^ Variable `qs` with non-copyable type `array[qubit, 42]`
+   |                       cannot be borrowed ...
    | 
 18 |     return foo(qs, qs[0])
    |                -- since it was already consumed here

--- a/tests/error/array_errors/subscript_drop.err
+++ b/tests/error/array_errors/subscript_drop.err
@@ -1,10 +1,10 @@
-Error: Linearity violation (at $FILE:18:11)
+Error: Drop violation (at $FILE:18:11)
    | 
 16 | @guppy(module)
 17 | def main() -> qubit:
 18 |     return foo()[0]
-   |            ^^^^^ Linear items of expression with type `array[qubit, 10]` are
-   |                  leaked ...
+   |            ^^^^^ Non-droppable items of expression with type `array[qubit,
+   |                  10]` are leaked ...
    | 
 18 |     return foo()[0]
    |                  - since only this subscript is used

--- a/tests/error/array_errors/subscript_non_inout.err
+++ b/tests/error/array_errors/subscript_non_inout.err
@@ -3,9 +3,9 @@ Error: Subscript moved (at $FILE:14:8)
 12 | @guppy(module)
 13 | def main(qs: array[qubit, 42]) -> tuple[qubit, array[qubit, 42]]:
 14 |     q = qs[0]
-   |         ^^^^^ Cannot move a subscript of `qs` with linear type
+   |         ^^^^^ Cannot move a subscript of `qs` with non-copyable type
    |               `array[qubit, 42]`
 
-Note: Subscripts on linear types are only allowed to be borrowed, not moved
+Note: Subscripts on non-copyable types are only allowed to be borrowed not moved
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/array_errors/subscript_non_inout.err
+++ b/tests/error/array_errors/subscript_non_inout.err
@@ -6,6 +6,7 @@ Error: Subscript moved (at $FILE:14:8)
    |         ^^^^^ Cannot move a subscript of `qs` with non-copyable type
    |               `array[qubit, 42]`
 
-Note: Subscripts on non-copyable types are only allowed to be borrowed not moved
+Note: Subscripts on non-copyable types are only allowed to be borrowed, not
+moved
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/array_errors/use_after_implicit_copy.err
+++ b/tests/error/array_errors/use_after_implicit_copy.err
@@ -1,10 +1,10 @@
-Error: Linearity violation (at $FILE:11:10)
+Error: Copy violation (at $FILE:11:10)
    | 
  9 | def main(xs: array[int, 2] @ owned) -> array[int, 2]:
 10 |    ys = xs
 11 |    return xs
-   |           ^^ Variable `xs` with affine type `array[int, 2]` cannot be
-   |              returned ...
+   |           ^^ Variable `xs` with non-copyable type `array[int, 2]` cannot
+   |              be returned ...
    | 
 10 |    ys = xs
    |         -- since it was already moved here

--- a/tests/error/array_errors/use_after_subscript.err
+++ b/tests/error/array_errors/use_after_subscript.err
@@ -1,10 +1,10 @@
-Error: Linearity violation (at $FILE:18:15)
+Error: Copy violation (at $FILE:18:15)
    | 
 16 | @guppy(module)
 17 | def main(qs: array[qubit, 42] @owned) -> array[qubit, 42]:
 18 |     return foo(qs[0], qs)
-   |                ^^^^^ Variable `qs` with linear type `array[qubit, 42]` cannot be
-   |                      borrowed ...
+   |                ^^^^^ Variable `qs` with non-copyable type `array[qubit, 42]`
+   |                      cannot be borrowed ...
    | 
 18 |     return foo(qs[0], qs)
    |                       -- since it was already consumed here

--- a/tests/error/comprehension_errors/borrow_after_consume.err
+++ b/tests/error/comprehension_errors/borrow_after_consume.err
@@ -1,10 +1,10 @@
-Error: Linearity violation (at $FILE:21:16)
+Error: Copy violation (at $FILE:21:16)
    | 
 19 | @guppy(module)
 20 | def foo(qs: list[qubit] @owned) -> list[int]:
 21 |     return [baz(q) for q in qs if bar(q)]
-   |                 ^ Variable `q` with linear type `qubit` cannot be borrowed
-   |                   ...
+   |                 ^ Variable `q` with non-copyable type `qubit` cannot be
+   |                   borrowed ...
    | 
 21 |     return [baz(q) for q in qs if bar(q)]
    |                                       - since it was already consumed here

--- a/tests/error/comprehension_errors/borrow_leaked1.err
+++ b/tests/error/comprehension_errors/borrow_leaked1.err
@@ -1,9 +1,9 @@
-Error: Linearity violation (at $FILE:17:16)
+Error: Drop violation (at $FILE:17:16)
    | 
 15 | @guppy(module)
 16 | def foo(n: int, q: qubit @owned) -> list[int]:
 17 |     return [bar(q) for _ in range(n)]
-   |                 ^ Variable `q` with linear type `qubit` is leaked
+   |                 ^ Variable `q` with non-droppable type `qubit` is leaked
 
 Help: Make sure that `q` is consumed or returned to avoid the leak
 

--- a/tests/error/comprehension_errors/borrow_leaked2.err
+++ b/tests/error/comprehension_errors/borrow_leaked2.err
@@ -1,8 +1,8 @@
-Error: Linearity violation (at $FILE:17:23)
+Error: Drop violation (at $FILE:17:23)
    | 
 15 | @guppy(module)
 16 | def foo(qs: list[qubit] @owned) -> list[int]:
 17 |     return [bar(q) for q in qs]
-   |                        ^ Variable `q` with linear type `qubit` is leaked
+   |                        ^ Variable `q` with non-droppable type `qubit` is leaked
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/comprehension_errors/borrow_leaked3.err
+++ b/tests/error/comprehension_errors/borrow_leaked3.err
@@ -1,9 +1,10 @@
-Error: Linearity violation (at $FILE:17:18)
+Error: Drop violation (at $FILE:17:18)
    | 
 15 | @guppy(module)
 16 | def foo(qs: list[qubit] @owned) -> list[int]:
 17 |     return [0 for q in qs if bar(q)]
-   |                   ^ Variable `q` with linear type `qubit` may be leaked ...
+   |                   ^ Variable `q` with non-droppable type `qubit` may be leaked
+   |                     ...
    | 
 17 |     return [0 for q in qs if bar(q)]
    |                              ------ if this expression is `False`

--- a/tests/error/comprehension_errors/borrow_leaked4.err
+++ b/tests/error/comprehension_errors/borrow_leaked4.err
@@ -1,8 +1,8 @@
-Error: Linearity violation (at $FILE:17:18)
+Error: Drop violation (at $FILE:17:18)
    | 
 15 | @guppy(module)
 16 | def foo(qs: list[qubit] @owned) -> list[qubit]:
 17 |     return [r for q in qs for r in bar(q)]
-   |                   ^ Variable `q` with linear type `qubit` is leaked
+   |                   ^ Variable `q` with non-droppable type `qubit` is leaked
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/comprehension_errors/capture1.err
+++ b/tests/error/comprehension_errors/capture1.err
@@ -1,9 +1,9 @@
-Error: Linearity violation (at $FILE:13:12)
+Error: Copy violation (at $FILE:13:12)
    | 
 11 | @guppy(module)
 12 | def foo(xs: list[int], q: qubit @owned) -> list[qubit]:
 13 |     return [q for x in xs]
-   |             ^ Variable `q` with linear type `qubit` would be moved
+   |             ^ Variable `q` with non-copyable type `qubit` would be moved
    |               multiple times when evaluating this
    |               comprehension
 

--- a/tests/error/comprehension_errors/capture2.err
+++ b/tests/error/comprehension_errors/capture2.err
@@ -1,11 +1,11 @@
-Error: Linearity violation (at $FILE:18:33)
+Error: Copy violation (at $FILE:18:33)
    | 
 16 | @guppy(module)
 17 | def foo(xs: list[int], q: qubit @owned) -> list[int]:
 18 |     return [x for x in xs if bar(q)]
-   |                                  ^ Variable `q` with linear type `qubit` would be consumed
-   |                                    multiple times when
-   |                                    evaluating this
+   |                                  ^ Variable `q` with non-copyable type `qubit` would be
+   |                                    consumed multiple times
+   |                                    when evaluating this
    |                                    comprehension
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/comprehension_errors/capture3.err
+++ b/tests/error/comprehension_errors/capture3.err
@@ -1,9 +1,9 @@
-Error: Linearity violation (at $FILE:18:12)
+Error: Copy violation (at $FILE:18:12)
    | 
 16 | @guppy(module)
 17 | def foo(xs: list[int], s: MyStruct @owned) -> list[MyStruct]:
 18 |     return [s for x in xs]
-   |             ^ Field `s.q` with linear type `qubit` would be moved
+   |             ^ Field `s.q` with non-copyable type `qubit` would be moved
    |               multiple times when evaluating this
    |               comprehension
 

--- a/tests/error/comprehension_errors/capture4.err
+++ b/tests/error/comprehension_errors/capture4.err
@@ -1,9 +1,9 @@
-Error: Linearity violation (at $FILE:18:12)
+Error: Copy violation (at $FILE:18:12)
    | 
 16 | @guppy(module)
 17 | def foo(xs: list[int], s: MyStruct @owned) -> list[qubit]:
 18 |     return [s.q for x in xs]
-   |             ^^^ Field `s.q` with linear type `qubit` would be moved
+   |             ^^^ Field `s.q` with non-copyable type `qubit` would be moved
    |                 multiple times when evaluating this
    |                 comprehension
 

--- a/tests/error/comprehension_errors/guarded1.err
+++ b/tests/error/comprehension_errors/guarded1.err
@@ -1,9 +1,10 @@
-Error: Linearity violation (at $FILE:13:21)
+Error: Drop violation (at $FILE:13:21)
    | 
 11 | @guppy(module)
 12 | def foo(qs: list[tuple[bool, qubit]] @owned) -> list[qubit]:
 13 |     return [q for b, q in qs if b]
-   |                      ^ Variable `q` with linear type `qubit` may be leaked ...
+   |                      ^ Variable `q` with non-droppable type `qubit` may be leaked
+   |                        ...
    | 
 13 |     return [q for b, q in qs if b]
    |                                 - if this expression is `False`

--- a/tests/error/comprehension_errors/guarded2.err
+++ b/tests/error/comprehension_errors/guarded2.err
@@ -1,9 +1,10 @@
-Error: Linearity violation (at $FILE:18:22)
+Error: Drop violation (at $FILE:18:22)
    | 
 16 | @guppy(module)
 17 | def foo(qs: list[tuple[bool, qubit]] @owned) -> list[int]:
 18 |     return [42 for b, q in qs if b if bar(q)]
-   |                       ^ Variable `q` with linear type `qubit` may be leaked ...
+   |                       ^ Variable `q` with non-droppable type `qubit` may be leaked
+   |                         ...
    | 
 18 |     return [42 for b, q in qs if b if bar(q)]
    |                                  - if this expression is `False`

--- a/tests/error/comprehension_errors/guarded3.err
+++ b/tests/error/comprehension_errors/guarded3.err
@@ -1,9 +1,10 @@
-Error: Linearity violation (at $FILE:24:21)
+Error: Drop violation (at $FILE:24:21)
    | 
 22 | @guppy(module)
 23 | def foo(qs: list[MyStruct] @owned) -> list[qubit]:
 24 |     return [s.q2 for s in qs if bar(s.q1)]
-   |                      ^ Field `s.q2` with linear type `qubit` may be leaked ...
+   |                      ^ Field `s.q2` with non-droppable type `qubit` may be leaked
+   |                        ...
    | 
 24 |     return [s.q2 for s in qs if bar(s.q1)]
    |                                 --------- if this expression is `False`

--- a/tests/error/comprehension_errors/multi_use1.err
+++ b/tests/error/comprehension_errors/multi_use1.err
@@ -1,9 +1,9 @@
-Error: Linearity violation (at $FILE:13:12)
+Error: Copy violation (at $FILE:13:12)
    | 
 11 | @guppy(module)
 12 | def foo(qs: list[qubit] @owned, xs: list[int]) -> list[qubit]:
 13 |     return [q for q in qs for x in xs]
-   |             ^ Variable `q` with linear type `qubit` would be moved
+   |             ^ Variable `q` with non-copyable type `qubit` would be moved
    |               multiple times when evaluating this
    |               comprehension
 

--- a/tests/error/comprehension_errors/multi_use2.err
+++ b/tests/error/comprehension_errors/multi_use2.err
@@ -1,9 +1,9 @@
-Error: Linearity violation (at $FILE:13:35)
+Error: Copy violation (at $FILE:13:35)
    | 
 11 | @guppy(module)
 12 | def foo(qs: list[qubit] @owned, xs: list[int]) -> list[qubit]:
 13 |     return [q for x in xs for q in qs]
-   |                                    ^^ Variable `qs` with linear type `list[qubit]` would be
+   |                                    ^^ Variable `qs` with non-copyable type `list[qubit]` would be
    |                                       consumed multiple
    |                                       times when evaluating
    |                                       this comprehension

--- a/tests/error/comprehension_errors/multi_use3.err
+++ b/tests/error/comprehension_errors/multi_use3.err
@@ -1,9 +1,10 @@
-Error: Linearity violation (at $FILE:18:45)
+Error: Copy violation (at $FILE:18:45)
    | 
 16 | @guppy(module)
 17 | def foo(qs: list[qubit] @owned, xs: list[int]) -> list[int]:
 18 |     return [x for q in qs for x in xs if bar(q)]
-   |                                              ^ Variable `q` with linear type `qubit` would be consumed
+   |                                              ^ Variable `q` with non-copyable type `qubit` would be
+   |                                                consumed
    |                                                multiple
    |                                                times when
    |                                                evaluating

--- a/tests/error/comprehension_errors/not_used1.err
+++ b/tests/error/comprehension_errors/not_used1.err
@@ -1,8 +1,8 @@
-Error: Linearity violation (at $FILE:13:19)
+Error: Drop violation (at $FILE:13:19)
    | 
 11 | @guppy(module)
 12 | def foo(qs: list[qubit] @owned) -> list[int]:
 13 |     return [42 for q in qs]
-   |                    ^ Variable `q` with linear type `qubit` is leaked
+   |                    ^ Variable `q` with non-droppable type `qubit` is leaked
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/comprehension_errors/not_used2.err
+++ b/tests/error/comprehension_errors/not_used2.err
@@ -1,8 +1,8 @@
-Error: Linearity violation (at $FILE:19:21)
+Error: Drop violation (at $FILE:19:21)
    | 
 17 | @guppy(module)
 18 | def foo(ss: list[MyStruct] @owned) -> list[qubit]:
 19 |     return [s.q1 for s in ss]
-   |                      ^ Field `s.q2` with linear type `qubit` is leaked
+   |                      ^ Field `s.q2` with non-droppable type `qubit` is leaked
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/comprehension_errors/pattern_override1.err
+++ b/tests/error/comprehension_errors/pattern_override1.err
@@ -1,9 +1,9 @@
-Error: Linearity violation (at $FILE:13:18)
+Error: Drop violation (at $FILE:13:18)
    | 
 11 | @guppy(module)
 12 | def foo(qs: list[tuple[qubit, qubit]] @owned) -> list[qubit]:
 13 |     return [q for q, q in qs]
-   |                   ^ Variable `q` with linear type `qubit` is leaked
+   |                   ^ Variable `q` with non-droppable type `qubit` is leaked
 
 Help: Make sure that `q` is consumed or returned to avoid the leak
 

--- a/tests/error/comprehension_errors/pattern_override2.err
+++ b/tests/error/comprehension_errors/pattern_override2.err
@@ -1,8 +1,8 @@
-Error: Linearity violation (at $FILE:13:18)
+Error: Drop violation (at $FILE:13:18)
    | 
 11 | @guppy(module)
 12 | def foo(qs: list[qubit] @owned, xs: list[int]) -> list[int]:
 13 |     return [q for q in qs for q in xs]
-   |                   ^ Variable `q` with linear type `qubit` is leaked
+   |                   ^ Variable `q` with non-droppable type `qubit` is leaked
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/comprehension_errors/used_twice1.err
+++ b/tests/error/comprehension_errors/used_twice1.err
@@ -1,9 +1,10 @@
-Error: Linearity violation (at $FILE:13:16)
+Error: Copy violation (at $FILE:13:16)
    | 
 11 | @guppy(module)
 12 | def foo(qs: list[qubit] @owned) -> list[tuple[qubit, qubit]]:
 13 |     return [(q, q) for q in qs]
-   |                 ^ Variable `q` with linear type `qubit` cannot be moved ...
+   |                 ^ Variable `q` with non-copyable type `qubit` cannot be moved
+   |                   ...
    | 
 13 |     return [(q, q) for q in qs]
    |              - since it was already moved here

--- a/tests/error/comprehension_errors/used_twice2.err
+++ b/tests/error/comprehension_errors/used_twice2.err
@@ -1,9 +1,10 @@
-Error: Linearity violation (at $FILE:18:12)
+Error: Copy violation (at $FILE:18:12)
    | 
 16 | @guppy(module)
 17 | def foo(qs: list[qubit] @owned) -> list[qubit]:
 18 |     return [q for q in qs if bar(q)]
-   |             ^ Variable `q` with linear type `qubit` cannot be moved ...
+   |             ^ Variable `q` with non-copyable type `qubit` cannot be moved
+   |               ...
    | 
 18 |     return [q for q in qs if bar(q)]
    |                                  - since it was already consumed here

--- a/tests/error/comprehension_errors/used_twice3.err
+++ b/tests/error/comprehension_errors/used_twice3.err
@@ -1,9 +1,10 @@
-Error: Linearity violation (at $FILE:18:12)
+Error: Copy violation (at $FILE:18:12)
    | 
 16 | @guppy(module)
 17 | def foo(qs: list[qubit] @owned) -> list[qubit]:
 18 |     return [q for q in qs for x in bar(q)]
-   |             ^ Variable `q` with linear type `qubit` cannot be moved ...
+   |             ^ Variable `q` with non-copyable type `qubit` cannot be moved
+   |               ...
    | 
 18 |     return [q for q in qs for x in bar(q)]
    |                                        - since it was already consumed here

--- a/tests/error/inout_errors/already_used.err
+++ b/tests/error/inout_errors/already_used.err
@@ -1,10 +1,10 @@
-Error: Linearity violation (at $FILE:21:8)
+Error: Copy violation (at $FILE:21:8)
    | 
 19 | def test(q: qubit @owned) -> None:
 20 |     use(q)
 21 |     foo(q)
-   |         ^ Variable `q` with linear type `qubit` cannot be borrowed
-   |           ...
+   |         ^ Variable `q` with non-copyable type `qubit` cannot be
+   |           borrowed ...
    | 
 20 |     use(q)
    |         - since it was already consumed here

--- a/tests/error/inout_errors/drop_after_call.err
+++ b/tests/error/inout_errors/drop_after_call.err
@@ -1,10 +1,10 @@
-Error: Linearity violation (at $FILE:15:7)
+Error: Drop violation (at $FILE:15:7)
    | 
 13 | @guppy(module)
 14 | def test() -> None:
 15 |    foo(qubit())
-   |        ^^^^^^^ Value with linear type `qubit` would be leaked after `foo`
-   |                returns
+   |        ^^^^^^^ Value with non-droppable type `qubit` would be leaked after
+   |                `foo` returns
 
 Help: Consider assigning the value to a local variable before passing it to
 `foo`

--- a/tests/error/inout_errors/moved_out.err
+++ b/tests/error/inout_errors/moved_out.err
@@ -1,4 +1,4 @@
-Error: Linearity violation (at $FILE:20:9)
+Error: Copy violation (at $FILE:20:9)
    | 
 18 | 
 19 | @guppy(module)
@@ -6,8 +6,8 @@ Error: Linearity violation (at $FILE:20:9)
    |          ^^^^^^^^^^^ Borrowed argument s cannot be returned to the caller ...
    | 
 21 |     use(s.q)
-   |         --- since `s.q` with linear type `qubit` was already consumed
-   |             here
+   |         --- since `s.q` with non-copyable type `qubit` was already
+   |             consumed here
 
 Help: Consider writing a value back into `s.q` before returning
 

--- a/tests/error/inout_errors/moved_out_if.err
+++ b/tests/error/inout_errors/moved_out_if.err
@@ -1,4 +1,4 @@
-Error: Linearity violation (at $FILE:20:9)
+Error: Copy violation (at $FILE:20:9)
    | 
 18 | 
 19 | @guppy(module)
@@ -6,8 +6,8 @@ Error: Linearity violation (at $FILE:20:9)
    |          ^^^^^^^^^^^ Borrowed argument s cannot be returned to the caller ...
    | 
 22 |         use(s.q)
-   |             --- since `s.q` with linear type `qubit` was already consumed
-   |                 here
+   |             --- since `s.q` with non-copyable type `qubit` was already
+   |                 consumed here
 
 Help: Consider writing a value back into `s.q` before returning
 

--- a/tests/error/inout_errors/nested_call_right_to_left.err
+++ b/tests/error/inout_errors/nested_call_right_to_left.err
@@ -1,10 +1,10 @@
-Error: Linearity violation (at $FILE:17:22)
+Error: Copy violation (at $FILE:17:22)
    | 
 15 | def test(q: qubit @owned) -> tuple[int, qubit]:
 16 |     # This doesn't work since arguments are evaluated from left to right
 17 |     return foo(q, foo(q, foo(q, 0))), q
-   |                       ^ Variable `q` with linear type `qubit` cannot be borrowed
-   |                         ...
+   |                       ^ Variable `q` with non-copyable type `qubit` cannot be
+   |                         borrowed ...
    | 
 17 |     return foo(q, foo(q, foo(q, 0))), q
    |                - since it was already borrowed here

--- a/tests/error/inout_errors/override_after_call.err
+++ b/tests/error/inout_errors/override_after_call.err
@@ -1,9 +1,9 @@
-Error: Linearity violation (at $FILE:15:9)
+Error: Drop violation (at $FILE:15:9)
    | 
 13 | 
 14 | @guppy(module)
 15 | def test(q1: qubit @owned, q2: qubit @owned) -> tuple[qubit, qubit]:
-   |          ^^^^^^^^^^^^^^^^ Variable `q1` with linear type `qubit` is leaked
+   |          ^^^^^^^^^^^^^^^^ Variable `q1` with non-droppable type `qubit` is leaked
 
 Help: Make sure that `q1` is consumed or returned to avoid the leak
 

--- a/tests/error/inout_errors/unused_after_call.err
+++ b/tests/error/inout_errors/unused_after_call.err
@@ -1,9 +1,9 @@
-Error: Linearity violation (at $FILE:15:9)
+Error: Drop violation (at $FILE:15:9)
    | 
 13 | 
 14 | @guppy(module)
 15 | def test(q: qubit @owned) -> None:
-   |          ^^^^^^^^^^^^^^^ Variable `q` with linear type `qubit` is leaked
+   |          ^^^^^^^^^^^^^^^ Variable `q` with non-droppable type `qubit` is leaked
 
 Help: Make sure that `q` is consumed or returned to avoid the leak
 

--- a/tests/error/linear_errors/branch_use.err
+++ b/tests/error/linear_errors/branch_use.err
@@ -1,9 +1,10 @@
-Error: Linearity violation (at $FILE:24:4)
+Error: Drop violation (at $FILE:24:4)
    | 
 22 | @guppy(module)
 23 | def foo(b: bool) -> bool:
 24 |     q = new_qubit()
-   |     ^ Variable `q` with linear type `qubit` may be leaked ...
+   |     ^ Variable `q` with non-droppable type `qubit` may be leaked
+   |       ...
    | 
 25 |     if b:
    |        - if this expression is `False`

--- a/tests/error/linear_errors/branch_use_field1.err
+++ b/tests/error/linear_errors/branch_use_field1.err
@@ -1,9 +1,10 @@
-Error: Linearity violation (at $FILE:18:4)
+Error: Drop violation (at $FILE:18:4)
    | 
 16 | @guppy(module)
 17 | def foo(b: bool) -> bool:
 18 |     s = MyStruct(qubit())
-   |     ^ Field `s.q` with linear type `qubit` may be leaked ...
+   |     ^ Field `s.q` with non-droppable type `qubit` may be leaked
+   |       ...
    | 
 19 |     if b:
    |        - if this expression is `False`

--- a/tests/error/linear_errors/branch_use_field2.err
+++ b/tests/error/linear_errors/branch_use_field2.err
@@ -1,10 +1,10 @@
-Error: Linearity violation (at $FILE:22:11)
+Error: Copy violation (at $FILE:22:11)
    | 
 20 |     if b:
 21 |         measure(s.q2)
 22 |     return s
-   |            ^ Field `s.q2` with linear type `qubit` cannot be returned
-   |              ...
+   |            ^ Field `s.q2` with non-copyable type `qubit` cannot be
+   |              returned ...
    | 
 21 |         measure(s.q2)
    |                 ---- since it was already consumed here

--- a/tests/error/linear_errors/break_unused.err
+++ b/tests/error/linear_errors/break_unused.err
@@ -1,9 +1,10 @@
-Error: Linearity violation (at $FILE:26:8)
+Error: Drop violation (at $FILE:26:8)
    | 
 24 |     b = False
 25 |     while True:
 26 |         q = new_qubit()
-   |         ^ Variable `q` with linear type `qubit` may be leaked ...
+   |         ^ Variable `q` with non-droppable type `qubit` may be leaked
+   |           ...
    | 
 27 |         if i == 0:
    |            ------ if this expression is `True`

--- a/tests/error/linear_errors/call_drop_field.err
+++ b/tests/error/linear_errors/call_drop_field.err
@@ -1,10 +1,10 @@
-Error: Linearity violation (at $FILE:24:11)
+Error: Drop violation (at $FILE:24:11)
    | 
 22 | @guppy(module)
 23 | def bar() -> qubit:
 24 |     return foo().q1
-   |            ^^^^^ Linear field `q2` of expression with type `MyStruct` is
-   |                  leaked
+   |            ^^^^^ Non-droppable field `q2` of expression with type `MyStruct`
+   |                  is leaked
 
 Help: Consider assigning this value to a local variable before accessing the
 field `q1`

--- a/tests/error/linear_errors/continue_unused.err
+++ b/tests/error/linear_errors/continue_unused.err
@@ -1,9 +1,10 @@
-Error: Linearity violation (at $FILE:26:8)
+Error: Drop violation (at $FILE:26:8)
    | 
 24 |     b = False
 25 |     while i > 0:
 26 |         q = new_qubit()
-   |         ^ Variable `q` with linear type `qubit` may be leaked ...
+   |         ^ Variable `q` with non-droppable type `qubit` may be leaked
+   |           ...
    | 
 27 |         if i % 10 == 0:
    |            ----------- if this expression is `True`

--- a/tests/error/linear_errors/copy_qubit.err
+++ b/tests/error/linear_errors/copy_qubit.err
@@ -1,10 +1,10 @@
-Error: Linearity violation (at $FILE:14:14)
+Error: Copy violation (at $FILE:14:14)
    | 
 12 | @guppy(module)
 13 | def foo(q: qubit @owned) -> tuple[qubit, qubit]:
 14 |     return q, q
-   |               ^ Variable `q` with linear type `qubit` cannot be returned
-   |                 ...
+   |               ^ Variable `q` with non-copyable type `qubit` cannot be
+   |                 returned ...
    | 
 14 |     return q, q
    |            - since it was already returned here

--- a/tests/error/linear_errors/field_copy1.err
+++ b/tests/error/linear_errors/field_copy1.err
@@ -1,9 +1,10 @@
-Error: Linearity violation (at $FILE:20:11)
+Error: Copy violation (at $FILE:20:11)
    | 
 18 | def foo(s: MyStruct @owned) -> tuple[qubit, qubit]:
 19 |     t = s
 20 |     return s.q, t.q
-   |            ^^^ Field `s.q` with linear type `qubit` cannot be returned ...
+   |            ^^^ Field `s.q` with non-copyable type `qubit` cannot be
+   |                returned ...
    | 
 19 |     t = s
    |         - since it was already moved here

--- a/tests/error/linear_errors/field_copy2.err
+++ b/tests/error/linear_errors/field_copy2.err
@@ -1,9 +1,10 @@
-Error: Linearity violation (at $FILE:18:14)
+Error: Copy violation (at $FILE:18:14)
    | 
 16 | @guppy(module)
 17 | def foo(s: MyStruct @owned) -> tuple[MyStruct, qubit]:
 18 |     return s, s.q
-   |               ^^^ Field `s.q` with linear type `qubit` cannot be returned ...
+   |               ^^^ Field `s.q` with non-copyable type `qubit` cannot be
+   |                   returned ...
    | 
 18 |     return s, s.q
    |            - since it was already returned here

--- a/tests/error/linear_errors/field_copy3.err
+++ b/tests/error/linear_errors/field_copy3.err
@@ -1,9 +1,10 @@
-Error: Linearity violation (at $FILE:18:16)
+Error: Copy violation (at $FILE:18:16)
    | 
 16 | @guppy(module)
 17 | def foo(s: MyStruct @owned) -> tuple[qubit, MyStruct]:
 18 |     return s.q, s
-   |                 ^ Field `s.q` with linear type `qubit` cannot be returned ...
+   |                 ^ Field `s.q` with non-copyable type `qubit` cannot be
+   |                   returned ...
    | 
 18 |     return s.q, s
    |            --- since it was already returned here

--- a/tests/error/linear_errors/field_copy_nested1.err
+++ b/tests/error/linear_errors/field_copy_nested1.err
@@ -1,10 +1,10 @@
-Error: Linearity violation (at $FILE:27:11)
+Error: Copy violation (at $FILE:27:11)
    | 
 25 |     measure(s.q)
 26 |     s.q = s.x.q
 27 |     return s
-   |            ^ Field `s.x.q` with linear type `qubit` cannot be returned
-   |              ...
+   |            ^ Field `s.x.q` with non-copyable type `qubit` cannot be
+   |              returned ...
    | 
 26 |     s.q = s.x.q
    |           ----- since it was already moved here

--- a/tests/error/linear_errors/field_copy_nested2.err
+++ b/tests/error/linear_errors/field_copy_nested2.err
@@ -1,10 +1,10 @@
-Error: Linearity violation (at $FILE:26:21)
+Error: Copy violation (at $FILE:26:21)
    | 
 24 | def foo(s: MyStruct1 @owned) -> MyStruct1:
 25 |     measure(s.x.q1)
 26 |     return MyStruct1(s.x)
-   |                      ^^^ Field `s.x.q1` with linear type `qubit` cannot be consumed
-   |                          ...
+   |                      ^^^ Field `s.x.q1` with non-copyable type `qubit` cannot be
+   |                          consumed ...
    | 
 25 |     measure(s.x.q1)
    |             ------ since it was already consumed here

--- a/tests/error/linear_errors/field_copy_nested3.err
+++ b/tests/error/linear_errors/field_copy_nested3.err
@@ -1,10 +1,10 @@
-Error: Linearity violation (at $FILE:29:11)
+Error: Copy violation (at $FILE:29:11)
    | 
 27 | def foo(s: MyStruct1 @owned) -> qubit:
 28 |     use(s.x)
 29 |     return s.x.q
-   |            ^^^^^ Field `s.x.q` with linear type `qubit` cannot be returned
-   |                  ...
+   |            ^^^^^ Field `s.x.q` with non-copyable type `qubit` cannot be
+   |                  returned ...
    | 
 28 |     use(s.x)
    |         --- since it was already consumed here

--- a/tests/error/linear_errors/field_copy_nested4.err
+++ b/tests/error/linear_errors/field_copy_nested4.err
@@ -1,10 +1,10 @@
-Error: Linearity violation (at $FILE:29:11)
+Error: Copy violation (at $FILE:29:11)
    | 
 27 | def foo(s: MyStruct1 @owned) -> MyStruct1:
 28 |     use(s)
 29 |     return s
-   |            ^ Field `s.x.q` with linear type `qubit` cannot be returned
-   |              ...
+   |            ^ Field `s.x.q` with non-copyable type `qubit` cannot be
+   |              returned ...
    | 
 28 |     use(s)
    |         - since it was already consumed here

--- a/tests/error/linear_errors/for_break.err
+++ b/tests/error/linear_errors/for_break.err
@@ -1,11 +1,11 @@
-Error: Break in linear loop (at $FILE:17:12)
+Error: Break in non-droppable loop (at $FILE:17:12)
    | 
 15 |         rs += [q]
 16 |         if b:
 17 |             break
-   |             ^^^^^ Early exit in linear loops is not allowed
+   |             ^^^^^ Early exit in non-droppable loops is not allowed
    | 
 14 |     for q, b in qs:
-   |                 -- Iterator has linear type `list[(qubit, bool)]`
+   |                 -- Iterator has non-droppable type `list[(qubit, bool)]`
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/linear_errors/for_return.err
+++ b/tests/error/linear_errors/for_return.err
@@ -1,11 +1,11 @@
-Error: Break in linear loop (at $FILE:17:12)
+Error: Break in non-droppable loop (at $FILE:17:12)
    | 
 15 |         rs += [q]
 16 |         if b:
 17 |             return []
-   |             ^^^^^^^^^ Early exit in linear loops is not allowed
+   |             ^^^^^^^^^ Early exit in non-droppable loops is not allowed
    | 
 14 |     for q, b in qs:
-   |                 -- Iterator has linear type `list[(qubit, bool)]`
+   |                 -- Iterator has non-droppable type `list[(qubit, bool)]`
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/linear_errors/if_both_unused.err
+++ b/tests/error/linear_errors/if_both_unused.err
@@ -1,9 +1,9 @@
-Error: Linearity violation (at $FILE:19:8)
+Error: Drop violation (at $FILE:19:8)
    | 
 17 | def foo(b: bool) -> int:
 18 |     if b:
 19 |         q = new_qubit()
-   |         ^ Variable `q` with linear type `qubit` is leaked
+   |         ^ Variable `q` with non-droppable type `qubit` is leaked
 
 Help: Make sure that `q` is consumed or returned to avoid the leak
 

--- a/tests/error/linear_errors/if_both_unused_field.err
+++ b/tests/error/linear_errors/if_both_unused_field.err
@@ -1,9 +1,9 @@
-Error: Linearity violation (at $FILE:19:8)
+Error: Drop violation (at $FILE:19:8)
    | 
 17 | def foo(b: bool) -> int:
 18 |     if b:
 19 |         s = MyStruct(qubit())
-   |         ^ Field `s.q` with linear type `qubit` is leaked
+   |         ^ Field `s.q` with non-droppable type `qubit` is leaked
 
 Help: Make sure that `s.q` is consumed or returned to avoid the leak
 

--- a/tests/error/linear_errors/if_both_unused_reassign.err
+++ b/tests/error/linear_errors/if_both_unused_reassign.err
@@ -1,9 +1,9 @@
-Error: Linearity violation (at $FILE:19:8)
+Error: Drop violation (at $FILE:19:8)
    | 
 17 | def foo(b: bool) -> qubit:
 18 |     if b:
 19 |         q = new_qubit()
-   |         ^ Variable `q` with linear type `qubit` is leaked
+   |         ^ Variable `q` with non-droppable type `qubit` is leaked
 
 Help: Make sure that `q` is consumed or returned to avoid the leak
 

--- a/tests/error/linear_errors/if_both_unused_reassign_field.err
+++ b/tests/error/linear_errors/if_both_unused_reassign_field.err
@@ -1,9 +1,9 @@
-Error: Linearity violation (at $FILE:18:17)
+Error: Drop violation (at $FILE:18:17)
    | 
 16 | 
 17 | @guppy(module)
 18 | def foo(b: bool, s: MyStruct @owned) -> MyStruct:
-   |                  ^^^^^^^^^^^^^^^^^^ Field `s.q` with linear type `qubit` is leaked
+   |                  ^^^^^^^^^^^^^^^^^^ Field `s.q` with non-droppable type `qubit` is leaked
 
 Help: Make sure that `s.q` is consumed or returned to avoid the leak
 

--- a/tests/error/linear_errors/method_capture.err
+++ b/tests/error/linear_errors/method_capture.err
@@ -1,13 +1,13 @@
-Error: Linearity violation (at $FILE:23:8)
+Error: Copy violation (at $FILE:23:8)
    | 
 21 | @guppy(module)
 22 | def foo(s: Struct @owned) -> Struct:
 23 |     f = s.foo
    |         ^^^^^ This expression implicitly constructs a closure that
-   |               captures a linear value
+   |               captures a non-copyable value
    | 
 23 |     f = s.foo
-   |         - This expression with linear type `Struct` is implicitly
-   |           captured
+   |         - This expression with non-copyable type `Struct` is
+   |           implicitly captured
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/linear_errors/nested_array.err
+++ b/tests/error/linear_errors/nested_array.err
@@ -3,9 +3,10 @@ Error: Subscript returned (at $FILE:10:11)
  8 | @guppy(module)
  9 | def foo(xs: array[array[int, 10], 20]) -> array[int, 10]:
 10 |     return xs[0]
-   |            ^^^^^ Cannot return a subscript of `xs` with affine type
+   |            ^^^^^ Cannot return a subscript of `xs` with non-copyable type
    |                  `array[array[int, 10], 20]`
 
-Note: Subscripts on affine types are only allowed to be borrowed, not returned
+Note: Subscripts on non-copyable types are only allowed to be borrowed not
+returned
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/linear_errors/nested_array.err
+++ b/tests/error/linear_errors/nested_array.err
@@ -6,7 +6,7 @@ Error: Subscript returned (at $FILE:10:11)
    |            ^^^^^ Cannot return a subscript of `xs` with non-copyable type
    |                  `array[array[int, 10], 20]`
 
-Note: Subscripts on non-copyable types are only allowed to be borrowed not
+Note: Subscripts on non-copyable types are only allowed to be borrowed, not
 returned
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/linear_errors/reassign_unused.err
+++ b/tests/error/linear_errors/reassign_unused.err
@@ -1,9 +1,9 @@
-Error: Linearity violation (at $FILE:18:8)
+Error: Drop violation (at $FILE:18:8)
    | 
 16 | 
 17 | @guppy(module)
 18 | def foo(q: qubit @owned) -> qubit:
-   |         ^^^^^^^^^^^^^^^ Variable `q` with linear type `qubit` is leaked
+   |         ^^^^^^^^^^^^^^^ Variable `q` with non-droppable type `qubit` is leaked
 
 Help: Make sure that `q` is consumed or returned to avoid the leak
 

--- a/tests/error/linear_errors/reassign_unused_field.err
+++ b/tests/error/linear_errors/reassign_unused_field.err
@@ -1,9 +1,9 @@
-Error: Linearity violation (at $FILE:18:8)
+Error: Drop violation (at $FILE:18:8)
    | 
 16 | 
 17 | @guppy(module)
 18 | def foo(s: MyStruct @owned) -> MyStruct:
-   |         ^^^^^^^^^^^^^^^^^^ Field `s.q` with linear type `qubit` is leaked
+   |         ^^^^^^^^^^^^^^^^^^ Field `s.q` with non-droppable type `qubit` is leaked
 
 Help: Make sure that `s.q` is consumed or returned to avoid the leak
 

--- a/tests/error/linear_errors/reassign_unused_tuple.err
+++ b/tests/error/linear_errors/reassign_unused_tuple.err
@@ -1,9 +1,9 @@
-Error: Linearity violation (at $FILE:18:8)
+Error: Drop violation (at $FILE:18:8)
    | 
 16 | 
 17 | @guppy(module)
 18 | def foo(q: qubit @owned) -> tuple[qubit, qubit]:
-   |         ^^^^^^^^^^^^^^^ Variable `q` with linear type `qubit` is leaked
+   |         ^^^^^^^^^^^^^^^ Variable `q` with non-droppable type `qubit` is leaked
 
 Help: Make sure that `q` is consumed or returned to avoid the leak
 

--- a/tests/error/linear_errors/unused.err
+++ b/tests/error/linear_errors/unused.err
@@ -1,9 +1,9 @@
-Error: Linearity violation (at $FILE:14:4)
+Error: Drop violation (at $FILE:14:4)
    | 
 12 | @guppy(module)
 13 | def foo(q: qubit @owned) -> int:
 14 |     x = q
-   |     ^ Variable `x` with linear type `qubit` is leaked
+   |     ^ Variable `x` with non-droppable type `qubit` is leaked
 
 Help: Make sure that `x` is consumed or returned to avoid the leak
 

--- a/tests/error/linear_errors/unused_expr.err
+++ b/tests/error/linear_errors/unused_expr.err
@@ -1,9 +1,9 @@
-Error: Linearity violation (at $FILE:13:4)
+Error: Drop violation (at $FILE:13:4)
    | 
 11 | @guppy(module)
 12 | def foo(q: qubit @owned) -> None:
 13 |     h(q)
-   |     ^^^^ Expression with linear type `qubit` is leaked
+   |     ^^^^ Expression with non-droppable type `qubit` is leaked
 
 Help: Consider assigning this value to a local variable
 

--- a/tests/error/linear_errors/unused_field1.err
+++ b/tests/error/linear_errors/unused_field1.err
@@ -1,9 +1,9 @@
-Error: Linearity violation (at $FILE:19:8)
+Error: Drop violation (at $FILE:19:8)
    | 
 17 | 
 18 | @guppy(module)
 19 | def foo(s: MyStruct @owned) -> int:
-   |         ^^^^^^^^^^^^^^^^^^ Field `s.q` with linear type `qubit` is leaked
+   |         ^^^^^^^^^^^^^^^^^^ Field `s.q` with non-droppable type `qubit` is leaked
 
 Help: Make sure that `s.q` is consumed or returned to avoid the leak
 

--- a/tests/error/linear_errors/unused_field2.err
+++ b/tests/error/linear_errors/unused_field2.err
@@ -1,9 +1,9 @@
-Error: Linearity violation (at $FILE:19:8)
+Error: Drop violation (at $FILE:19:8)
    | 
 17 | 
 18 | @guppy(module)
 19 | def foo(s: MyStruct @owned) -> qubit:
-   |         ^^^^^^^^^^^^^^^^^^ Field `s.q2` with linear type `qubit` is leaked
+   |         ^^^^^^^^^^^^^^^^^^ Field `s.q2` with non-droppable type `qubit` is leaked
 
 Help: Make sure that `s.q2` is consumed or returned to avoid the leak
 

--- a/tests/error/linear_errors/unused_field3.err
+++ b/tests/error/linear_errors/unused_field3.err
@@ -1,9 +1,9 @@
-Error: Linearity violation (at $FILE:25:8)
+Error: Drop violation (at $FILE:25:8)
    | 
 23 | 
 24 | @guppy(module)
 25 | def foo(s: MyStruct1 @owned) -> int:
-   |         ^^^^^^^^^^^^^^^^^^^ Field `s.x.q2` with linear type `qubit` is leaked
+   |         ^^^^^^^^^^^^^^^^^^^ Field `s.x.q2` with non-droppable type `qubit` is leaked
 
 Help: Make sure that `s.x.q2` is consumed or returned to avoid the leak
 

--- a/tests/error/linear_errors/unused_non_terminating.err
+++ b/tests/error/linear_errors/unused_non_terminating.err
@@ -1,9 +1,9 @@
-Error: Linearity violation (at $FILE:13:8)
+Error: Drop violation (at $FILE:13:8)
    | 
 11 | 
 12 | @guppy(module)
 13 | def foo(q: qubit @owned) -> None:
-   |         ^^^^^^^^^^^^^^^ Variable `q` with linear type `qubit` is leaked
+   |         ^^^^^^^^^^^^^^^ Variable `q` with non-droppable type `qubit` is leaked
 
 Help: Make sure that `q` is consumed or returned to avoid the leak
 

--- a/tests/error/linear_errors/unused_same_block.err
+++ b/tests/error/linear_errors/unused_same_block.err
@@ -1,9 +1,9 @@
-Error: Linearity violation (at $FILE:14:4)
+Error: Drop violation (at $FILE:14:4)
    | 
 12 | @guppy(module)
 13 | def foo(q: qubit @owned) -> int:
 14 |     x = q
-   |     ^ Variable `x` with linear type `qubit` is leaked
+   |     ^ Variable `x` with non-droppable type `qubit` is leaked
 
 Help: Make sure that `x` is consumed or returned to avoid the leak
 

--- a/tests/error/linear_errors/while_unused.err
+++ b/tests/error/linear_errors/while_unused.err
@@ -1,9 +1,10 @@
-Error: Linearity violation (at $FILE:12:4)
+Error: Drop violation (at $FILE:12:4)
    | 
 10 | @guppy(module)
 11 | def test(n: int) -> None:
 12 |     q = qubit()
-   |     ^ Variable `q` with linear type `qubit` may be leaked ...
+   |     ^ Variable `q` with non-droppable type `qubit` may be leaked
+   |       ...
    | 
 14 |     while i < n:
    |           ----- if this expression is `False`

--- a/tests/error/nested_errors/linear_capture.err
+++ b/tests/error/nested_errors/linear_capture.err
@@ -1,10 +1,11 @@
-Error: Linearity violation (at $FILE:15:15)
+Error: Copy violation (at $FILE:15:15)
    | 
 13 | def foo(q: qubit @owned) -> qubit:
 14 |     def bar() -> qubit:
 15 |         return q
-   |                ^ Variable `q` with linear type qubit cannot be used here
-   |                  since `q` is captured from an outer scope
+   |                ^ Variable `q` with non-copyable type qubit cannot be used
+   |                  here since `q` is captured from an outer
+   |                  scope
    | 
 13 | def foo(q: qubit @owned) -> qubit:
    |         --------------- `q` defined here


### PR DESCRIPTION
Closes #771