### PR TITLE
fix: Correctly handle assignments of arrays in control-flow

### DIFF
--- a/guppylang/cfg/bb.py
+++ b/guppylang/cfg/bb.py
@@ -156,6 +156,11 @@ class VariableVisitor(ast.NodeVisitor):
                 # Setting attributes counts as a use of the value, so we do a regular
                 # visit instead of treating it like a LHS
                 self.visit(value)
+            case ast.Subscript(value=value, slice=slice):
+                # Setting subscripts counts as a use of the value in the implicit,
+                # `__setitem__` call, so we do a regular visit
+                self.visit(slice)
+                self.visit(value)
             case ast.Starred(value=value):
                 self._handle_assign_target(value, node)
 

--- a/tests/integration/test_array.py
+++ b/tests/integration/test_array.py
@@ -692,3 +692,27 @@ def test_multiple_functions(validate, run_int_fn):
     compiled = module.compile()
     validate(compiled)
     run_int_fn(compiled, expected=3)
+
+
+def test_assign_dataflow(validate):
+    """Test that dataflow analysis considers subscript assignments as uses and correctly
+    wires up the Hugr.
+
+    See https://github.com/CQCL/guppylang/issues/844
+    """
+    module = GuppyModule("test")
+
+    @guppy(module)
+    def test1() -> None:
+        xs = array(1, 2)
+        for i in range(2):
+            xs[i] = 0
+
+    @guppy(module)
+    def test2() -> None:
+        xs = array(0, 1)
+        ys = array(1, 2)
+        for i in range(2):
+            ys[xs[i]] = 0
+
+    module.compile()


### PR DESCRIPTION
Fixes #844