### PR TITLE
fix: Use correct copyable/droppable terminology for type arg errors

### DIFF
--- a/guppylang/checker/errors/type_errors.py
+++ b/guppylang/checker/errors/type_errors.py
@@ -8,7 +8,7 @@ from guppylang.diagnostic import Error, Help, Note
 if TYPE_CHECKING:
     from guppylang.definition.struct import StructField
     from guppylang.tys.const import Const
-    from guppylang.tys.param import Parameter
+    from guppylang.tys.param import TypeParam
     from guppylang.tys.ty import FunctionType, Type
 
 
@@ -65,12 +65,16 @@ class AssignSubscriptTypeMismatchError(Error):
 class NonLinearInstantiateError(Error):
     title: ClassVar[str] = "Not defined for linear argument"
     span_label: ClassVar[str] = (
-        "Cannot instantiate non-linear type parameter `{param.name}` in type "
-        "`{func_ty}` with linear type `{ty}`"
+        "Cannot instantiate {expected} type parameter `{param.name}` in type "
+        "`{func_ty}` with non-{expected} type `{ty}`"
     )
-    param: Parameter
+    param: TypeParam
     func_ty: FunctionType
     ty: Type
+
+    @property
+    def expected(self) -> str:
+        return "copyable" if self.param.must_be_copyable else "droppable"
 
 
 @dataclass(frozen=True)

--- a/guppylang/checker/expr_checker.py
+++ b/guppylang/checker/expr_checker.py
@@ -1111,15 +1111,15 @@ def check_inst(func_ty: FunctionType, inst: Inst, node: AstNode) -> None:
     """
     for param, arg in zip(func_ty.params, inst, strict=True):
         # Give a more informative error message for linearity issues
-        if (
-            isinstance(param, TypeParam)
-            and isinstance(arg, TypeArg)
-            and arg.ty.linear
-            and not param.can_be_linear
-        ):
-            raise GuppyTypeError(
-                NonLinearInstantiateError(node, param, func_ty, arg.ty)
-            )
+        if isinstance(param, TypeParam) and isinstance(arg, TypeArg):
+            if param.must_be_copyable and not arg.ty.copyable:
+                raise GuppyTypeError(
+                    NonLinearInstantiateError(node, param, func_ty, arg.ty)
+                )
+            if param.must_be_droppable and not arg.ty.droppable:
+                raise GuppyTypeError(
+                    NonLinearInstantiateError(node, param, func_ty, arg.ty)
+                )
         # For everything else, we fall back to the default checking implementation
         param.check_arg(arg, node)
 

--- a/guppylang/tys/param.py
+++ b/guppylang/tys/param.py
@@ -101,9 +101,18 @@ class TypeParam(ParameterBase):
                 err = ExpectedError(loc, "a type", got=f"value of type `{const.ty}`")
                 raise GuppyTypeError(err)
             case TypeArg(ty):
-                if not self.can_be_linear and ty.linear:
+                if self.must_be_copyable and not ty.copyable:
                     err = ExpectedError(
-                        loc, "a non-linear type", got=f"value of type `{ty}`"
+                        loc,
+                        "a copyable type",
+                        got=f"type `{ty}` which is not implicitly copyable",
+                    )
+                    raise GuppyTypeError(err)
+                if self.must_be_droppable and not ty.droppable:
+                    err = ExpectedError(
+                        loc,
+                        "a droppable type",
+                        got=f"type `{ty}` which is not implicitly droppable",
                     )
                     raise GuppyTypeError(err)
                 return arg

--- a/tests/error/poly_errors/non_linear2.err
+++ b/tests/error/poly_errors/non_linear2.err
@@ -3,7 +3,7 @@ Error: Not defined for linear argument (at $FILE:23:4)
 21 | @guppy(module)
 22 | def main() -> None:
 23 |     foo(h)
-   |     ^^^^^^ Cannot instantiate non-linear type parameter `T` in type
-   |            `forall T. (T -> T) -> None` with linear type `qubit`
+   |     ^^^^^^ Cannot instantiate copyable type parameter `T` in type
+   |            `forall T. (T -> T) -> None` with non-copyable type `qubit`
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/poly_errors/non_linear3.err
+++ b/tests/error/poly_errors/non_linear3.err
@@ -3,7 +3,8 @@ Error: Not defined for linear argument (at $FILE:25:4)
 23 | @guppy(module)
 24 | def main() -> None:
 25 |     foo(h)
-   |     ^^^^^^ Cannot instantiate non-linear type parameter `T` in type
-   |            `forall T. (T -> None) -> None` with linear type `qubit`
+   |     ^^^^^^ Cannot instantiate copyable type parameter `T` in type
+   |            `forall T. (T -> None) -> None` with non-copyable type
+   |            `qubit`
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/poly_errors/non_linear4.err
+++ b/tests/error/poly_errors/non_linear4.err
@@ -3,7 +3,7 @@ Error: Not defined for linear argument (at $FILE:21:4)
 19 | @guppy(module)
 20 | def main(q: qubit) -> None:
 21 |     foo(q)
-   |     ^^^^^^ Cannot instantiate copyable type parameter `T` in type
-   |            `forall T. T -> None` with non-copyable type `qubit`
+   |     ^^^^^^ Cannot instantiate droppable type parameter `T` in type
+   |            `forall T. T -> None` with non-droppable type `qubit`
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/poly_errors/non_linear4.py
+++ b/tests/error/poly_errors/non_linear4.py
@@ -1,0 +1,24 @@
+from guppylang.decorator import guppy
+from guppylang.module import GuppyModule
+from guppylang.std.quantum import qubit
+
+import guppylang.std.quantum as quantum
+
+module = GuppyModule("test")
+module.load_all(quantum)
+
+
+T = guppy.type_var("T", copyable=False, droppable=True, module=module)
+
+
+@guppy.declare(module)
+def foo(x: T) -> None:
+    ...
+
+
+@guppy(module)
+def main(q: qubit) -> None:
+    foo(q)
+
+
+module.compile()

--- a/tests/error/poly_errors/type_arg_not_copyable.err
+++ b/tests/error/poly_errors/type_arg_not_copyable.err
@@ -1,0 +1,9 @@
+Error: Expected a copyable type (at $FILE:17:12)
+   | 
+15 | @guppy(module)
+16 | def main() -> None:
+17 |     f = foo[array[int, 10]]
+   |             ^^^^^^^^^^^^^^ Expected a copyable type, got type `array[int, 10]` which is
+   |                            not implicitly copyable
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/poly_errors/type_arg_not_copyable.py
+++ b/tests/error/poly_errors/type_arg_not_copyable.py
@@ -1,0 +1,20 @@
+from guppylang import array
+from guppylang.decorator import guppy
+from guppylang.module import GuppyModule
+
+module = GuppyModule("test")
+
+T = guppy.type_var("T", copyable=True, droppable=False, module=module)
+
+
+@guppy(module)
+def foo(x: T) -> T:
+    return x
+
+
+@guppy(module)
+def main() -> None:
+    f = foo[array[int, 10]]
+
+
+module.compile()

--- a/tests/error/poly_errors/type_arg_not_droppable.err
+++ b/tests/error/poly_errors/type_arg_not_droppable.err
@@ -1,0 +1,9 @@
+Error: Expected a droppable type (at $FILE:19:12)
+   | 
+17 | @guppy(module)
+18 | def main() -> None:
+19 |     f = foo[qubit]
+   |             ^^^^^ Expected a droppable type, got type `qubit` which is not
+   |                   implicitly droppable
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/poly_errors/type_arg_not_droppable.py
+++ b/tests/error/poly_errors/type_arg_not_droppable.py
@@ -1,0 +1,22 @@
+from guppylang.std.builtins import owned
+from guppylang.std.quantum import qubit
+from guppylang.decorator import guppy
+from guppylang.module import GuppyModule
+
+module = GuppyModule("test")
+module.load(qubit)
+
+T = guppy.type_var("T", copyable=False, droppable=True, module=module)
+
+
+@guppy(module)
+def foo(x: T @ owned) -> T:
+    return x
+
+
+@guppy(module)
+def main() -> None:
+    f = foo[qubit]
+
+
+module.compile()


### PR DESCRIPTION
Fixes #867