### PR TITLE
feat!: Generalise scalar angle operations to float

### DIFF
--- a/guppylang/std/angles.py
+++ b/guppylang/std/angles.py
@@ -35,22 +35,22 @@ class angle:
 
     @guppy(angles)
     @no_type_check
-    def __mul__(self: "angle", other: int) -> "angle":
+    def __mul__(self: "angle", other: float) -> "angle":
         return angle(self.halfturns * other)
 
     @guppy(angles)
     @no_type_check
-    def __rmul__(self: "angle", other: int) -> "angle":
+    def __rmul__(self: "angle", other: float) -> "angle":
         return angle(self.halfturns * other)
 
     @guppy(angles)
     @no_type_check
-    def __truediv__(self: "angle", other: int) -> "angle":
+    def __truediv__(self: "angle", other: float) -> "angle":
         return angle(self.halfturns / other)
 
     @guppy(angles)
     @no_type_check
-    def __rtruediv__(self: "angle", other: int) -> "angle":
+    def __rtruediv__(self: "angle", other: float) -> "angle":
         return angle(other / self.halfturns)
 
     @guppy(angles)

--- a/tests/integration/test_arithmetic.py
+++ b/tests/integration/test_arithmetic.py
@@ -124,6 +124,20 @@ def test_angle_arith(validate):
     validate(module.compile())
 
 
+def test_angle_arith_float(validate):
+    module = GuppyModule("test")
+    module.load(angle)
+
+    @guppy(module)
+    def main(a1: angle, a2: angle) -> bool:
+        a3 = -a1 + a2 * -3.5
+        a3 -= a1
+        a3 += 2.2 * a1
+        return a3 / 3.9 == -a2
+
+    validate(module.compile())
+
+
 def test_implicit_coercion(validate):
     @compile_guppy
     def coerce(x: nat) -> float:


### PR DESCRIPTION
Closes #761

BREAKING CHANGE: `angle.{__mul__, __rmul__, __truediv__, __rtruediv__` now take a `float` instead of an `int`.