### PR TITLE
docs: Fix API docs build

### DIFF
--- a/guppylang/decorator.py
+++ b/guppylang/decorator.py
@@ -584,6 +584,9 @@ class _GuppyDummy:
     def load(self, *args: Any, **kwargs: Any) -> None:
         pass
 
+    def get_module(self, *args: Any, **kwargs: Any) -> Any:
+        return GuppyModule("dummy", import_builtins=False)
+
 
 guppy = cast(_Guppy, _GuppyDummy()) if sphinx_running() else _Guppy()
 


### PR DESCRIPTION
Fixes #842 

The docs build broke since `guppyland.std.option` now calls `guppy.get_module` but this function was missing from the `guppy` decorator mock