### PR TITLE
ci: Bump patch version in 0.x.y packages

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,7 @@
       "release-type": "python",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": false,
+      "bump-patch-for-minor-pre-major": true,
       "draft": false,
       "prerelease": false,
       "draft-pull-request": true,


### PR DESCRIPTION
Non breaking releases for the library should bump the last version component as long as we stay pre-`1.0.0`.