### PR TITLE
fix: Merge `Bool` and `bool` in builtins

### DIFF
--- a/guppylang/std/builtins.py
+++ b/guppylang/std/builtins.py
@@ -109,9 +109,6 @@ class bool:
     ``False`` using the standard truth testing procedure.
     """
 
-
-@guppy.extend_type(bool_type_def)
-class Bool:
     @guppy.hugr_op(bool_logic_op("and"))
     def __and__(self: bool, other: bool) -> bool: ...
 


### PR DESCRIPTION
At some point during merging the rename from `Bool` to `bool` from commit https://github.com/CQCL/guppylang/pull/884 must have been accidentally reverted, causing issues with docs