### PR TITLE
chore: Enable deprecation warnings on pre-313 python

### DIFF
--- a/guppylang/qsys_result.py
+++ b/guppylang/qsys_result.py
@@ -29,22 +29,14 @@ from __future__ import annotations
 import re
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Literal
+
+from typing_extensions import deprecated
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable
+    from collections.abc import Iterable
 
     from pytket.backends.backendresult import BackendResult
-
-try:
-    from warnings import deprecated  # type: ignore[attr-defined]
-except ImportError:
-    # Python < 3.13
-    def deprecated(_msg: str) -> Callable[..., Any]:  # type: ignore[no-redef, unused-ignore]
-        def _deprecated(func: Any) -> Any:
-            return func
-
-        return _deprecated
 
 
 #: Primitive data types that can be returned by a result

--- a/guppylang/std/builtins.py
+++ b/guppylang/std/builtins.py
@@ -2,10 +2,10 @@
 
 # mypy: disable-error-code="empty-body, misc, override, valid-type, no-untyped-def"
 
-from collections.abc import Callable
 from typing import Any, Generic, TypeVar, no_type_check
 
 import hugr.std.int
+from typing_extensions import deprecated
 
 from guppylang.decorator import guppy
 from guppylang.definition.custom import CopyInoutCompiler, NoopCompiler
@@ -57,17 +57,6 @@ from guppylang.tys.builtin import (
     sized_iter_type_def,
     string_type_def,
 )
-
-try:
-    from warnings import deprecated  # type: ignore[attr-defined]
-except ImportError:
-    # Python < 3.13
-    def deprecated(_msg: str) -> Callable[..., Any]:  # type: ignore[no-redef, unused-ignore]
-        def _deprecated(func: Any) -> Any:
-            return func
-
-        return _deprecated
-
 
 guppy.init_module(import_builtins=False)
 


### PR DESCRIPTION
`typing_extensions` defines a `@deprecated` decorator compatible with `python<3.13`