### PR TITLE
fix: Prevent reordering of operations with side-effects

### DIFF
--- a/guppylang/compiler/core.py
+++ b/guppylang/compiler/core.py
@@ -1,12 +1,19 @@
 import itertools
 from abc import ABC
+from collections import defaultdict
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import cast
+from typing import Any, cast
 
-from hugr import Wire, ops
+import tket2_exts
+from hugr import Hugr, Node, Wire, ops
 from hugr import tys as ht
 from hugr.build import function as hf
 from hugr.build.dfg import DP, DefinitionBuilder, DfBase
+from hugr.hugr.base import OpVarCov
+from hugr.hugr.node_port import ToNode
+from hugr.std import PRELUDE
 
 from guppylang.checker.core import FieldAccess, Globals, Place, PlaceId, Variable
 from guppylang.definition.common import CheckedDef, CompilableDef, CompiledDef, DefId
@@ -90,8 +97,9 @@ class CompilerContext:
         self.worklist.add(defn.id)
         while self.worklist:
             next_id = self.worklist.pop()
-            next_def = self.build_compiled_def(next_id)
-            next_def.compile_inner(self)
+            with track_hugr_side_effects():
+                next_def = self.build_compiled_def(next_id)
+                next_def.compile_inner(self)
 
     def get_instance_func(
         self, ty: Type | TypeDef, name: str
@@ -216,3 +224,93 @@ def return_var(n: int) -> str:
 def is_return_var(x: str) -> bool:
     """Checks whether the given name is a dummy return variable."""
     return x.startswith("%ret")
+
+
+QUANTUM_EXTENSION = tket2_exts.quantum()
+RESULT_EXTENSION = tket2_exts.result()
+
+#: List of extension ops that have side-effects, identified by their qualified name
+EXTENSION_OPS_WITH_SIDE_EFFECTS: list[str] = [
+    # Results should be order w.r.t. each other but also w.r.t. panics
+    *(op_def.qualified_name() for op_def in RESULT_EXTENSION.operations.values()),
+    PRELUDE.get_op("panic").qualified_name(),
+    # Qubit allocation and deallocation have the side-effect of changing the number of
+    # available free qubits
+    QUANTUM_EXTENSION.get_op("QAlloc").qualified_name(),
+    QUANTUM_EXTENSION.get_op("QFree").qualified_name(),
+    QUANTUM_EXTENSION.get_op("MeasureFree").qualified_name(),
+]
+
+
+def may_have_side_effect(op: ops.Op) -> bool:
+    """Checks whether an operation could have a side-effect.
+
+    We need to insert implicit state order edges between these kinds of nodes to ensure
+    they are executed in the correct order, even if there is no data dependency.
+    """
+    match op:
+        case ops.ExtOp() as ext_op:
+            return ext_op.op_def().qualified_name() in EXTENSION_OPS_WITH_SIDE_EFFECTS
+        case ops.Custom(op_name=op_name, extension=extension):
+            qualified_name = f"{extension}.{op_name}" if extension else op_name
+            return qualified_name in EXTENSION_OPS_WITH_SIDE_EFFECTS
+        case ops.Call() | ops.CallIndirect():
+            # Conservative choice is to assume that all calls could have side effects.
+            # In the future we could inspect the call graph to figure out a more
+            # precise answer
+            return True
+        case _:
+            return False
+
+
+@contextmanager
+def track_hugr_side_effects() -> Iterator[None]:
+    """Initialises the tracking of nodes with side-effects during Hugr building.
+
+    Ensures that state-order edges are implicitly inserted between side-effectful nodes
+    to ensure they are executed in the order they are added.
+    """
+    # Remember original `Hugr.add_node` method that is monkey-patched below.
+    hugr_add_node = Hugr.add_node
+    # Last node with potential side effects for each dataflow parent
+    prev_node_with_side_effect: defaultdict[Node, Node | None] = defaultdict(
+        lambda: None
+    )
+
+    def hugr_add_node_with_order(
+        self: Hugr[OpVarCov],
+        op: ops.Op,
+        parent: ToNode | None = None,
+        num_outs: int | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> Node:
+        """Monkey-patched version of `Hugr.add_node` that takes care of implicitly
+        inserting state order edges between operations that could have side-effects.
+        """
+        new_node = hugr_add_node(self, op, parent, num_outs, metadata)
+        if may_have_side_effect(op):
+            handle_side_effect(new_node, self)
+        return new_node
+
+    def handle_side_effect(node: Node, hugr: Hugr[OpVarCov]) -> None:
+        """Performs the actual order-edge insertion, assuming that `node` has a side-
+        effect."""
+        parent = hugr[node].parent
+        if parent is not None:
+            if prev := prev_node_with_side_effect[parent]:
+                hugr.add_order_link(prev, node)
+            else:
+                # If this is the first side-effectful op in this DFG, make a recursive
+                # call with the parent since the parent is also considered side-
+                # effectful now. We shouldn't walk up through function definitions
+                # or basic blocks though
+                if not isinstance(hugr[parent].op, ops.FuncDefn | ops.DataflowBlock):
+                    handle_side_effect(parent, hugr)
+            prev_node_with_side_effect[parent] = node
+
+    # Monkey-patch the `add_node` method
+    Hugr.add_node = hugr_add_node_with_order  # type: ignore[method-assign]
+    try:
+        yield
+    finally:
+        Hugr.add_node = hugr_add_node  # type: ignore[method-assign]

--- a/tests/integration/test_side_effect_ordering.py
+++ b/tests/integration/test_side_effect_ordering.py
@@ -1,0 +1,148 @@
+"""Tests that the compiler correctly inserts order edges between operations that have
+side-effects.
+"""
+
+from hugr import ops, Hugr, Node
+from hugr.std import PRELUDE
+
+from guppylang import guppy
+from guppylang.module import GuppyModule
+from guppylang.std._internal.compiler.quantum import RESULT_EXTENSION, QUANTUM_EXTENSION
+from guppylang.std.builtins import result, array, owned, panic
+from guppylang.std.quantum import qubit, discard, measure
+
+
+def find_ext_nodes(hugr: Hugr, qualified_name: str) -> list[Node]:
+    """Returns all extension nodes in a Hugr that match the given qualified name."""
+    return [
+        node for node, data in hugr.nodes() if name_matches(data.op, qualified_name)
+    ]
+
+
+def name_matches(op: ops.Op, qualified_name: str) -> bool:
+    """Checks if an op is an extension op that matches the given qualified name."""
+    match op:
+        case ops.ExtOp() as ext_op:
+            return ext_op.op_def().qualified_name() == qualified_name
+        case ops.Custom(op_name=op_name, extension=extension):
+            return qualified_name == (
+                f"{extension}.{op_name}" if extension else op_name
+            )
+        case _:
+            return False
+
+
+def check_order(hugr: Hugr, nodes: list[Node]) -> None:
+    """Checks that the provided nodes appear in the specified order in the order-edge
+    graph."""
+    # Do a DFS traversal of the order edge graph starting at the first node
+    stack = [nodes[0]]
+    visited = set()
+    while stack:
+        curr = stack.pop()
+        visited.add(curr)
+        if curr in nodes:
+            # Check this node is the next one in the sequence
+            assert curr == nodes.pop(0)
+        for n in hugr.outgoing_order_links(curr):
+            assert n not in visited, "Order edge graph must be acyclic"
+            stack.append(n)
+    # Check that all specified nodes occurred in the graph
+    assert len(nodes) == 0
+
+
+def test_result_panic(validate):
+    module = GuppyModule("test")
+
+    @guppy(module)
+    def test() -> None:
+        result("a", True)
+        result("b", 10)
+        panic("Boo!")
+        result("c", 10.5)
+
+    compiled = module.compile()
+    validate(compiled)
+
+    # Check that we have the expected order edges between the results
+    hugr = compiled.module
+    [a] = find_ext_nodes(hugr, RESULT_EXTENSION.get_op("result_bool").qualified_name())
+    [b] = find_ext_nodes(hugr, RESULT_EXTENSION.get_op("result_int").qualified_name())
+    [p] = find_ext_nodes(hugr, PRELUDE.get_op("panic").qualified_name())
+    [c] = find_ext_nodes(hugr, RESULT_EXTENSION.get_op("result_f64").qualified_name())
+    check_order(hugr, [a, b, p, c])
+
+
+def test_qalloc_qfree(validate):
+    module = GuppyModule("test")
+    module.load(qubit, discard, measure)
+
+    @guppy(module)
+    def test() -> None:
+        q1 = qubit()
+        discard(q1)
+        q2 = qubit()
+        measure(q2)
+
+    compiled = module.compile()
+    validate(compiled)
+
+    # Check that we have the expected order edges between the allocations and frees
+    hugr = compiled.module
+    [a1, a2] = find_ext_nodes(hugr, QUANTUM_EXTENSION.get_op("QAlloc").qualified_name())
+    [d1] = find_ext_nodes(hugr, QUANTUM_EXTENSION.get_op("QFree").qualified_name())
+    [d2] = find_ext_nodes(
+        hugr, QUANTUM_EXTENSION.get_op("MeasureFree").qualified_name()
+    )
+    check_order(hugr, [a1, d1, a2, d2])
+
+
+def test_call(validate):
+    module = GuppyModule("test")
+    module.load(qubit, discard)
+
+    @guppy(module)
+    def my_discard(q: qubit @ owned) -> None:
+        discard(q)
+
+    @guppy(module)
+    def test() -> None:
+        q1 = qubit()
+        my_discard(q1)
+        q2 = qubit()
+        f = my_discard
+        f(q2)
+
+    compiled = module.compile()
+    validate(compiled)
+
+    # Check that we have the expected order edges between the allocations and calls
+    hugr = compiled.module
+    [a1, a2] = find_ext_nodes(hugr, QUANTUM_EXTENSION.get_op("QAlloc").qualified_name())
+    [d1] = [node for node, data in hugr.nodes() if isinstance(data.op, ops.Call)]
+    [d2] = [
+        node for node, data in hugr.nodes() if isinstance(data.op, ops.CallIndirect)
+    ]
+    check_order(hugr, [a1, d1, a2, d2])
+
+
+def test_nested(validate):
+    module = GuppyModule("test")
+    module.load(qubit, discard, measure)
+
+    @guppy(module)
+    def test() -> None:
+        qs1 = array(qubit() for _ in range(10))
+        array(measure(q) for q in qs1)
+        qs2 = array(qubit() for _ in range(10))
+        array(discard(q) for q in qs2)
+
+    compiled = module.compile()
+    validate(compiled)
+
+    # Check that we have the expected order edges between the comprehension tail loops
+    hugr = compiled.module
+    [l1, l2, l3, l4] = [
+        node for node, data in hugr.nodes() if isinstance(data.op, ops.TailLoop)
+    ]
+    check_order(hugr, [l1, l2, l3, l4])


### PR DESCRIPTION
Closes #853
 
This is a temporary solution until we properly solve #778. Therefore, the implementation is somewhat hacky as we're going to remove this in the future anyways. 

The approach is to monkey-patch the `Hugr.add_node` method to implicitly insert state-order edges between nodes that could have side-effects. The list of side-effectful nodes is hard-coded in the compiler.

Also relies on the fix from https://github.com/CQCL/hugr/pull/1971, so we should wait to merge until `hugr-py` is released