### PR TITLE
fix: Capture entire Python scope when defining comptime functions

### DIFF
--- a/guppylang/decorator.py
+++ b/guppylang/decorator.py
@@ -181,7 +181,12 @@ class _Guppy:
     @pretty_errors
     def comptime(self, arg: PyFunc | GuppyModule) -> FuncDecorator | GuppyDefinition:
         def dec(f: Callable[..., Any], module: GuppyModule) -> GuppyDefinition:
-            defn = RawTracedFunctionDef(DefId.fresh(module), f.__name__, None, f, {})
+            from guppylang.module import get_py_scope
+
+            py_scope = get_py_scope(f)
+            defn = RawTracedFunctionDef(
+                DefId.fresh(module), f.__name__, None, f, py_scope
+            )
             module.register_def(defn)
             return GuppyDefinition(defn)
 

--- a/tests/integration/tracing/test_basic.py
+++ b/tests/integration/tracing/test_basic.py
@@ -2,6 +2,7 @@ from collections.abc import Callable
 
 from guppylang.decorator import guppy
 from guppylang.module import GuppyModule
+from guppylang.std.builtins import array, comptime
 
 from hugr import ops
 from hugr.std.int import IntVal
@@ -80,5 +81,21 @@ def test_load_func(validate):
     def test() -> Callable[[int], int]:
         return foo
 
+    validate(module.compile())
+
+
+def test_inner_scope(validate):
+    module = GuppyModule("test")
+
+    def make(n: int):
+        @guppy.comptime(module)
+        def foo() -> int:
+            return n
+
+        @guppy.comptime(module)
+        def bar(xs: array[int, comptime(n)]) -> None:
+            pass
+
+    make(42)
     validate(module.compile())
 

--- a/tests/integration/tracing/test_basic.py
+++ b/tests/integration/tracing/test_basic.py
@@ -88,6 +88,9 @@ def test_inner_scope(validate):
     module = GuppyModule("test")
 
     def make(n: int):
+        # Test that `n` is scope even if it is only defined in this function scope
+        # instead of globally:
+
         @guppy.comptime(module)
         def foo() -> int:
             return n


### PR DESCRIPTION
Fixes #945