### PR TITLE
feat: add `Option.take()` for swapping with None

### DIFF
--- a/guppylang/std/option.py
+++ b/guppylang/std/option.py
@@ -53,13 +53,11 @@ class Option(Generic[T]):  # type: ignore[misc]
 
     @guppy
     @no_type_check
-    def take(self: "Option[T]") -> T:
-        """Swaps the value of `self` with `nothing` and returns the original value.
-
-        Panics if the option is a `nothing` value."""
+    def take(self: "Option[T]") -> "Option[T]":
+        """Swaps the value of `self` with `nothing` and returns the original value."""
         n: Option[T] = nothing()  # type: ignore[type-arg, valid-type]
         mem_swap(n, self)
-        return n.unwrap()
+        return n
 
 
 @guppy.custom(OptionConstructor(0))

--- a/tests/integration/test_option.py
+++ b/tests/integration/test_option.py
@@ -46,7 +46,7 @@ def test_take(validate, run_int_fn):
     @no_type_check
     def main() -> int:
         x: Option[int] = some(42)
-        y = x.take()
+        y = x.take().unwrap()
         is_none = 1 if x.is_nothing() else 0
         return y + is_none
 


### PR DESCRIPTION
Example use case: measure without changing array indexing

```python

@guppy
def measure_option(ar: array[Option[qubit], N], index: int) -> bool:
    return measure(ar[index].take().unwrap())
```