### PR TITLE
refactor!: delete deprecated result modules

### DIFF
--- a/guppylang/hresult.py
+++ b/guppylang/hresult.py
@@ -1,2 +1,0 @@
-# TODO module is deprecated remove in breaking update.
-from .qsys_result import *  # noqa: F403

--- a/guppylang/qsys_result.py
+++ b/guppylang/qsys_result.py
@@ -1,2 +1,0 @@
-# TODO module is deprecated remove in breaking update.
-from hugr.qsystem.result import *  # noqa: F403

--- a/guppylang/std/qsystem/__init__.py
+++ b/guppylang/std/qsystem/__init__.py
@@ -1,7 +1,5 @@
 from typing import no_type_check
 
-from typing_extensions import deprecated
-
 from guppylang.decorator import guppy
 from guppylang.module import GuppyModule
 from guppylang.std import angles
@@ -29,12 +27,11 @@ def phased_x(q: qubit, angle1: angle, angle2: angle) -> None:
 
 
 @guppy(qsystem)
-@deprecated("zz_max is not a system primitive, use zz_phase directly with angle pi/2.")
 @no_type_check
 def zz_max(q1: qubit, q2: qubit) -> None:
-    """ZZMax operation from the qsystem extension.
+    """Maximally entangling ZZPhase.
 
-    This is a special case of the ZZPhase operation with angle = pi/2.
+    Equivalent to `zz_phase(q1, q2, pi/2).
     """
     zz_phase(q1, q2, pi / 2)
 


### PR DESCRIPTION
drive-by keep zz_max as a library function

BREAKING CHANGE: deprecated `hresult` and `qsys_result` modules have been removed. Use `hugr.qysystem.result` directly.