### PR TITLE
ci: Update uv.lock on release-please PRs

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,14 @@
       "bump-patch-for-minor-pre-major": false,
       "draft": false,
       "prerelease": false,
-      "draft-pull-request": true
+      "draft-pull-request": true,
+      "extra-files": [
+        {
+          "type": "toml",
+          "path": "uv.lock",
+          "jsonpath": "$.package[?(@.name.value=='guppylang')].version"
+        }
+      ]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
`uv 0.6.6` adds a hard error when the version of the package in `uv.lock` does not match the one declared in the editable wheel: https://github.com/astral-sh/uv/pull/12235.

`release-please` doesn't update the lock files automatically, so release PRs needed a manual lock update.
This PR adds the lockfile as an `extra-file`, to avoid this manual step.

Note that the _jsonpath_ in the config is not technically correct, as release-please's json array filters don't quite work for toml files. See https://github.com/googleapis/release-please/issues/2455, which includes this hacky workaround.