### PR TITLE
fix: Specify bash shell in justfile.

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+set shell := ["bash", "-uc"]
+
 # List the available commands
 help:
     @just --list --justfile {{justfile()}}


### PR DESCRIPTION
Otherwise, it uses `sh` which doesn't recognize the `[[` ... `]]` syntax:
```
[[ -n "${JUST_INHIBIT_GIT_HOOKS:-}" ]] || uv run pre-commit install -t pre-commit
sh: 1: [[: not found
```