### PR TITLE
fix: Fix resolution of generic lengths in array constructor

### DIFF
--- a/guppylang/std/_internal/checker.py
+++ b/guppylang/std/_internal/checker.py
@@ -253,8 +253,12 @@ class NewArrayChecker(CustomCallChecker):
                                 )
                             )
                         subst |= ls
+                        type_args = [
+                            TypeArg(elem_ty.substitute(subst)),
+                            ConstValue(nat_type(), len(args)),
+                        ]
                         call = GlobalCall(
-                            def_id=self.func.id, args=args, type_args=ty.args
+                            def_id=self.func.id, args=args, type_args=type_args
                         )
                         return with_loc(self.node, call), subst
             case type_args:

--- a/tests/integration/test_array.py
+++ b/tests/integration/test_array.py
@@ -99,6 +99,21 @@ def test_new_array_infer_nested(validate):
     validate(main)
 
 
+def test_new_array_check_nested_length(validate):
+    module = GuppyModule("test")
+    n = guppy.nat_var("n", module=module)
+
+    @guppy(module)
+    def foo(xs: array[array[int, n], 1]) -> None:
+        pass
+
+    @guppy(module)
+    def main() -> None:
+        foo(array(array(1, 2, 3)))
+
+    validate(module.compile())
+
+
 def test_return_linear_array(validate):
     module = GuppyModule("test")
     module.load(qubit)


### PR DESCRIPTION
Fixes #939

The problem was that we forgot to store the inferred type args in the constructor call and instead just reused the previous `ty.args` which could still contain free type variables