### PR TITLE
fix: Fix comptime angle arithmetic

### DIFF
--- a/guppylang/tracing/object.py
+++ b/guppylang/tracing/object.py
@@ -97,7 +97,9 @@ def binary_operation(f: BinaryDunderMethod) -> BinaryDunderMethod:
         with suppress(Exception):
             return f(self, other)
 
-        # If that failed, try the reverse method on `other`
+        # If that failed, try the reverse method on `other`.
+        # NB: We know that `f.__name__` is in one of the tables since we make sure to
+        # only put this decorator on the correct dunder methods below
         if f.__name__ in binary_table:
             reverse_method, display_name = binary_table[f.__name__]
             left_ty, right_ty = self._ty, other._ty

--- a/guppylang/tracing/object.py
+++ b/guppylang/tracing/object.py
@@ -115,168 +115,174 @@ def binary_operation(f: BinaryDunderMethod) -> BinaryDunderMethod:
 
 
 class DunderMixin:
-    """Mixin class to allow `GuppyObject`s to be used in arithmetic expressions etc.
-    via providing the corresponding dunder methods delegating to the objects impls.
+    """Mixin class to allow `GuppyObject`s and `GuppyDefinition`s to be used in
+    arithmetic expressions etc. via providing the corresponding dunder methods
+    delegating to the objects impls.
     """
 
-    def __getattr__(self, item: Any) -> Any:
-        return super().__getattribute__(item)
+    def _get_method(self, name: str) -> Any:
+        from guppylang.tracing.state import get_tracing_state
+        from guppylang.tracing.unpacking import guppy_object_from_py
+
+        state = get_tracing_state()
+        self = guppy_object_from_py(self, state.dfg.builder, state.node)
+        return self.__getattr__(name)
 
     def __abs__(self) -> Any:
-        return self.__getattr__("__abs__")()
+        return self._get_method("__abs__")()
 
     @binary_operation
     def __add__(self, other: Any) -> Any:
-        return self.__getattr__("__add__")(other)
+        return self._get_method("__add__")(other)
 
     @binary_operation
     def __and__(self, other: Any) -> Any:
-        return self.__getattr__("__and__")(other)
+        return self._get_method("__and__")(other)
 
     def __bool__(self: Any) -> Any:
-        return self.__getattr__("__bool__")()
+        return self._get_method("__bool__")()
 
     def __ceil__(self: Any) -> Any:
-        return self.__getattr__("__ceil__")()
+        return self._get_method("__ceil__")()
 
     def __divmod__(self, other: Any) -> Any:
-        return self.__getattr__("__divmod__")(other)
+        return self._get_method("__divmod__")(other)
 
     @binary_operation
     def __eq__(self, other: object) -> Any:
-        return self.__getattr__("__eq__")(other)
+        return self._get_method("__eq__")(other)
 
     def __float__(self) -> Any:
-        return self.__getattr__("__float__")()
+        return self._get_method("__float__")()
 
     def __floor__(self) -> Any:
-        return self.__getattr__("__floor__")()
+        return self._get_method("__floor__")()
 
     @binary_operation
     def __floordiv__(self, other: Any) -> Any:
-        return self.__getattr__("__floordiv__")(other)
+        return self._get_method("__floordiv__")(other)
 
     @binary_operation
     def __ge__(self, other: Any) -> Any:
-        return self.__getattr__("__ge__")(other)
+        return self._get_method("__ge__")(other)
 
     @binary_operation
     def __gt__(self, other: Any) -> Any:
-        return self.__getattr__("__gt__")(other)
+        return self._get_method("__gt__")(other)
 
     def __int__(self) -> Any:
-        return self.__getattr__("__int__")()
+        return self._get_method("__int__")()
 
     @unary_operation
     def __invert__(self) -> Any:
-        return self.__getattr__("__invert__")()
+        return self._get_method("__invert__")()
 
     @binary_operation
     def __le__(self, other: Any) -> Any:
-        return self.__getattr__("__le__")(other)
+        return self._get_method("__le__")(other)
 
     @binary_operation
     def __lshift__(self, other: Any) -> Any:
-        return self.__getattr__("__lshift__")(other)
+        return self._get_method("__lshift__")(other)
 
     @binary_operation
     def __lt__(self, other: Any) -> Any:
-        return self.__getattr__("__lt__")(other)
+        return self._get_method("__lt__")(other)
 
     @binary_operation
     def __mod__(self, other: Any) -> Any:
-        return self.__getattr__("__mod__")(other)
+        return self._get_method("__mod__")(other)
 
     @binary_operation
     def __mul__(self, other: Any) -> Any:
-        return self.__getattr__("__mul__")(other)
+        return self._get_method("__mul__")(other)
 
     @binary_operation
     def __ne__(self, other: object) -> Any:
-        return self.__getattr__("__ne__")(other)
+        return self._get_method("__ne__")(other)
 
     @unary_operation
     def __neg__(self) -> Any:
-        return self.__getattr__("__neg__")()
+        return self._get_method("__neg__")()
 
     @binary_operation
     def __or__(self, other: Any) -> Any:
-        return self.__getattr__("__or__")(other)
+        return self._get_method("__or__")(other)
 
     @unary_operation
     def __pos__(self) -> Any:
-        return self.__getattr__("__pos__")()
+        return self._get_method("__pos__")()
 
     @binary_operation
     def __pow__(self, other: Any) -> Any:
-        return self.__getattr__("__pow__")(other)
+        return self._get_method("__pow__")(other)
 
     @binary_operation
     def __radd__(self, other: Any) -> Any:
-        return self.__getattr__("__radd__")(other)
+        return self._get_method("__radd__")(other)
 
     @binary_operation
     def __rand__(self, other: Any) -> Any:
-        return self.__getattr__("__rand__")(other)
+        return self._get_method("__rand__")(other)
 
     @binary_operation
     def __rfloordiv__(self, other: Any) -> Any:
-        return self.__getattr__("__rfloordiv__")(other)
+        return self._get_method("__rfloordiv__")(other)
 
     @binary_operation
     def __rlshift__(self, other: Any) -> Any:
-        return self.__getattr__("__rlshift__")(other)
+        return self._get_method("__rlshift__")(other)
 
     @binary_operation
     def __rmod__(self, other: Any) -> Any:
-        return self.__getattr__("__rmod__")(other)
+        return self._get_method("__rmod__")(other)
 
     @binary_operation
     def __rmul__(self, other: Any) -> Any:
-        return self.__getattr__("__rmul__")(other)
+        return self._get_method("__rmul__")(other)
 
     @binary_operation
     def __ror__(self, other: Any) -> Any:
-        return self.__getattr__("__ror__")(other)
+        return self._get_method("__ror__")(other)
 
     @binary_operation
     def __rpow__(self, other: Any) -> Any:
-        return self.__getattr__("__rpow__")(other)
+        return self._get_method("__rpow__")(other)
 
     @binary_operation
     def __rrshift__(self, other: Any) -> Any:
-        return self.__getattr__("__pow__")(other)
+        return self._get_method("__pow__")(other)
 
     @binary_operation
     def __rshift__(self, other: Any) -> Any:
-        return self.__getattr__("__rshift__")(other)
+        return self._get_method("__rshift__")(other)
 
     @binary_operation
     def __rsub__(self, other: Any) -> Any:
-        return self.__getattr__("__rsub__")(other)
+        return self._get_method("__rsub__")(other)
 
     @binary_operation
     def __rtruediv__(self, other: Any) -> Any:
-        return self.__getattr__("__rtruediv__")(other)
+        return self._get_method("__rtruediv__")(other)
 
     @binary_operation
     def __rxor__(self, other: Any) -> Any:
-        return self.__getattr__("__rxor__")(other)
+        return self._get_method("__rxor__")(other)
 
     @binary_operation
     def __sub__(self, other: Any) -> Any:
-        return self.__getattr__("__sub__")(other)
+        return self._get_method("__sub__")(other)
 
     @binary_operation
     def __truediv__(self, other: Any) -> Any:
-        return self.__getattr__("__truediv__")(other)
+        return self._get_method("__truediv__")(other)
 
     def __trunc__(self) -> Any:
-        return self.__getattr__("__trunc__")()
+        return self._get_method("__trunc__")()
 
     @binary_operation
     def __xor__(self, other: Any) -> Any:
-        return self.__getattr__("__xor__")(other)
+        return self._get_method("__xor__")(other)
 
 
 class ObjectUse(NamedTuple):
@@ -493,6 +499,10 @@ class GuppyDefinition(DunderMixin):
     @property
     def id(self) -> DefId:
         return self.wrapped.id
+
+    @hide_trace
+    def __getattr__(self, item: Any) -> Any:
+        return self.to_guppy_object().__getattr__(item)
 
     @hide_trace
     def __call__(self, *args: Any) -> Any:

--- a/guppylang/tracing/object.py
+++ b/guppylang/tracing/object.py
@@ -501,10 +501,6 @@ class GuppyDefinition(DunderMixin):
         return self.wrapped.id
 
     @hide_trace
-    def __getattr__(self, item: Any) -> Any:
-        return self.to_guppy_object().__getattr__(item)
-
-    @hide_trace
     def __call__(self, *args: Any) -> Any:
         from guppylang.tracing.function import trace_call
 

--- a/tests/integration/tracing/test_arithmetic.py
+++ b/tests/integration/tracing/test_arithmetic.py
@@ -1,6 +1,9 @@
 from guppylang.decorator import guppy
 from guppylang.module import GuppyModule
+from guppylang.std.angles import angle, pi
 from guppylang.std.builtins import nat
+
+from hugr.std.int import IntVal
 
 
 def test_int(validate, run_int_fn):
@@ -113,6 +116,37 @@ def test_float(validate, run_float_fn_approx):
     # run_float_fn_approx(compiled, ..., "pow", [...])
 
 
+def test_angle(validate):
+    module = GuppyModule("module")
+    module.load(angle, pi)
+
+    @guppy.comptime(module)
+    def neg(x: angle) -> angle:
+        return -x
+
+    @guppy.comptime(module)
+    def neg_pi() -> angle:
+        return -pi
+
+    @guppy.comptime(module)
+    def add(x: angle, y: float) -> angle:
+        return pi + (x + angle(y) + pi)
+
+    @guppy.comptime(module)
+    def sub(x: float, y: angle) -> angle:
+        return pi - (angle(x) - (y - pi))
+
+    @guppy.comptime(module)
+    def mul(x: float, y: angle) -> angle:
+        return 1.5 * (x * (y * 2))
+
+    @guppy.comptime(module)
+    def div(x: angle, y: float) -> angle:
+        return x / y
+
+    validate(module.compile())
+
+
 def test_dunder_coercions(validate):
     module = GuppyModule("module")
 
@@ -141,3 +175,30 @@ def test_dunder_coercions(validate):
         return x + y
 
     validate(module.compile())
+
+
+def test_const(validate):
+    module = GuppyModule("module")
+
+    x = guppy.constant("x", "int", IntVal(10, 6))
+
+    @guppy.comptime(module)
+    def test1() -> int:
+        return -x
+
+    @guppy.comptime(module)
+    def test2() -> int:
+        return 1 + x
+
+    @guppy.comptime(module)
+    def test2() -> int:
+        return x * 2
+
+    @guppy.comptime(module)
+    def test3() -> float:
+        return 1.5 - x
+
+    @guppy.comptime(module)
+    def test4() -> float:
+        return x / 0.5
+


### PR DESCRIPTION
Fixes #946

The problem was that `pi` is a `@guppy.constant` (i.e. a `GuppyDefinition` at comptime) which didn't implement the corresponding `__add__` etc dunder methods.

I fixed this by making `GuppyDefinition` inherit from `DunderMixin` as well as refactoring the `binary_operation` and `unray_operation` wrappers to first load definitions as values (via `guppy_object_from_py`) before calling the methods.