### PR TITLE
fix: Fix compiler diagnostics when calling `check` instead of `compile`

### DIFF
--- a/guppylang/error.py
+++ b/guppylang/error.py
@@ -7,8 +7,6 @@ from dataclasses import dataclass
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
-from guppylang.ipython_inspect import is_running_ipython
-
 if TYPE_CHECKING:
     from guppylang.diagnostic import Error, Fatal
 
@@ -97,18 +95,7 @@ def pretty_errors(f: FuncT) -> FuncT:
     @functools.wraps(f)
     def pretty_errors_wrapped(*args: Any, **kwargs: Any) -> Any:
         with exception_hook(hook):
-            try:
-                return f(*args, **kwargs)
-            except GuppyError as err:
-                # For normal usage, this `try` block is not necessary since the
-                # excepthook is automatically invoked when the exception (which is being
-                # reraised below) is not handled. However, when running tests, we have
-                # to manually invoke the hook to print the error message, since the
-                # tests always have to capture exceptions. The only exception are
-                # notebook tests which don't rely on the capsys fixture.
-                if _pytest_running() and not is_running_ipython():
-                    hook(type(err), err, err.__traceback__)
-                raise
+            return f(*args, **kwargs)
 
     return cast(FuncT, pretty_errors_wrapped)
 

--- a/guppylang/module.py
+++ b/guppylang/module.py
@@ -297,6 +297,7 @@ class GuppyModule:
             for def_id, defn in parsed.items()
         }
 
+    @pretty_errors
     def check(self) -> None:
         """Type-checks the module."""
         if self.checked:

--- a/tests/error/misc_errors/check_error.err
+++ b/tests/error/misc_errors/check_error.err
@@ -1,0 +1,8 @@
+Error: Type mismatch (at $FILE:10:11)
+   | 
+ 8 | @guppy(module)
+ 9 | def foo(x: float) -> int:
+10 |     return x
+   |            ^ Expected return value of type `int`, got `float`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/misc_errors/check_error.py
+++ b/tests/error/misc_errors/check_error.py
@@ -1,0 +1,14 @@
+from guppylang.decorator import guppy
+from guppylang.module import GuppyModule
+
+
+module = GuppyModule("test")
+
+
+@guppy(module)
+def foo(x: float) -> int:
+    return x
+
+
+# Call check instead of compile
+module.check()

--- a/tests/error/misc_errors/implicit_load_error.err
+++ b/tests/error/misc_errors/implicit_load_error.err
@@ -1,0 +1,8 @@
+Error: Type mismatch (at $FILE:10:11)
+   | 
+ 8 | @guppy(module)
+ 9 | def foo(x: float) -> int:
+10 |     return x
+   |            ^ Expected return value of type `int`, got `float`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/misc_errors/implicit_load_error.py
+++ b/tests/error/misc_errors/implicit_load_error.py
@@ -1,0 +1,20 @@
+from guppylang.decorator import guppy
+from guppylang.module import GuppyModule
+
+
+module = GuppyModule("test1")
+
+
+@guppy(module)
+def foo(x: float) -> int:
+    return x
+
+
+# Declaring an implicit module will load the explicit one above since it is in
+# scope, so we will get the type error even though none of the modules were explicitly
+# compiled
+
+@guppy
+def bar() -> None:
+    pass
+

--- a/tests/error/misc_errors/load_error.err
+++ b/tests/error/misc_errors/load_error.err
@@ -1,0 +1,8 @@
+Error: Type mismatch (at $FILE:10:11)
+   | 
+ 8 | @guppy(module1)
+ 9 | def foo(x: float) -> int:
+10 |     return x
+   |            ^ Expected return value of type `int`, got `float`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/misc_errors/load_error.py
+++ b/tests/error/misc_errors/load_error.py
@@ -1,0 +1,17 @@
+from guppylang.decorator import guppy
+from guppylang.module import GuppyModule
+
+
+module1 = GuppyModule("test1")
+
+
+@guppy(module1)
+def foo(x: float) -> int:
+    return x
+
+
+module2 = GuppyModule("test2")
+
+# Load invokes `check` on the imported module, so this will fail even though we don't
+# compile `module2`
+module2.load(foo)

--- a/tests/error/util.py
+++ b/tests/error/util.py
@@ -1,6 +1,7 @@
 import importlib.util
 import pathlib
 import pytest
+import sys
 from hugr import tys
 from hugr.tys import TypeBound
 
@@ -13,8 +14,11 @@ import guppylang.decorator as decorator
 def run_error_test(file, capsys, snapshot):
     file = pathlib.Path(file)
 
-    with pytest.raises(GuppyError):
+    with pytest.raises(GuppyError) as exc_info:
         importlib.import_module(f"tests.error.{file.parent.name}.{file.name}")
+
+    # Invoke except hook to print the exception to stderr
+    sys.excepthook(exc_info.type, exc_info.value, exc_info.tb)
 
     err = capsys.readouterr().err
     err = err.replace(str(file), "$FILE")


### PR DESCRIPTION
Fixes #851

This also fixes the same issue when `load` or `load_all` is called since they rely on `check`.

Drive-by: Get rid of the horrible hack to capture diagnostics in error tests. This broke, now that check is also decorated with `pretty_errors` and I found a better way to do the same thing