### PR TITLE
feat: Allow users to wrap `guppy` in their own decorator

### DIFF
--- a/guppylang/decorator.py
+++ b/guppylang/decorator.py
@@ -471,10 +471,40 @@ def _find_load_call(sources: SourceMap) -> Span | None:
     return None
 
 
+def custom_guppy_decorator(f: F) -> F:
+    """Decorator to mark user-defined decorators thag wrap builtin `guppy` decorators.
+
+    Example:
+
+    ```
+    @custom_guppy_decorator
+    def my_guppy(f):
+        # Some custom logic here ...
+        return guppy(f)
+
+    @my_guppy
+    def main() -> int: ...
+    ```
+
+    If the `custom_guppy_decorator` were missing, then the `@my_guppy` annotation would
+    not produce a valid guppy definition.
+    """
+    object.__setattr__(f, "__custom_guppy_decorator__", True)
+    return f
+
+
 def get_calling_frame() -> FrameType:
     """Finds the first frame that called this function outside the compiler modules."""
     frame = inspect.currentframe()
     while frame:
+        # Skip frame if we're inside a user-defined decorator that wraps the `guppy`
+        # decorator. Those are functions that have a `__custom_guppy_decorator__` field.
+        # We can get a reference to the calling function by looking up the code function
+        # name in the frame globals:
+        func = frame.f_globals.get(frame.f_code.co_name)
+        if hasattr(func, "__custom_guppy_decorator__"):
+            frame = frame.f_back
+            continue
         module = inspect.getmodule(frame)
         if module is None:
             return frame

--- a/tests/integration/test_custom_decorator.py
+++ b/tests/integration/test_custom_decorator.py
@@ -1,0 +1,27 @@
+from guppylang.decorator import custom_guppy_decorator, guppy
+
+
+@custom_guppy_decorator
+def my_guppy(f):
+    return guppy(f)
+
+
+def test_custom_decorator(validate):
+    def make():
+        @my_guppy
+        def foooo() -> int:
+            return 1 + bar()
+
+        return foooo
+
+    foo = make()
+
+    @guppy
+    def bar() -> int:
+        return 2 + foo()
+
+    @my_guppy
+    def main() -> int:
+        return foo() + bar() + main()
+
+    validate(guppy.compile(main))

--- a/tests/util.py
+++ b/tests/util.py
@@ -4,11 +4,13 @@ from typing import TYPE_CHECKING
 
 import guppylang
 from guppylang import guppy
+from guppylang.decorator import custom_guppy_decorator
 
 if TYPE_CHECKING:
     from hugr.package import FuncDefnPointer, PackagePointer
 
 
+@custom_guppy_decorator
 def compile_guppy(fn) -> FuncDefnPointer:
     """A decorator that combines @guppy with HUGR compilation."""
     defn = guppylang.decorator.guppy(fn)


### PR DESCRIPTION
Closes #1016

Adds a new `@custom_guppy_decorator` decorator to annotate functions that wrap a call to the builtin `guppy` decorator. This makes the compiler aware that the function acts as a decorator which is taken into account during name resolution.

Examples:

```python
@custom_guppy_decorator
def my_guppy(f):
    # Some custom logic here ...
    return guppy(f)

@my_guppy
def main() -> int: ...
```

If the `@custom_guppy_decorator` were missing, then compilation of `main` would not work correctly.