### PR TITLE
feat: add `get_current_shot()` to qsystem module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Code Refactoring
 
-* Stop inlining array.__getitem__ and arrary.__setitem__ ([#799](https://github.com/CQCL/guppylang/issues/799)) ([bb199a0](https://github.com/CQCL/guppylang/commit/bb199a0d581ead991212a2b7afe45e8f856fd214)), closes [#786](https://github.com/CQCL/guppylang/issues/786)
+* Stop inlining array.__getitem__ and array.__setitem__ ([#799](https://github.com/CQCL/guppylang/issues/799)) ([bb199a0](https://github.com/CQCL/guppylang/commit/bb199a0d581ead991212a2b7afe45e8f856fd214)), closes [#786](https://github.com/CQCL/guppylang/issues/786)
 
 ## [0.15.0](https://github.com/CQCL/guppylang/compare/v0.14.0...v0.15.0) (2025-02-07)
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -30,9 +30,8 @@ To setup the environment manually you will need:
 
 - Just: [just.systems](https://just.systems/)
 - uv `>=0.4.27`: [docs.astral.sh](https://docs.astral.sh/uv/getting-started/installation/)
-    * If you have an older manually installed `uv` version you can upgrade it
-      with `uv self update`, or by following the instructions in your package
-      manager.
+  - If you have an older manually installed `uv` version you can upgrade it with `uv self update`,
+    or by following the instructions in your package manager.
 
 The extended test suite has additional requirements. These are **optional**; tests that require them will be skipped if they are not installed.
 
@@ -108,7 +107,7 @@ PRs should be made against the `main` branch, and should pass all CI checks befo
 
 The general format of a contribution title should be:
 
-```
+```text
 <type>(<scope>)!: <description>
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ More examples and tutorials are available [here][examples].
 
 [examples]: ./examples/
 
-
 ## Install
 
 Guppy can be installed via `pip`. Requires Python >= 3.10.
@@ -49,13 +48,12 @@ Guppy can be installed via `pip`. Requires Python >= 3.10.
 pip install guppylang
 ```
 
-
 ## Development
 
 See [DEVELOPMENT.md](https://github.com/CQCL/guppylang/blob/main/DEVELOPMENT.md) for instructions on setting up the development environment.
 
 ## License
 
-This project is licensed under Apache License, Version 2.0 ([LICENCE][] or http://www.apache.org/licenses/LICENSE-2.0).
+This project is licensed under Apache License, Version 2.0 ([LICENCE][] or <http://www.apache.org/licenses/LICENSE-2.0>).
 
   [LICENCE]: ./LICENCE

--- a/guppylang/std/_internal/compiler/quantum.py
+++ b/guppylang/std/_internal/compiler/quantum.py
@@ -8,7 +8,7 @@ from hugr import Wire, ops
 from hugr import ext as he
 from hugr import tys as ht
 from hugr.std.float import FLOAT_T
-from tket2_exts import futures, qsystem, quantum, result, rotation, utils
+from tket2_exts import futures, qsystem, qsystem_utils, quantum, result, rotation
 
 from guppylang.definition.custom import CustomInoutCallCompiler
 from guppylang.definition.value import CallReturnWires
@@ -19,7 +19,7 @@ from guppylang.definition.value import CallReturnWires
 
 FUTURES_EXTENSION = futures()
 QSYSTEM_EXTENSION = qsystem()
-QSYSTEM_UTILS_EXTENSION = utils()
+QSYSTEM_UTILS_EXTENSION = qsystem_utils()
 QUANTUM_EXTENSION = quantum()
 RESULT_EXTENSION = result()
 ROTATION_EXTENSION = rotation()

--- a/guppylang/std/_internal/compiler/quantum.py
+++ b/guppylang/std/_internal/compiler/quantum.py
@@ -8,7 +8,7 @@ from hugr import Wire, ops
 from hugr import ext as he
 from hugr import tys as ht
 from hugr.std.float import FLOAT_T
-from tket2_exts import futures, qsystem, quantum, result, rotation
+from tket2_exts import futures, qsystem, quantum, result, rotation, utils
 
 from guppylang.definition.custom import CustomInoutCallCompiler
 from guppylang.definition.value import CallReturnWires
@@ -19,6 +19,7 @@ from guppylang.definition.value import CallReturnWires
 
 FUTURES_EXTENSION = futures()
 QSYSTEM_EXTENSION = qsystem()
+QSYSTEM_UTILS_EXTENSION = utils()
 QUANTUM_EXTENSION = quantum()
 RESULT_EXTENSION = result()
 ROTATION_EXTENSION = rotation()
@@ -29,6 +30,7 @@ ROTATION_T = ht.ExtType(ROTATION_T_DEF)
 TKET2_EXTENSIONS = [
     FUTURES_EXTENSION,
     QSYSTEM_EXTENSION,
+    QSYSTEM_UTILS_EXTENSION,
     QUANTUM_EXTENSION,
     RESULT_EXTENSION,
     ROTATION_EXTENSION,

--- a/guppylang/std/qsystem/__init__.py
+++ b/guppylang/std/qsystem/__init__.py
@@ -5,10 +5,9 @@ from guppylang.module import GuppyModule
 from guppylang.std import angles
 from guppylang.std._internal.compiler.quantum import (
     QSYSTEM_EXTENSION,
-    QSYSTEM_UTILS_EXTENSION,
     InoutMeasureCompiler,
 )
-from guppylang.std._internal.util import external_op, quantum_op
+from guppylang.std._internal.util import quantum_op
 from guppylang.std.angles import angle
 from guppylang.std.builtins import owned
 from guppylang.std.quantum import qubit
@@ -72,13 +71,6 @@ def reset(q: qubit) -> None: ...
 @guppy.hugr_op(quantum_op("QFree", ext=QSYSTEM_EXTENSION), module=qsystem)
 @no_type_check
 def qfree(q: qubit @ owned) -> None: ...
-
-
-@guppy.hugr_op(
-    external_op("GetCurrentShot", [], ext=QSYSTEM_UTILS_EXTENSION), module=qsystem
-)
-@no_type_check
-def get_current_shot() -> int: ...
 
 
 # ------------------------------------------------------

--- a/guppylang/std/qsystem/__init__.py
+++ b/guppylang/std/qsystem/__init__.py
@@ -5,9 +5,10 @@ from guppylang.module import GuppyModule
 from guppylang.std import angles
 from guppylang.std._internal.compiler.quantum import (
     QSYSTEM_EXTENSION,
+    QSYSTEM_UTILS_EXTENSION,
     InoutMeasureCompiler,
 )
-from guppylang.std._internal.util import quantum_op
+from guppylang.std._internal.util import external_op, quantum_op
 from guppylang.std.angles import angle
 from guppylang.std.builtins import owned
 from guppylang.std.quantum import qubit
@@ -71,6 +72,13 @@ def reset(q: qubit) -> None: ...
 @guppy.hugr_op(quantum_op("QFree", ext=QSYSTEM_EXTENSION), module=qsystem)
 @no_type_check
 def qfree(q: qubit @ owned) -> None: ...
+
+
+@guppy.hugr_op(
+    external_op("GetCurrentShot", [], ext=QSYSTEM_UTILS_EXTENSION), module=qsystem
+)
+@no_type_check
+def get_current_shot() -> int: ...
 
 
 # ------------------------------------------------------

--- a/guppylang/std/qsystem/utils.py
+++ b/guppylang/std/qsystem/utils.py
@@ -1,0 +1,15 @@
+from typing import no_type_check
+
+from guppylang.decorator import guppy
+from guppylang.module import GuppyModule
+from guppylang.std._internal.compiler.quantum import QSYSTEM_UTILS_EXTENSION
+from guppylang.std._internal.util import external_op
+
+qsystem_utils = GuppyModule("qsystem.utils")
+
+
+@guppy.hugr_op(
+    external_op("GetCurrentShot", [], ext=QSYSTEM_UTILS_EXTENSION), module=qsystem_utils
+)
+@no_type_check
+def get_current_shot() -> int: ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ execute-llvm = { workspace = true }
 
 # Uncomment these to test the latest dependency version during development
 #  hugr = { git = "https://github.com/CQCL/hugr", subdirectory = "hugr-py", rev = "e40b6c7" }
-tket2-exts = { git = "https://github.com/CQCL/tket2", subdirectory = "tket2-exts", branch = "767-hseries-get_current_shot"}
+tket2-exts = { git = "https://github.com/CQCL/tket2", subdirectory = "tket2-exts", rev = "175a02d"}
 # tket2 = { git = "https://github.com/CQCL/tket2", subdirectory = "tket2-py", rev = "eb7cc63"}
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "pydantic >=2.7.0b1,<3",
     "typing-extensions >=4.9.0,<5",
     "hugr >=0.10.3,<0.11",
-    "tket2-exts>=0.3.0,<0.4",
+    "tket2-exts>=0.4.0,<0.5",
 ]
 
 [project.optional-dependencies]
@@ -86,7 +86,7 @@ execute-llvm = { workspace = true }
 
 # Uncomment these to test the latest dependency version during development
 #  hugr = { git = "https://github.com/CQCL/hugr", subdirectory = "hugr-py", rev = "e40b6c7" }
-tket2-exts = { git = "https://github.com/CQCL/tket2", subdirectory = "tket2-exts", rev = "175a02d"}
+# tket2-exts = { git = "https://github.com/CQCL/tket2", subdirectory = "tket2-exts", rev = "175a02d"}
 # tket2 = { git = "https://github.com/CQCL/tket2", subdirectory = "tket2-py", rev = "eb7cc63"}
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ execute-llvm = { workspace = true }
 
 # Uncomment these to test the latest dependency version during development
 #  hugr = { git = "https://github.com/CQCL/hugr", subdirectory = "hugr-py", rev = "e40b6c7" }
-# tket2-exts = { git = "https://github.com/CQCL/tket2", subdirectory = "tket2-exts", rev = "eb7cc63"}
+tket2-exts = { git = "https://github.com/CQCL/tket2", subdirectory = "tket2-exts", branch = "767-hseries-get_current_shot"}
 # tket2 = { git = "https://github.com/CQCL/tket2", subdirectory = "tket2-py", rev = "eb7cc63"}
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ test = [
     "pytest-notebook >=0.10.0,<0.11",
     "pytest-snapshot >=0.9.0,<1",
     "ipykernel >=6.29.5,<7",
-    "tket2>=0.6.0",
+    "tket2>=0.6.1",
     "pytest-benchmark>=5.1.0",
 ]
 execution = [
@@ -87,7 +87,7 @@ execute-llvm = { workspace = true }
 # Uncomment these to test the latest dependency version during development
 #  hugr = { git = "https://github.com/CQCL/hugr", subdirectory = "hugr-py", rev = "e40b6c7" }
 # tket2-exts = { git = "https://github.com/CQCL/tket2", subdirectory = "tket2-exts", rev = "175a02d"}
-# tket2 = { git = "https://github.com/CQCL/tket2", subdirectory = "tket2-py", rev = "eb7cc63"}
+# tket2 = { git = "https://github.com/CQCL/tket2", subdirectory = "tket2-py", rev = "259cf88"}
 
 
 [build-system]

--- a/tests/integration/test_qsystem.py
+++ b/tests/integration/test_qsystem.py
@@ -5,6 +5,7 @@ from guppylang.module import GuppyModule
 from guppylang.std.angles import angle
 
 from guppylang.std.builtins import owned
+from guppylang.std.qsystem import get_current_shot
 from guppylang.std.quantum import qubit
 from guppylang.std.qsystem.functional import (
     phased_x,
@@ -18,7 +19,7 @@ from guppylang.std.qsystem.functional import (
 )
 
 
-def compile_qsystem_guppy(fn) -> ModulePointer:
+def compile_qsystem_guppy(fn) -> ModulePointer:  # type: ignore[no-untyped-def]
     """A decorator that combines @guppy with HUGR compilation.
 
     Modified version of `tests.util.compile_guppy` that loads the qsytem module.
@@ -29,17 +30,18 @@ def compile_qsystem_guppy(fn) -> ModulePointer:
     ), "`@compile_qsystem_guppy` does not support extra arguments."
 
     module = GuppyModule("module")
-    module.load(angle, qubit)
+    module.load(angle, qubit, get_current_shot)  # type: ignore[arg-type]
     module.load_all(qsystem_functional)
     guppylang.decorator.guppy(module)(fn)
     return module.compile()
 
 
-def test_qsystem(validate):
+def test_qsystem(validate):  # type: ignore[no-untyped-def]
     """Compile various operations from the qsystem extension."""
 
     @compile_qsystem_guppy
     def test(q1: qubit @ owned, q2: qubit @ owned, a1: angle) -> bool:
+        shot = get_current_shot()
         q1 = phased_x(q1, a1, a1)
         q1, q2 = zz_phase(q1, q2, a1)
         q1 = rz(q1, a1)

--- a/tests/integration/test_qsystem.py
+++ b/tests/integration/test_qsystem.py
@@ -5,7 +5,7 @@ from guppylang.module import GuppyModule
 from guppylang.std.angles import angle
 
 from guppylang.std.builtins import owned
-from guppylang.std.qsystem import get_current_shot
+from guppylang.std.qsystem.utils import get_current_shot
 from guppylang.std.quantum import qubit
 from guppylang.std.qsystem.functional import (
     phased_x,


### PR DESCRIPTION
Closes: #798

It's not clear to me whether the type in tket2-hseries for `get_current_shot()` should be `usize` or `int(6)`. I used usize initially but got the following runtime error during json validation (`[] -> [tket2.qsystem.utils][usize] but stored signature was [] -> [tket2.qsystem.utils][int(6)]`):
```py
tests/integration/conftest.py:64: in validate_impl
    validate_json(js)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

hugr = '{"modules":[{"version":"live","nodes":[{"parent":0,"op":"Module"},{"parent":0,"op":"FuncDefn","name":"test","signatur..."i":1,"b":"A"}],"output":[{"t":"R","i":2,"b":"A"}],"runtime_reqs":["guppylang"]}},"binary":false,"lower_funcs":[]}}}]}'

    def validate_json(hugr: str):
        # Executes `cargo run -p validator -- validate -`
        # passing the hugr JSON as stdin
        p = subprocess.run(  # noqa: S603
            [validator, "validate", "-"],
            text=True,
            input=hugr,
            capture_output=True,
        )

        if p.returncode != 0:
>           raise RuntimeError(f"{p.stderr}")
E           RuntimeError: Error parsing package: Error resolving opaque operation: Conflicting signature: resolved GetCurrentShot in extension tket2.qsystem.utils to a concrete implementation which computed [] -> [tket2.qsystem.utils][usize] but stored signature was [] -> [tket2.qsystem.utils][int(6)]
```

I [changed the signature](https://github.com/CQCL/tket2/pull/772/commits/a173d44814a853327683ecc821658eb4ee942fc6) to use `int(6)`, which then made the types compatible.