### PR TITLE
fix(qsystem)!: remove `random_nat` and `maybe_rng`

### DIFF
--- a/guppylang/std/qsystem/random.py
+++ b/guppylang/std/qsystem/random.py
@@ -11,7 +11,7 @@ from guppylang.std._internal.compiler.quantum import (
     RNGCONTEXT_T,
 )
 from guppylang.std._internal.util import external_op
-from guppylang.std.builtins import nat, owned
+from guppylang.std.builtins import owned
 from guppylang.std.option import Option
 
 qsystem_random = GuppyModule("qsystem.random")
@@ -23,14 +23,6 @@ qsystem_random = GuppyModule("qsystem.random")
 )
 @no_type_check
 def _new_rng_context(seed: int) -> Option["RNG"]: ...
-
-
-@guppy(qsystem_random)
-def maybe_rng(seed: int) -> Option["RNG"]:  # type: ignore[type-arg] # "Option" expects no type arguments, but 1 given
-    """Safely create a new random number generator using a seed.
-
-    Returns `nothing` if RNG is already initialized."""
-    return _new_rng_context(seed)  # type: ignore[no-any-return] # Returning Any from function declared to return "Option"
 
 
 @guppy.type(RNGCONTEXT_T, copyable=False, droppable=False, module=qsystem_random)
@@ -52,11 +44,6 @@ class RNG:
     @guppy.custom(RandomIntCompiler(), module=qsystem_random)
     @no_type_check
     def random_int(self: "RNG") -> int: ...
-
-    @guppy(qsystem_random)
-    def random_nat(self: "RNG") -> nat:
-        """Generate a random 32-bit natural number."""
-        return nat(self.random_int())  # type: ignore[call-arg] # Too many arguments for "nat"
 
     @guppy.hugr_op(
         external_op("RandomFloat", [], ext=QSYSTEM_RANDOM_EXTENSION),

--- a/guppylang/std/qsystem/random.py
+++ b/guppylang/std/qsystem/random.py
@@ -1,3 +1,4 @@
+# mypy: disable-error-code="no-any-return"
 from typing import no_type_check
 
 from guppylang.decorator import guppy
@@ -32,26 +33,50 @@ class RNG:
     @guppy(qsystem_random)  # type: ignore[misc] # Unsupported decorated constructor type; Self argument missing for a non-static method (or an invalid type for self)
     def __new__(seed: int) -> "RNG":
         """Create a new random number generator using a seed."""
-        return _new_rng_context(seed).unwrap()  # type: ignore[no-any-return] # Returning Any from function declared to return "RNGContext"
+        return _new_rng_context(seed).unwrap()
+
+    @guppy(qsystem_random)
+    def discard(self: "RNG" @ owned) -> None:  # type: ignore[valid-type] # Invalid type comment or annotation
+        """Discard the random number generator."""
+        self._discard()
+
+    @guppy(qsystem_random)
+    def random_int(self: "RNG") -> int:
+        """Generate a random 32-bit signed integer."""
+        return self._random_int()
+
+    @guppy(qsystem_random)
+    def random_float(self: "RNG") -> float:
+        """Generate a random floating point value in the range [0,1)."""
+        return self._random_float()
+
+    @guppy(qsystem_random)
+    def random_int_bounded(self: "RNG", bound: int) -> int:
+        """Generate a random 32-bit integer in the range [0, bound).
+
+        Args:
+            bound: The upper bound of the range, needs to less than 2^31.
+        """
+        return self._random_int_bounded(bound)
 
     @guppy.hugr_op(
         external_op("DeleteRNGContext", [], ext=QSYSTEM_RANDOM_EXTENSION),
         module=qsystem_random,
     )
     @no_type_check
-    def discard(self: "RNG" @ owned) -> None: ...
+    def _discard(self: "RNG" @ owned) -> None: ...
 
     @guppy.custom(RandomIntCompiler(), module=qsystem_random)
     @no_type_check
-    def random_int(self: "RNG") -> int: ...
+    def _random_int(self: "RNG") -> int: ...
 
     @guppy.hugr_op(
         external_op("RandomFloat", [], ext=QSYSTEM_RANDOM_EXTENSION),
         module=qsystem_random,
     )
     @no_type_check
-    def random_float(self: "RNG") -> float: ...
+    def _random_float(self: "RNG") -> float: ...
 
     @guppy.custom(RandomIntBoundedCompiler(), module=qsystem_random)
     @no_type_check
-    def random_int_bounded(self: "RNG", bound: int) -> int: ...
+    def _random_int_bounded(self: "RNG", bound: int) -> int: ...

--- a/tests/integration/test_qsystem.py
+++ b/tests/integration/test_qsystem.py
@@ -4,8 +4,8 @@ import guppylang.decorator
 from guppylang.module import GuppyModule
 from guppylang.std.angles import angle
 
-from guppylang.std.builtins import nat, owned
-from guppylang.std.qsystem.random import RNG, maybe_rng
+from guppylang.std.builtins import owned
+from guppylang.std.qsystem.random import RNG
 from guppylang.std.qsystem.utils import get_current_shot
 from guppylang.std.quantum import qubit
 from guppylang.std.qsystem.functional import (
@@ -32,7 +32,7 @@ def compile_qsystem_guppy(fn) -> ModulePointer:  # type: ignore[no-untyped-def]
     ), "`@compile_qsystem_guppy` does not support extra arguments."
 
     module = GuppyModule("module")
-    module.load(angle, qubit, get_current_shot, RNG, maybe_rng)  # type: ignore[arg-type]
+    module.load(angle, qubit, get_current_shot, RNG)  # type: ignore[arg-type]
     module.load_all(qsystem_functional)
     guppylang.decorator.guppy(module)(fn)
     return module.compile()
@@ -61,15 +61,12 @@ def test_qsystem_random(validate):  # type: ignore[no-untyped-def]
     """Compile various operations from the qsystem random extension."""
 
     @compile_qsystem_guppy
-    def test() -> tuple[int, nat, float, int]:
+    def test() -> tuple[int, float, int]:
         rng = RNG(42)
-        rng2 = maybe_rng(84)
-        rng2.unwrap_nothing()
         rint = rng.random_int()
-        rnat = rng.random_nat()
         rfloat = rng.random_float()
         rint_bnd = rng.random_int_bounded(100)
         rng.discard()
-        return rint, rnat, rfloat, rint_bnd
+        return rint, rfloat, rint_bnd
 
     validate(test)


### PR DESCRIPTION
For random_nat, see: quantinuum-dev/hugrverse#138

Discussion on maybe_rng at https://github.com/CQCL/guppylang/pull/822#issuecomment-2741571177

BREAKING CHANGE: removed `random.RNG.random_nat()` and `random.maybe_rng()`