### PR TITLE
feat: Add generic `guppy.const_var` declarations

### DIFF
--- a/guppylang/compiler/core.py
+++ b/guppylang/compiler/core.py
@@ -21,6 +21,7 @@ from guppylang.definition.ty import TypeDef
 from guppylang.definition.value import CompiledCallableDef
 from guppylang.engine import ENGINE
 from guppylang.error import InternalGuppyError
+from guppylang.tys.common import ToHugrContext
 from guppylang.tys.ty import StructType, Type
 
 CompiledLocals = dict[PlaceId, Wire]
@@ -42,7 +43,7 @@ class GlobalConstId:
         return f"{self.base_name}.{self.id}"
 
 
-class CompilerContext:
+class CompilerContext(ToHugrContext):
     """Compilation context containing all available definitions.
 
     Maintains a `worklist` of definitions which have been used by other compiled code

--- a/guppylang/compiler/expr_compiler.py
+++ b/guppylang/compiler/expr_compiler.py
@@ -135,7 +135,7 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
         assert len({inp.place.id for inp in inputs}) == len(
             inputs
         ), "Inputs are not unique"
-        self.dfg = DFContainer(builder, self.dfg.locals.copy())
+        self.dfg = DFContainer(builder, self.ctx, self.dfg.locals.copy())
         hugr_input = builder.input_node
         for input_node, wire in zip(inputs, hugr_input, strict=True):
             self.dfg[input_node.place] = wire
@@ -239,7 +239,7 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
             yield
 
     def visit_Constant(self, node: ast.Constant) -> Wire:
-        if value := python_value_to_hugr(node.value, get_type(node)):
+        if value := python_value_to_hugr(node.value, get_type(node), self.ctx):
             return self.builder.load(value)
         raise InternalGuppyError("Unsupported constant expression in compiler")
 
@@ -264,7 +264,7 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
     def visit_GenericParamValue(self, node: GenericParamValue) -> Wire:
         match node.param.ty:
             case NumericType(NumericType.Kind.Nat):
-                arg = node.param.to_bound().to_hugr()
+                arg = node.param.to_bound().to_hugr(self.ctx)
                 load_nat = hugr.std.PRELUDE.get_op("load_nat").instantiate(
                     [arg], ht.FunctionType([], [ht.USize()])
                 )
@@ -286,16 +286,16 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
         inputs = [self.visit(e) for e in node.elts]
         list_ty = get_type(node)
         elem_ty = get_element_type(list_ty)
-        return list_new(self.builder, elem_ty.to_hugr(), inputs)
+        return list_new(self.builder, elem_ty.to_hugr(self.ctx), inputs)
 
     def _unpack_tuple(self, wire: Wire, types: Sequence[Type]) -> Sequence[Wire]:
         """Add a tuple unpack operation to the graph"""
-        types = [t.to_hugr() for t in types]
+        types = [t.to_hugr(self.ctx) for t in types]
         return list(self.builder.add_op(ops.UnpackTuple(types), wire))
 
     def _pack_tuple(self, wires: Sequence[Wire], types: Sequence[Type]) -> Wire:
         """Add a tuple pack operation to the graph"""
-        types = [t.to_hugr() for t in types]
+        types = [t.to_hugr(self.ctx) for t in types]
         return self.builder.add_op(ops.MakeTuple(types), *wires)
 
     def _pack_returns(self, returns: Sequence[Wire], return_ty: Type) -> Wire:
@@ -345,7 +345,9 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
         num_returns = len(type_to_row(func_ty.output))
 
         args = self._compile_call_args(node.args, func_ty)
-        call = self.builder.add_op(ops.CallIndirect(func_ty.to_hugr()), func, *args)
+        call = self.builder.add_op(
+            ops.CallIndirect(func_ty.to_hugr(self.ctx)), func, *args
+        )
         regular_returns = list(call[:num_returns])
         inout_returns = call[num_returns:]
         self._update_inout_ports(node.args, inout_returns, func_ty)
@@ -401,7 +403,7 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
             consumed_args, other_args = args[0:input_len], args[input_len:]
             consumed_wires = self._compile_call_args(consumed_args, func_ty)
             call = self.builder.add_op(
-                ops.CallIndirect(func_ty.to_hugr()), func, *consumed_wires
+                ops.CallIndirect(func_ty.to_hugr(self.ctx)), func, *consumed_wires
             )
             regular_returns: list[Wire] = list(call[:num_returns])
             inout_returns = call[num_returns:]
@@ -449,7 +451,8 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
         func_ty = get_type(node.func)
         assert isinstance(func_ty, FunctionType)
         op = PartialOp.from_closure(
-            func_ty.to_hugr(), [get_type(arg).to_hugr() for arg in node.args]
+            func_ty.to_hugr(self.ctx),
+            [get_type(arg).to_hugr(self.ctx) for arg in node.args],
         )
         return self.builder.add_op(
             op, self.visit(node.func), *(self.visit(arg) for arg in node.args)
@@ -499,7 +502,7 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
 
     def visit_ResultExpr(self, node: ResultExpr) -> Wire:
         value_wire = self.visit(node.value)
-        base_ty = node.base_ty.to_hugr()
+        base_ty = node.base_ty.to_hugr(self.ctx)
         extra_args: list[ht.TypeArg] = []
         if isinstance(node.base_ty, NumericType):
             match node.base_ty.kind:
@@ -519,7 +522,7 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
             base_name = "bool"
         if node.array_len is not None:
             op_name = f"result_array_{base_name}"
-            size_arg = node.array_len.to_arg().to_hugr()
+            size_arg = node.array_len.to_arg().to_hugr(self.ctx)
             extra_args = [size_arg, *extra_args]
             # Remove the option wrapping in the array
             unwrap = array_unwrap_elem(self.ctx)
@@ -559,8 +562,8 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
 
     def visit_PanicExpr(self, node: PanicExpr) -> Wire:
         err = build_error(self.builder, node.signal, node.msg)
-        in_tys = [get_type(e).to_hugr() for e in node.values]
-        out_tys = [ty.to_hugr() for ty in type_to_row(get_type(node))]
+        in_tys = [get_type(e).to_hugr(self.ctx) for e in node.values]
+        out_tys = [ty.to_hugr(self.ctx) for ty in type_to_row(get_type(node))]
         args = [self.visit(e) for e in node.values]
         match node.kind:
             case ExitKind.Panic:
@@ -571,7 +574,7 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
         return self._pack_returns(list(h_node.outputs()), get_type(node))
 
     def visit_BarrierExpr(self, node: BarrierExpr) -> Wire:
-        hugr_tys = [get_type(e).to_hugr() for e in node.args]
+        hugr_tys = [get_type(e).to_hugr(self.ctx) for e in node.args]
         op = hugr.std.prelude.PRELUDE_EXTENSION.get_op("Barrier").instantiate(
             [ht.SequenceArg([ht.TypeTypeArg(ty) for ty in hugr_tys])],
             ht.FunctionType.endo(hugr_tys),
@@ -588,7 +591,7 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
         assert isinstance(list_ty, OpaqueType)
         elem_ty = get_element_type(list_ty)
         list_place = Variable(next(tmp_vars), list_ty, node)
-        self.dfg[list_place] = list_new(self.builder, elem_ty.to_hugr(), [])
+        self.dfg[list_place] = list_new(self.builder, elem_ty.to_hugr(self.ctx), [])
         with self._build_generators(node.generators, [list_place]):
             elt_port = self.visit(node.elt)
             list_port = self.dfg[list_place]
@@ -604,16 +607,16 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
         array_var = Variable(next(tmp_vars), array_ty, node)
         count_var = Variable(next(tmp_vars), int_type(), node)
         # See https://github.com/CQCL/guppylang/issues/629
-        hugr_elt_ty = ht.Option(node.elt_ty.to_hugr())
+        hugr_elt_ty = ht.Option(node.elt_ty.to_hugr(self.ctx))
         # Initialise array with `None`s
         make_none = array_comprehension_init_func(self.ctx)
         make_none = self.builder.load_function(
             make_none,
             instantiation=ht.FunctionType([], [hugr_elt_ty]),
-            type_args=[ht.TypeTypeArg(node.elt_ty.to_hugr())],
+            type_args=[ht.TypeTypeArg(node.elt_ty.to_hugr(self.ctx))],
         )
         self.dfg[array_var] = self.builder.add_op(
-            array_repeat(hugr_elt_ty, node.length.to_arg().to_hugr()), make_none
+            array_repeat(hugr_elt_ty, node.length.to_arg().to_hugr(self.ctx)), make_none
         )
         self.dfg[count_var] = self.builder.load(
             hugr.std.int.IntVal(0, width=NumericType.INT_WIDTH)
@@ -677,7 +680,7 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
                     outputs=[break_pred, *inputs],
                 )
                 # In the "no" case, we set the break predicate to true
-                break_pred_hugr_ty = ht.Either([iter_ty.to_hugr()], [])
+                break_pred_hugr_ty = ht.Either([iter_ty.to_hugr(self.ctx)], [])
                 with stop_case:
                     self.dfg[break_pred.place] = self.dfg.builder.add_op(
                         ops.Tag(1, break_pred_hugr_ty)
@@ -718,7 +721,7 @@ def instantiation_needs_unpacking(func_ty: FunctionType, inst: Inst) -> bool:
     return False
 
 
-def python_value_to_hugr(v: Any, exp_ty: Type) -> hv.Value | None:
+def python_value_to_hugr(v: Any, exp_ty: Type, ctx: CompilerContext) -> hv.Value | None:
     """Turns a Python value into a Hugr value.
 
     Returns None if the Python value cannot be represented in Guppy.
@@ -735,7 +738,7 @@ def python_value_to_hugr(v: Any, exp_ty: Type) -> hv.Value | None:
         case tuple(elts):
             assert isinstance(exp_ty, TupleType)
             vs = [
-                python_value_to_hugr(elt, ty)
+                python_value_to_hugr(elt, ty, ctx)
                 for elt, ty in zip(elts, exp_ty.element_types, strict=True)
             ]
             if doesnt_contain_none(vs):
@@ -743,10 +746,10 @@ def python_value_to_hugr(v: Any, exp_ty: Type) -> hv.Value | None:
         case list(elts):
             assert is_frozenarray_type(exp_ty)
             elem_ty = get_element_type(exp_ty)
-            vs = [python_value_to_hugr(elt, elem_ty) for elt in elts]
+            vs = [python_value_to_hugr(elt, elem_ty, ctx) for elt in elts]
             if doesnt_contain_none(vs):
                 return hugr.std.collections.static_array.StaticArrayVal(
-                    vs, elem_ty.to_hugr(), name=f"static_pyarray.{next(tmp_vars)}"
+                    vs, elem_ty.to_hugr(ctx), name=f"static_pyarray.{next(tmp_vars)}"
                 )
         case _:
             return None

--- a/guppylang/compiler/func_compiler.py
+++ b/guppylang/compiler/func_compiler.py
@@ -36,13 +36,13 @@ def compile_local_func_def(
 
     # Pick an order for the captured variables
     captured = list(func.captured.values())
-    captured_types = [v.ty.to_hugr() for v, _ in captured]
+    captured_types = [v.ty.to_hugr(ctx) for v, _ in captured]
 
     # Whether the function calls itself recursively.
     recursive = func.name in func.cfg.live_before[func.cfg.entry_bb]
 
     # Prepend captured variables to the function arguments
-    func_ty = func.ty.to_hugr()
+    func_ty = func.ty.to_hugr(ctx)
     closure_ty = ht.FunctionType([*captured_types, *func_ty.input], func_ty.output)
     func_builder = dfg.builder.define_function(
         func.name, closure_ty.input, closure_ty.output

--- a/guppylang/compiler/stmt_compiler.py
+++ b/guppylang/compiler/stmt_compiler.py
@@ -101,7 +101,7 @@ class StmtCompiler(CompilerBase, AstVisitor[None]):
         """Handles assignment where the RHS is a tuple that should be unpacked."""
         # Unpack the RHS tuple
         left, starred, right = lhs.pattern.left, lhs.pattern.starred, lhs.pattern.right
-        types = [ty.to_hugr() for ty in type_to_row(get_type(lhs))]
+        types = [ty.to_hugr(self.ctx) for ty in type_to_row(get_type(lhs))]
         unpack = self.builder.add_op(ops.UnpackTuple(types), port)
         ports = list(unpack)
 
@@ -118,7 +118,7 @@ class StmtCompiler(CompilerBase, AstVisitor[None]):
             starred_ports = (
                 ports[len(left) : -len(right)] if right else ports[len(left) :]
             )
-            elt = get_element_type(array_ty).to_hugr()
+            elt = get_element_type(array_ty).to_hugr(self.ctx)
             opts = [self.builder.add_op(ops.Some(elt), p) for p in starred_ports]
             array = self.builder.add_op(array_new(ht.Option(elt), len(opts)), *opts)
             self._assign(starred, array)
@@ -132,7 +132,7 @@ class StmtCompiler(CompilerBase, AstVisitor[None]):
         assert isinstance(lhs.compr.length, ConstValue)
         length = lhs.compr.length.value
         assert isinstance(length, int)
-        opt_elt_ty = ht.Option(lhs.compr.elt_ty.to_hugr())
+        opt_elt_ty = ht.Option(lhs.compr.elt_ty.to_hugr(self.ctx))
 
         def pop(
             array: Wire, length: int, pats: list[ast.expr], from_left: bool
@@ -194,7 +194,7 @@ class StmtCompiler(CompilerBase, AstVisitor[None]):
 
             row: list[tuple[Wire, Type]]
             if isinstance(return_ty, TupleType):
-                types = [e.to_hugr() for e in return_ty.element_types]
+                types = [e.to_hugr(self.ctx) for e in return_ty.element_types]
                 unpack = self.builder.add_op(ops.UnpackTuple(types), port)
                 row = list(zip(unpack, return_ty.element_types, strict=True))
             else:

--- a/guppylang/decorator.py
+++ b/guppylang/decorator.py
@@ -14,6 +14,7 @@ from hugr.package import FuncDefnPointer, ModulePointer
 from typing_extensions import dataclass_transform
 
 from guppylang.ast_util import annotate_location
+from guppylang.compiler.core import CompilerContext
 from guppylang.definition.common import DefId
 from guppylang.definition.const import RawConstDef
 from guppylang.definition.custom import (
@@ -111,7 +112,7 @@ class _Guppy:
 
     def type(
         self,
-        hugr_ty: ht.Type | Callable[[Sequence[Argument]], ht.Type],
+        hugr_ty: ht.Type | Callable[[Sequence[Argument], CompilerContext], ht.Type],
         name: str = "",
         copyable: bool = True,
         droppable: bool = True,
@@ -128,7 +129,9 @@ class _Guppy:
         For generic types, a callable may be passed that takes the type arguments of a
         concrete instantiation.
         """
-        mk_hugr_ty = (lambda _: hugr_ty) if isinstance(hugr_ty, ht.Type) else hugr_ty
+        mk_hugr_ty = (
+            (lambda args, ctx: hugr_ty) if isinstance(hugr_ty, ht.Type) else hugr_ty
+        )
 
         def dec(c: type[T]) -> type[T]:
             defn = OpaqueTypeDef(
@@ -217,7 +220,7 @@ class _Guppy:
 
     def hugr_op(
         self,
-        op: Callable[[ht.FunctionType, Inst], ops.DataflowOp],
+        op: Callable[[ht.FunctionType, Inst, CompilerContext], ops.DataflowOp],
         checker: CustomCallChecker | None = None,
         higher_order_value: bool = True,
         name: str = "",

--- a/guppylang/definition/common.py
+++ b/guppylang/definition/common.py
@@ -125,7 +125,9 @@ class CompilableDef(Definition):
     """
 
     @abstractmethod
-    def compile_outer(self, module: DefinitionBuilder[OpVar]) -> "CompiledDef":
+    def compile_outer(
+        self, module: DefinitionBuilder[OpVar], ctx: "CompilerContext"
+    ) -> "CompiledDef":
         """Adds a Hugr node for the definition to the provided Hugr module.
 
         Note that is not required to fill in the contents of the node. At this point,

--- a/guppylang/definition/const.py
+++ b/guppylang/definition/const.py
@@ -39,7 +39,9 @@ class RawConstDef(ParsableDef):
 class ConstDef(RawConstDef, ValueDef, CompilableDef):
     """A constant with a checked type."""
 
-    def compile_outer(self, graph: DefinitionBuilder[OpVar]) -> "CompiledConstDef":
+    def compile_outer(
+        self, graph: DefinitionBuilder[OpVar], ctx: CompilerContext
+    ) -> "CompiledConstDef":
         const_node = graph.add_const(self.value)
         return CompiledConstDef(
             self.id,

--- a/guppylang/definition/custom.py
+++ b/guppylang/definition/custom.py
@@ -228,18 +228,18 @@ class CustomFunctionDef(CompiledCallableDef):
         # We create a generic `FunctionDef` that takes some inputs, compiles a call to
         # the function, and returns the results
         func, already_defined = ctx.declare_global_func(
-            self.higher_order_func_id, self.ty.to_hugr_poly()
+            self.higher_order_func_id, self.ty.to_hugr_poly(ctx)
         )
         if not already_defined:
-            func_dfg = DFContainer(func, dfg.locals.copy())
+            func_dfg = DFContainer(func, ctx, dfg.locals.copy())
             args: list[Wire] = list(func.inputs())
             generic_ty_args = [param.to_bound() for param in self.ty.params]
             returns = self.compile_call(args, generic_ty_args, func_dfg, ctx, node)
             func.set_outputs(*returns.regular_returns, *returns.inout_returns)
 
         # Finally, load the function into the local DFG
-        mono_ty = self.ty.instantiate(type_args).to_hugr()
-        hugr_ty_args = [arg.to_hugr() for arg in type_args]
+        mono_ty = self.ty.instantiate(type_args).to_hugr(ctx)
+        hugr_ty_args = [arg.to_hugr(ctx) for arg in type_args]
         return dfg.builder.load_function(func, mono_ty, hugr_ty_args)
 
     def compile_call(
@@ -259,7 +259,7 @@ class CustomFunctionDef(CompiledCallableDef):
                 [FuncInput(get_type(arg), InputFlags.NoFlags) for arg in node.args],
                 get_type(node),
             )
-        hugr_ty = concrete_ty.to_hugr()
+        hugr_ty = concrete_ty.to_hugr(ctx)
 
         self.call_compiler._setup(type_args, dfg, ctx, node, hugr_ty, self)
         return self.call_compiler.compile_with_inouts(args)
@@ -392,13 +392,15 @@ class OpCompiler(CustomInoutCallCompiler):
             the monomorphic function type, and returns a concrete HUGR op.
     """
 
-    op: Callable[[ht.FunctionType, Inst], ops.DataflowOp]
+    op: Callable[[ht.FunctionType, Inst, CompilerContext], ops.DataflowOp]
 
-    def __init__(self, op: Callable[[ht.FunctionType, Inst], ops.DataflowOp]) -> None:
+    def __init__(
+        self, op: Callable[[ht.FunctionType, Inst, CompilerContext], ops.DataflowOp]
+    ) -> None:
         self.op = op
 
     def compile_with_inouts(self, args: list[Wire]) -> CallReturnWires:
-        op = self.op(self.ty, self.type_args)
+        op = self.op(self.ty, self.type_args, self.ctx)
         node = self.builder.add_op(op, *args)
         num_returns = (
             len(type_to_row(self.func.ty.output)) if self.func else len(self.ty.output)
@@ -419,9 +421,11 @@ class BoolOpCompiler(CustomInoutCallCompiler):
             the monomorphic function type, and returns a concrete HUGR op.
     """
 
-    op: Callable[[ht.FunctionType, Inst], ops.DataflowOp]
+    op: Callable[[ht.FunctionType, Inst, CompilerContext], ops.DataflowOp]
 
-    def __init__(self, op: Callable[[ht.FunctionType, Inst], ops.DataflowOp]) -> None:
+    def __init__(
+        self, op: Callable[[ht.FunctionType, Inst, CompilerContext], ops.DataflowOp]
+    ) -> None:
         self.op = op
 
     def compile_with_inouts(self, args: list[Wire]) -> CallReturnWires:
@@ -430,7 +434,7 @@ class BoolOpCompiler(CustomInoutCallCompiler):
             ht.Bool if out == OpaqueBool else out for out in self.ty.output
         ]
         hugr_op_ty = ht.FunctionType(converted_in, converted_out)
-        op = self.op(hugr_op_ty, self.type_args)
+        op = self.op(hugr_op_ty, self.type_args, self.ctx)
         converted_args = [
             self.builder.add_op(read_bool(), arg)
             if self.builder.hugr.port_type(arg.out_port()) == OpaqueBool

--- a/guppylang/definition/declaration.py
+++ b/guppylang/definition/declaration.py
@@ -89,14 +89,16 @@ class CheckedFunctionDecl(RawFunctionDecl, CompilableDef, CallableDef):
         node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
         return with_type(ty, node), ty
 
-    def compile_outer(self, module: DefinitionBuilder[OpVar]) -> "CompiledFunctionDecl":
+    def compile_outer(
+        self, module: DefinitionBuilder[OpVar], ctx: CompilerContext
+    ) -> "CompiledFunctionDecl":
         """Adds a Hugr `FuncDecl` node for this function to the Hugr."""
         assert isinstance(
             module, hf.Module
         ), "Functions can only be declared in modules"
         module: hf.Module = module
 
-        node = module.declare_function(self.name, self.ty.to_hugr_poly())
+        node = module.declare_function(self.name, self.ty.to_hugr_poly(ctx))
         return CompiledFunctionDecl(
             self.id,
             self.name,

--- a/guppylang/definition/extern.py
+++ b/guppylang/definition/extern.py
@@ -40,18 +40,20 @@ class RawExternDef(ParsableDef):
 class ExternDef(RawExternDef, ValueDef, CompilableDef):
     """An extern symbol definition."""
 
-    def compile_outer(self, graph: DefinitionBuilder[OpVar]) -> "CompiledExternDef":
+    def compile_outer(
+        self, graph: DefinitionBuilder[OpVar], ctx: CompilerContext
+    ) -> "CompiledExternDef":
         """Adds a Hugr constant node for the extern definition to the provided graph."""
         # The `typ` field must be serialized at this point, to ensure that the
         # `Extension` is serializable.
         custom_const = {
             "symbol": self.symbol,
-            "typ": self.ty.to_hugr()._to_serial_root(),
+            "typ": self.ty.to_hugr(ctx)._to_serial_root(),
             "constant": self.constant,
         }
         value = val.Extension(
             name="ConstExternalSymbol",
-            typ=self.ty.to_hugr(),
+            typ=self.ty.to_hugr(ctx),
             val=custom_const,
         )
         const_node = graph.add_const(value)

--- a/guppylang/definition/function.py
+++ b/guppylang/definition/function.py
@@ -138,14 +138,16 @@ class CheckedFunctionDef(ParsedFunctionDef, CompilableDef):
 
     cfg: CheckedCFG[Place]
 
-    def compile_outer(self, module: DefinitionBuilder[OpVar]) -> "CompiledFunctionDef":
+    def compile_outer(
+        self, module: DefinitionBuilder[OpVar], ctx: CompilerContext
+    ) -> "CompiledFunctionDef":
         """Adds a Hugr `FuncDefn` node for this function to the Hugr.
 
         Note that we don't compile the function body at this point since we don't have
         access to the other compiled functions yet. The body is compiled later in
         `CompiledFunctionDef.compile_inner()`.
         """
-        func_type = self.ty.to_hugr_poly()
+        func_type = self.ty.to_hugr_poly(ctx)
         func_def = module.define_function(
             self.name, func_type.body.input, func_type.body.output, func_type.params
         )
@@ -210,8 +212,8 @@ def load_with_args(
     func: ToNode,
 ) -> Wire:
     """Loads the function as a value into a local Hugr dataflow graph."""
-    func_ty: ht.FunctionType = ty.instantiate(type_args).to_hugr()
-    type_args: list[ht.TypeArg] = [arg.to_hugr() for arg in type_args]
+    func_ty: ht.FunctionType = ty.instantiate(type_args).to_hugr(dfg.ctx)
+    type_args: list[ht.TypeArg] = [arg.to_hugr(dfg.ctx) for arg in type_args]
     return dfg.builder.load_function(func, func_ty, type_args)
 
 
@@ -223,8 +225,8 @@ def compile_call(
     func: ToNode,
 ) -> CallReturnWires:
     """Compiles a call to the function."""
-    func_ty: ht.FunctionType = ty.instantiate(type_args).to_hugr()
-    type_args: list[ht.TypeArg] = [arg.to_hugr() for arg in type_args]
+    func_ty: ht.FunctionType = ty.instantiate(type_args).to_hugr(dfg.ctx)
+    type_args: list[ht.TypeArg] = [arg.to_hugr(dfg.ctx) for arg in type_args]
     num_returns = len(type_to_row(ty.output))
     call = dfg.builder.call(func, *args, instantiation=func_ty, type_args=type_args)
     return CallReturnWires(

--- a/guppylang/definition/pytket_circuits.py
+++ b/guppylang/definition/pytket_circuits.py
@@ -154,7 +154,9 @@ class ParsedPytketDef(CallableDef, CompilableDef):
 
     description: str = field(default="pytket circuit", init=False)
 
-    def compile_outer(self, module: DefinitionBuilder[OpVar]) -> "CompiledPytketDef":
+    def compile_outer(
+        self, module: DefinitionBuilder[OpVar], ctx: CompilerContext
+    ) -> "CompiledPytketDef":
         """Adds a Hugr `FuncDefn` node for this function to the Hugr."""
         try:
             import pytket
@@ -171,7 +173,7 @@ class ParsedPytketDef(CallableDef, CompilableDef):
                 mapping = module.hugr.insert_hugr(circ)
                 hugr_func = mapping[circ.entrypoint]
 
-                func_type = self.ty.to_hugr_poly()
+                func_type = self.ty.to_hugr_poly(ctx)
                 outer_func = module.define_function(
                     self.name, func_type.body.input, func_type.body.output
                 )

--- a/guppylang/definition/traced.py
+++ b/guppylang/definition/traced.py
@@ -80,7 +80,7 @@ class TracedFunctionDef(RawTracedFunctionDef, CallableDef, CompilableDef):
         return node, ty
 
     def compile_outer(
-        self, module: DefinitionBuilder[OpVar]
+        self, module: DefinitionBuilder[OpVar], ctx: CompilerContext
     ) -> "CompiledTracedFunctionDef":
         """Adds a Hugr `FuncDefn` node for this function to the Hugr.
 
@@ -88,7 +88,7 @@ class TracedFunctionDef(RawTracedFunctionDef, CallableDef, CompilableDef):
         access to the other compiled functions yet. The body is compiled later in
         `CompiledFunctionDef.compile_inner()`.
         """
-        func_type = self.ty.to_hugr_poly()
+        func_type = self.ty.to_hugr_poly(ctx)
         func_def = module.define_function(
             self.name, func_type.body.input, func_type.body.output, func_type.params
         )
@@ -114,8 +114,8 @@ class CompiledTracedFunctionDef(TracedFunctionDef, CompiledCallableDef):
         node: AstNode,
     ) -> Wire:
         """Loads the function as a value into a local Hugr dataflow graph."""
-        func_ty: ht.FunctionType = self.ty.instantiate(type_args).to_hugr()
-        type_args: list[ht.TypeArg] = [arg.to_hugr() for arg in type_args]
+        func_ty: ht.FunctionType = self.ty.instantiate(type_args).to_hugr(ctx)
+        type_args: list[ht.TypeArg] = [arg.to_hugr(ctx) for arg in type_args]
         return dfg.builder.load_function(self.func_def, func_ty, type_args)
 
     def compile_call(
@@ -127,8 +127,8 @@ class CompiledTracedFunctionDef(TracedFunctionDef, CompiledCallableDef):
         node: AstNode,
     ) -> CallReturnWires:
         """Compiles a call to the function."""
-        func_ty: ht.FunctionType = self.ty.instantiate(type_args).to_hugr()
-        type_args: list[ht.TypeArg] = [arg.to_hugr() for arg in type_args]
+        func_ty: ht.FunctionType = self.ty.instantiate(type_args).to_hugr(ctx)
+        type_args: list[ht.TypeArg] = [arg.to_hugr(ctx) for arg in type_args]
         num_returns = len(type_to_row(self.ty.output))
         call = dfg.builder.call(
             self.func_def, *args, instantiation=func_ty, type_args=type_args

--- a/guppylang/definition/ty.py
+++ b/guppylang/definition/ty.py
@@ -1,18 +1,15 @@
 from abc import abstractmethod
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
 
 from hugr import tys
 
 from guppylang.ast_util import AstNode
 from guppylang.definition.common import CompiledDef, Definition
 from guppylang.tys.arg import Argument
+from guppylang.tys.common import ToHugrContext
 from guppylang.tys.param import Parameter, check_all_args
 from guppylang.tys.ty import OpaqueType, Type
-
-if TYPE_CHECKING:
-    from guppylang.compiler.core import CompilerContext
 
 
 @dataclass(frozen=True)
@@ -39,7 +36,7 @@ class OpaqueTypeDef(TypeDef, CompiledDef):
     params: Sequence[Parameter]
     never_copyable: bool
     never_droppable: bool
-    to_hugr: Callable[[Sequence[Argument], "CompilerContext"], tys.Type]
+    to_hugr: Callable[[Sequence[Argument], ToHugrContext], tys.Type]
     bound: tys.TypeBound | None = None
 
     def check_instantiate(

--- a/guppylang/definition/ty.py
+++ b/guppylang/definition/ty.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from hugr import tys
 
@@ -9,6 +10,9 @@ from guppylang.definition.common import CompiledDef, Definition
 from guppylang.tys.arg import Argument
 from guppylang.tys.param import Parameter, check_all_args
 from guppylang.tys.ty import OpaqueType, Type
+
+if TYPE_CHECKING:
+    from guppylang.compiler.core import CompilerContext
 
 
 @dataclass(frozen=True)
@@ -35,7 +39,7 @@ class OpaqueTypeDef(TypeDef, CompiledDef):
     params: Sequence[Parameter]
     never_copyable: bool
     never_droppable: bool
-    to_hugr: Callable[[Sequence[Argument]], tys.Type]
+    to_hugr: Callable[[Sequence[Argument], "CompilerContext"], tys.Type]
     bound: tys.TypeBound | None = None
 
     def check_instantiate(

--- a/guppylang/std/_internal/compiler/array.py
+++ b/guppylang/std/_internal/compiler/array.py
@@ -214,7 +214,7 @@ class ArrayCompiler(CustomCallCompiler):
         """The element type for the array op that is being compiled."""
         match self.type_args:
             case [TypeArg(ty=elem_ty), _]:
-                return elem_ty.to_hugr()
+                return elem_ty.to_hugr(self.ctx)
             case _:
                 raise InternalGuppyError("Invalid array type args")
 
@@ -223,7 +223,7 @@ class ArrayCompiler(CustomCallCompiler):
         """The length for the array op that is being compiled."""
         match self.type_args:
             case [_, ConstArg(const)]:  # Const includes both literals and variables
-                return const.to_arg().to_hugr()
+                return const.to_arg().to_hugr(self.ctx)
             case _:
                 raise InternalGuppyError("Invalid array type args")
 
@@ -287,7 +287,7 @@ class ArrayGetitemCompiler(ArrayCompiler):
                         ht.Option(ht.Variable(0, bound)),
                         ht.VariableArg(1, length_param),
                     ),
-                    int_type().to_hugr(),
+                    int_type().to_hugr(self.ctx),
                 ],
                 output=[
                     ht.Variable(0, bound),
@@ -361,7 +361,7 @@ class ArrayGetitemCompiler(ArrayCompiler):
         concrete_func_ty = ht.FunctionType(
             input=[
                 array_type(ht.Option(self.elem_ty), self.length),
-                int_type().to_hugr(),
+                int_type().to_hugr(self.ctx),
             ],
             output=[self.elem_ty, array_type(ht.Option(self.elem_ty), self.length)],
         )
@@ -423,7 +423,7 @@ class ArraySetitemCompiler(ArrayCompiler):
                         ht.Option(ht.Variable(0, bound)),
                         ht.VariableArg(1, length_param),
                     ),
-                    int_type().to_hugr(),
+                    int_type().to_hugr(self.ctx),
                     ht.Variable(0, bound),
                 ],
                 output=[
@@ -485,7 +485,7 @@ class ArraySetitemCompiler(ArrayCompiler):
         concrete_func_ty = ht.FunctionType(
             input=[
                 array_type(ht.Option(self.elem_ty), self.length),
-                int_type().to_hugr(),
+                int_type().to_hugr(self.ctx),
                 self.elem_ty,
             ],
             output=[array_type(ht.Option(self.elem_ty), self.length)],

--- a/guppylang/std/_internal/compiler/either.py
+++ b/guppylang/std/_internal/compiler/either.py
@@ -4,7 +4,6 @@ from collections.abc import Sequence
 from hugr import Wire, ops
 from hugr import tys as ht
 
-from guppylang.compiler.core import CompilerContext
 from guppylang.definition.custom import CustomCallCompiler, CustomInoutCallCompiler
 from guppylang.definition.value import CallReturnWires
 from guppylang.error import InternalGuppyError
@@ -14,10 +13,11 @@ from guppylang.std._internal.compiler.prelude import (
 )
 from guppylang.std._internal.compiler.tket2_bool import OPAQUE_FALSE, OPAQUE_TRUE
 from guppylang.tys.arg import Argument, TypeArg
+from guppylang.tys.common import ToHugrContext
 from guppylang.tys.ty import type_to_row
 
 
-def either_to_hugr(type_args: Sequence[Argument], ctx: CompilerContext) -> ht.Either:
+def either_to_hugr(type_args: Sequence[Argument], ctx: ToHugrContext) -> ht.Either:
     match type_args:
         case [TypeArg(left_ty), TypeArg(right_ty)]:
             left_tys = [ty.to_hugr(ctx) for ty in type_to_row(left_ty)]

--- a/guppylang/std/_internal/compiler/frozenarray.py
+++ b/guppylang/std/_internal/compiler/frozenarray.py
@@ -56,7 +56,7 @@ class FrozenarrayGetitemCompiler(CustomCallCompiler):
     def compile(self, args: list[Wire]) -> list[Wire]:
         [ty_arg, _] = self.type_args
         assert isinstance(ty_arg, TypeArg)
-        elem_ty = ty_arg.ty.to_hugr()
+        elem_ty = ty_arg.ty.to_hugr(self.ctx)
         inst = ht.FunctionType([StaticArray(elem_ty), INT_T], [elem_ty])
         type_args = [ht.TypeTypeArg(elem_ty)]
         elem = self.builder.call(

--- a/guppylang/std/_internal/compiler/list.py
+++ b/guppylang/std/_internal/compiler/list.py
@@ -144,10 +144,12 @@ class ListGetitemCompiler(CustomCallCompiler):
         [elem_ty_arg] = self.type_args
         assert isinstance(elem_ty_arg, TypeArg)
         if elem_ty_arg.ty.linear:
-            return self.build_linear_getitem(list_wire, idx, elem_ty_arg.ty.to_hugr())
+            return self.build_linear_getitem(
+                list_wire, idx, elem_ty_arg.ty.to_hugr(self.ctx)
+            )
         else:
             return self.build_classical_getitem(
-                list_wire, idx, elem_ty_arg.ty.to_hugr()
+                list_wire, idx, elem_ty_arg.ty.to_hugr(self.ctx)
             )
 
     def compile(self, args: list[Wire]) -> list[Wire]:
@@ -201,11 +203,11 @@ class ListSetitemCompiler(CustomCallCompiler):
         assert isinstance(elem_ty_arg, TypeArg)
         if elem_ty_arg.ty.linear:
             return self.build_linear_setitem(
-                list_wire, idx, elem, elem_ty_arg.ty.to_hugr()
+                list_wire, idx, elem, elem_ty_arg.ty.to_hugr(self.ctx)
             )
         else:
             return self.build_classical_setitem(
-                list_wire, idx, elem, elem_ty_arg.ty.to_hugr()
+                list_wire, idx, elem, elem_ty_arg.ty.to_hugr(self.ctx)
             )
 
     def compile(self, args: list[Wire]) -> list[Wire]:
@@ -244,9 +246,9 @@ class ListPopCompiler(CustomCallCompiler):
         [elem_ty_arg] = self.type_args
         assert isinstance(elem_ty_arg, TypeArg)
         if elem_ty_arg.ty.linear:
-            return self.build_linear_pop(list_wire, elem_ty_arg.ty.to_hugr())
+            return self.build_linear_pop(list_wire, elem_ty_arg.ty.to_hugr(self.ctx))
         else:
-            return self.build_classical_pop(list_wire, elem_ty_arg.ty.to_hugr())
+            return self.build_classical_pop(list_wire, elem_ty_arg.ty.to_hugr(self.ctx))
 
     def compile(self, args: list[Wire]) -> list[Wire]:
         raise InternalGuppyError("Call compile_with_inouts instead")
@@ -283,9 +285,13 @@ class ListPushCompiler(CustomCallCompiler):
         [elem_ty_arg] = self.type_args
         assert isinstance(elem_ty_arg, TypeArg)
         if elem_ty_arg.ty.linear:
-            return self.build_linear_push(list_wire, elem, elem_ty_arg.ty.to_hugr())
+            return self.build_linear_push(
+                list_wire, elem, elem_ty_arg.ty.to_hugr(self.ctx)
+            )
         else:
-            return self.build_classical_push(list_wire, elem, elem_ty_arg.ty.to_hugr())
+            return self.build_classical_push(
+                list_wire, elem, elem_ty_arg.ty.to_hugr(self.ctx)
+            )
 
     def compile(self, args: list[Wire]) -> list[Wire]:
         raise InternalGuppyError("Call compile_with_inouts instead")
@@ -298,7 +304,7 @@ class ListLengthCompiler(CustomCallCompiler):
         [list_wire] = args
         [elem_ty_arg] = self.type_args
         assert isinstance(elem_ty_arg, TypeArg)
-        elem_ty = elem_ty_arg.ty.to_hugr()
+        elem_ty = elem_ty_arg.ty.to_hugr(self.ctx)
         if elem_ty_arg.ty.linear:
             elem_ty = ht.Option(elem_ty)
         list_wire, length = self.builder.add_op(list_length(elem_ty), list_wire)

--- a/guppylang/std/_internal/compiler/option.py
+++ b/guppylang/std/_internal/compiler/option.py
@@ -18,7 +18,7 @@ class OptionCompiler(CustomInoutCallCompiler, ABC):
     def option_ty(self) -> ht.Option:
         match self.type_args:
             case [TypeArg(ty)]:
-                return ht.Option(ty.to_hugr())
+                return ht.Option(ty.to_hugr(self.ctx))
             case _:
                 raise InternalGuppyError("Invalid type args for Option op")
 

--- a/guppylang/std/_internal/compiler/prelude.py
+++ b/guppylang/std/_internal/compiler/prelude.py
@@ -226,9 +226,11 @@ class UnwrapOpCompiler(CustomInoutCallCompiler):
         op: A HUGR operation that outputs an Either<error, result> value.
     """
 
-    op: Callable[[ht.FunctionType, Inst], ops.DataflowOp]
+    op: Callable[[ht.FunctionType, Inst, CompilerContext], ops.DataflowOp]
 
-    def __init__(self, op: Callable[[ht.FunctionType, Inst], ops.DataflowOp]):
+    def __init__(
+        self, op: Callable[[ht.FunctionType, Inst, CompilerContext], ops.DataflowOp]
+    ):
         self.op = op
 
     def compile_with_inouts(self, args: list[Wire]) -> CallReturnWires:
@@ -239,7 +241,7 @@ class UnwrapOpCompiler(CustomInoutCallCompiler):
             input=self.ty.input,
             output=[ht.Either([error_type()], self.ty.output)],
         )
-        op = self.op(opt_func_type, self.type_args)
+        op = self.op(opt_func_type, self.type_args, self.ctx)
         either = self.builder.add_op(op, *args)
         result = unwrap_result(self.builder, self.ctx, either)
         return CallReturnWires(regular_returns=[result], inout_returns=[])

--- a/guppylang/std/_internal/compiler/prelude.py
+++ b/guppylang/std/_internal/compiler/prelude.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from hugr.build import function as hf
     from hugr.build.dfg import DfBase
 
+    from guppylang.tys.common import ToHugrContext
     from guppylang.tys.subst import Inst
 
 
@@ -226,10 +227,10 @@ class UnwrapOpCompiler(CustomInoutCallCompiler):
         op: A HUGR operation that outputs an Either<error, result> value.
     """
 
-    op: Callable[[ht.FunctionType, Inst, CompilerContext], ops.DataflowOp]
+    op: Callable[[ht.FunctionType, Inst, ToHugrContext], ops.DataflowOp]
 
     def __init__(
-        self, op: Callable[[ht.FunctionType, Inst, CompilerContext], ops.DataflowOp]
+        self, op: Callable[[ht.FunctionType, Inst, ToHugrContext], ops.DataflowOp]
     ):
         self.op = op
 

--- a/guppylang/std/_internal/compiler/qsystem.py
+++ b/guppylang/std/_internal/compiler/qsystem.py
@@ -18,7 +18,7 @@ class RandomIntCompiler(CustomInoutCallCompiler):
         [ctx] = args
         [rnd, ctx] = self.builder.add_op(
             external_op("RandomInt", [], ext=QSYSTEM_RANDOM_EXTENSION)(
-                ht.FunctionType([RNGCONTEXT_T], [int_t(5), RNGCONTEXT_T]), []
+                ht.FunctionType([RNGCONTEXT_T], [int_t(5), RNGCONTEXT_T]), [], self.ctx
             ),
             ctx,
         )
@@ -35,7 +35,9 @@ class RandomIntBoundedCompiler(CustomInoutCallCompiler):
         )
         [rnd, ctx] = self.builder.add_op(
             external_op("RandomIntBounded", [], ext=QSYSTEM_RANDOM_EXTENSION)(
-                ht.FunctionType([RNGCONTEXT_T, int_t(5)], [int_t(5), RNGCONTEXT_T]), []
+                ht.FunctionType([RNGCONTEXT_T, int_t(5)], [int_t(5), RNGCONTEXT_T]),
+                [],
+                self.ctx,
             ),
             ctx,
             bound,

--- a/guppylang/std/_internal/compiler/quantum.py
+++ b/guppylang/std/_internal/compiler/quantum.py
@@ -59,7 +59,7 @@ class InoutMeasureCompiler(CustomInoutCallCompiler):
         [q] = args
         [q, bit] = self.builder.add_op(
             quantum_op(self.opname, ext=self.ext)(
-                ht.FunctionType([ht.Qubit], [ht.Qubit, ht.Bool]), []
+                ht.FunctionType([ht.Qubit], [ht.Qubit, ht.Bool]), [], self.ctx
             ),
             q,
         )
@@ -84,7 +84,7 @@ class InoutMeasureResetCompiler(CustomInoutCallCompiler):
         [q] = args
         [q, bit] = self.builder.add_op(
             quantum_op(self.opname, ext=self.ext)(
-                ht.FunctionType([ht.Qubit], [ht.Qubit, OpaqueBool]), []
+                ht.FunctionType([ht.Qubit], [ht.Qubit, OpaqueBool]), [], self.ctx
             ),
             q,
         )
@@ -110,6 +110,7 @@ class RotationCompiler(CustomInoutCallCompiler):
                     [ht.Qubit for _ in qs] + [ROTATION_T], [ht.Qubit for _ in qs]
                 ),
                 [],
+                self.ctx,
             ),
             *qs,
             rotation,

--- a/guppylang/tracing/function.py
+++ b/guppylang/tracing/function.py
@@ -56,7 +56,7 @@ def trace_function(
     Invokes the passed Python callable and constructs the corresponding Hugr using the
     passed builder.
     """
-    state = TracingState(ctx, DFContainer(builder, {}), node)
+    state = TracingState(ctx, DFContainer(builder, ctx, {}), node)
     with set_tracing_state(state):
         inputs = [
             unpack_guppy_object(
@@ -75,7 +75,7 @@ def trace_function(
             py_out = python_func(*inputs)
 
         try:
-            out_obj = guppy_object_from_py(py_out, builder, node)
+            out_obj = guppy_object_from_py(py_out, builder, node, ctx)
         except GuppyComptimeError as err:
             # Error in the return statement. For example, this happens if users
             # try to return a struct with invalid field values or there is a linearity
@@ -109,7 +109,7 @@ def trace_function(
                     f"the caller. "
                 )
                 try:
-                    obj = guppy_object_from_py(inout_obj, builder, node)
+                    obj = guppy_object_from_py(inout_obj, builder, node, ctx)
                     inout_returns.append(obj._use_wire(None))
                 except GuppyComptimeError as err:
                     msg = str(err)
@@ -147,7 +147,8 @@ def trace_call(func: CompiledCallableDef, *args: Any) -> Any:
 
     # Try to turn args into `GuppyObjects`
     args_objs = [
-        guppy_object_from_py(arg, state.dfg.builder, state.node) for arg in args
+        guppy_object_from_py(arg, state.dfg.builder, state.node, state.ctx)
+        for arg in args
     ]
 
     # Create dummy variables and bind the objects to them

--- a/guppylang/tracing/object.py
+++ b/guppylang/tracing/object.py
@@ -62,7 +62,7 @@ def unary_operation(f: UnaryDunderMethod) -> UnaryDunderMethod:
         from guppylang.tracing.unpacking import guppy_object_from_py
 
         state = get_tracing_state()
-        self = guppy_object_from_py(self, state.dfg.builder, state.node)
+        self = guppy_object_from_py(self, state.dfg.builder, state.node, state.ctx)
 
         with suppress(Exception):
             return f(self)
@@ -89,8 +89,8 @@ def binary_operation(f: BinaryDunderMethod) -> BinaryDunderMethod:
         from guppylang.tracing.unpacking import guppy_object_from_py
 
         state = get_tracing_state()
-        self = guppy_object_from_py(self, state.dfg.builder, state.node)
-        other = guppy_object_from_py(other, state.dfg.builder, state.node)
+        self = guppy_object_from_py(self, state.dfg.builder, state.node, state.ctx)
+        other = guppy_object_from_py(other, state.dfg.builder, state.node, state.ctx)
 
         # First try the method on `self`
         with suppress(Exception):
@@ -126,7 +126,7 @@ class DunderMixin:
         from guppylang.tracing.unpacking import guppy_object_from_py
 
         state = get_tracing_state()
-        self = guppy_object_from_py(self, state.dfg.builder, state.node)
+        self = guppy_object_from_py(self, state.dfg.builder, state.node, state.ctx)
         return self.__getattr__(name)
 
     def __abs__(self) -> Any:

--- a/guppylang/tracing/unpacking.py
+++ b/guppylang/tracing/unpacking.py
@@ -7,6 +7,7 @@ from hugr.build.dfg import DfBase
 from guppylang.ast_util import AstNode
 from guppylang.checker.errors.comptime_errors import IllegalComptimeExpressionError
 from guppylang.checker.expr_checker import python_value_to_guppy_type
+from guppylang.compiler.core import CompilerContext
 from guppylang.compiler.expr_compiler import python_value_to_hugr
 from guppylang.error import GuppyComptimeError, GuppyError
 from guppylang.std._internal.compiler.array import array_new, unpack_array
@@ -79,7 +80,9 @@ def unpack_guppy_object(
             return obj
 
 
-def guppy_object_from_py(v: Any, builder: DfBase[P], node: AstNode) -> GuppyObject:
+def guppy_object_from_py(
+    v: Any, builder: DfBase[P], node: AstNode, ctx: CompilerContext
+) -> GuppyObject:
     """Constructs a Guppy object from a Python value.
 
     Essentially undoes the `unpack_guppy_object` operation.
@@ -92,7 +95,7 @@ def guppy_object_from_py(v: Any, builder: DfBase[P], node: AstNode) -> GuppyObje
         case None:
             return GuppyObject(NoneType(), builder.add_op(ops.MakeTuple()))
         case tuple(vs):
-            objs = [guppy_object_from_py(v, builder, node) for v in vs]
+            objs = [guppy_object_from_py(v, builder, node, ctx) for v in vs]
             return GuppyObject(
                 TupleType([obj._ty for obj in objs]),
                 builder.add_op(ops.MakeTuple(), *(obj._use_wire(None) for obj in objs)),
@@ -100,7 +103,7 @@ def guppy_object_from_py(v: Any, builder: DfBase[P], node: AstNode) -> GuppyObje
         case GuppyStructObject(_ty=struct_ty, _field_values=values):
             wires = []
             for f in struct_ty.fields:
-                obj = guppy_object_from_py(values[f.name], builder, node)
+                obj = guppy_object_from_py(values[f.name], builder, node, ctx)
                 # Check that the field still has the correct type. Since we allow users
                 # to mutate structs unchecked, this needs to be checked here
                 if obj._ty != f.ty:
@@ -111,7 +114,7 @@ def guppy_object_from_py(v: Any, builder: DfBase[P], node: AstNode) -> GuppyObje
                 wires.append(obj._use_wire(None))
             return GuppyObject(struct_ty, builder.add_op(ops.MakeTuple(), *wires))
         case list(vs) if len(vs) > 0:
-            objs = [guppy_object_from_py(v, builder, node) for v in vs]
+            objs = [guppy_object_from_py(v, builder, node, ctx) for v in vs]
             elem_ty = objs[0]._ty
             for i, obj in enumerate(objs[1:]):
                 if obj._ty != elem_ty:
@@ -119,7 +122,7 @@ def guppy_object_from_py(v: Any, builder: DfBase[P], node: AstNode) -> GuppyObje
                         f"Element at index {i + 1} does not match the type of "
                         f"previous elements. Expected `{elem_ty}`, got `{obj._ty}`."
                     )
-            hugr_elem_ty = ht.Option(elem_ty.to_hugr())
+            hugr_elem_ty = ht.Option(elem_ty.to_hugr(ctx))
             wires = [
                 builder.add_op(ops.Tag(1, hugr_elem_ty), obj._use_wire(None))
                 for obj in objs
@@ -136,7 +139,7 @@ def guppy_object_from_py(v: Any, builder: DfBase[P], node: AstNode) -> GuppyObje
             ty = python_value_to_guppy_type(v, node, get_tracing_state().globals)
             if ty is None:
                 raise GuppyError(IllegalComptimeExpressionError(node, type(v)))
-            hugr_val = python_value_to_hugr(v, ty)
+            hugr_val = python_value_to_hugr(v, ty, ctx)
             assert hugr_val is not None
             return GuppyObject(ty, builder.load(hugr_val))
 

--- a/guppylang/tys/arg.py
+++ b/guppylang/tys/arg.py
@@ -10,6 +10,7 @@ from guppylang.tys.const import BoundConstVar, Const, ConstValue, ExistentialCon
 from guppylang.tys.var import ExistentialVar
 
 if TYPE_CHECKING:
+    from guppylang.compiler.core import CompilerContext
     from guppylang.tys.ty import Type
 
 
@@ -47,9 +48,9 @@ class TypeArg(ArgumentBase):
         """The existential type variables contained in this argument."""
         return self.ty.unsolved_vars
 
-    def to_hugr(self) -> ht.TypeTypeArg:
+    def to_hugr(self, ctx: "CompilerContext") -> ht.TypeTypeArg:
         """Computes the Hugr representation of the argument."""
-        ty: ht.Type = self.ty.to_hugr()
+        ty: ht.Type = self.ty.to_hugr(ctx)
         return ty.type_arg()
 
     def visit(self, visitor: Visitor) -> None:
@@ -73,7 +74,7 @@ class ConstArg(ArgumentBase):
         """The existential const variables contained in this argument."""
         return self.const.unsolved_vars
 
-    def to_hugr(self) -> ht.TypeArg:
+    def to_hugr(self, ctx: "CompilerContext") -> ht.TypeArg:
         """Computes the Hugr representation of this argument."""
         from guppylang.tys.ty import NumericType
 

--- a/guppylang/tys/arg.py
+++ b/guppylang/tys/arg.py
@@ -5,12 +5,17 @@ from typing import TYPE_CHECKING, TypeAlias
 from hugr import tys as ht
 
 from guppylang.error import InternalGuppyError
-from guppylang.tys.common import ToHugr, Transformable, Transformer, Visitor
+from guppylang.tys.common import (
+    ToHugr,
+    ToHugrContext,
+    Transformable,
+    Transformer,
+    Visitor,
+)
 from guppylang.tys.const import BoundConstVar, Const, ConstValue, ExistentialConstVar
 from guppylang.tys.var import ExistentialVar
 
 if TYPE_CHECKING:
-    from guppylang.compiler.core import CompilerContext
     from guppylang.tys.ty import Type
 
 
@@ -48,7 +53,7 @@ class TypeArg(ArgumentBase):
         """The existential type variables contained in this argument."""
         return self.ty.unsolved_vars
 
-    def to_hugr(self, ctx: "CompilerContext") -> ht.TypeTypeArg:
+    def to_hugr(self, ctx: ToHugrContext) -> ht.TypeTypeArg:
         """Computes the Hugr representation of the argument."""
         ty: ht.Type = self.ty.to_hugr(ctx)
         return ty.type_arg()
@@ -74,7 +79,7 @@ class ConstArg(ArgumentBase):
         """The existential const variables contained in this argument."""
         return self.const.unsolved_vars
 
-    def to_hugr(self, ctx: "CompilerContext") -> ht.TypeArg:
+    def to_hugr(self, ctx: ToHugrContext) -> ht.TypeArg:
         """Computes the Hugr representation of this argument."""
         from guppylang.tys.ty import NumericType
 

--- a/guppylang/tys/builtin.py
+++ b/guppylang/tys/builtin.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Literal, TypeGuard
+from typing import Literal, TypeGuard
 
 import hugr.std
 import hugr.std.collections.array
@@ -14,6 +14,7 @@ from guppylang.error import GuppyError, InternalGuppyError
 from guppylang.experimental import check_lists_enabled
 from guppylang.std._internal.compiler.tket2_bool import OpaqueBool
 from guppylang.tys.arg import Argument, ConstArg, TypeArg
+from guppylang.tys.common import ToHugrContext
 from guppylang.tys.const import Const, ConstValue
 from guppylang.tys.errors import WrongNumberOfTypeArgsError
 from guppylang.tys.param import ConstParam, TypeParam
@@ -25,9 +26,6 @@ from guppylang.tys.ty import (
     TupleType,
     Type,
 )
-
-if TYPE_CHECKING:
-    from guppylang.compiler.core import CompilerContext
 
 
 @dataclass(frozen=True)
@@ -119,7 +117,7 @@ class _ListTypeDef(OpaqueTypeDef, CompiledDef):
         return super().check_instantiate(args, loc)
 
 
-def _list_to_hugr(args: Sequence[Argument], ctx: "CompilerContext") -> ht.Type:
+def _list_to_hugr(args: Sequence[Argument], ctx: ToHugrContext) -> ht.Type:
     # Type checker ensures that we get a single arg of kind type
     [arg] = args
     assert isinstance(arg, TypeArg)
@@ -129,7 +127,7 @@ def _list_to_hugr(args: Sequence[Argument], ctx: "CompilerContext") -> ht.Type:
     return hugr.std.collections.list.List(elem_ty)
 
 
-def _array_to_hugr(args: Sequence[Argument], ctx: "CompilerContext") -> ht.Type:
+def _array_to_hugr(args: Sequence[Argument], ctx: ToHugrContext) -> ht.Type:
     # Type checker ensures that we get a two args
     [ty_arg, len_arg] = args
     assert isinstance(ty_arg, TypeArg)
@@ -144,7 +142,7 @@ def _array_to_hugr(args: Sequence[Argument], ctx: "CompilerContext") -> ht.Type:
     return hugr.std.collections.value_array.ValueArray(elem_ty, hugr_arg)
 
 
-def _frozenarray_to_hugr(args: Sequence[Argument], ctx: "CompilerContext") -> ht.Type:
+def _frozenarray_to_hugr(args: Sequence[Argument], ctx: ToHugrContext) -> ht.Type:
     # Type checker ensures that we get a two args
     [ty_arg, len_arg] = args
     assert isinstance(ty_arg, TypeArg)
@@ -152,14 +150,14 @@ def _frozenarray_to_hugr(args: Sequence[Argument], ctx: "CompilerContext") -> ht
     return hugr.std.collections.static_array.StaticArray(ty_arg.ty.to_hugr(ctx))
 
 
-def _sized_iter_to_hugr(args: Sequence[Argument], ctx: "CompilerContext") -> ht.Type:
+def _sized_iter_to_hugr(args: Sequence[Argument], ctx: ToHugrContext) -> ht.Type:
     [ty_arg, len_arg] = args
     assert isinstance(ty_arg, TypeArg)
     assert isinstance(len_arg, ConstArg)
     return ty_arg.ty.to_hugr(ctx)
 
 
-def _option_to_hugr(args: Sequence[Argument], ctx: "CompilerContext") -> ht.Type:
+def _option_to_hugr(args: Sequence[Argument], ctx: ToHugrContext) -> ht.Type:
     [arg] = args
     assert isinstance(arg, TypeArg)
     return ht.Option(arg.ty.to_hugr(ctx))

--- a/guppylang/tys/common.py
+++ b/guppylang/tys/common.py
@@ -1,5 +1,8 @@
 from abc import ABC, abstractmethod
-from typing import Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
+
+if TYPE_CHECKING:
+    from guppylang.compiler.core import CompilerContext
 
 T = TypeVar("T")
 
@@ -8,7 +11,7 @@ class ToHugr(ABC, Generic[T]):
     """Abstract base class for objects that have a Hugr representation."""
 
     @abstractmethod
-    def to_hugr(self) -> T:
+    def to_hugr(self, ctx: "CompilerContext") -> T:
         """Computes the Hugr representation of the object."""
 
 

--- a/guppylang/tys/common.py
+++ b/guppylang/tys/common.py
@@ -1,17 +1,22 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
-
-if TYPE_CHECKING:
-    from guppylang.compiler.core import CompilerContext
+from typing import Any, Generic, Protocol, TypeVar
 
 T = TypeVar("T")
+
+
+class ToHugrContext(Protocol):
+    """Protocol for the context capabilities required to translate Guppy types into Hugr
+    types.
+
+    This is empty for now, but will soon be used for partial monomorphization.
+    """
 
 
 class ToHugr(ABC, Generic[T]):
     """Abstract base class for objects that have a Hugr representation."""
 
     @abstractmethod
-    def to_hugr(self, ctx: "CompilerContext") -> T:
+    def to_hugr(self, ctx: ToHugrContext) -> T:
         """Computes the Hugr representation of the object."""
 
 

--- a/guppylang/tys/const.py
+++ b/guppylang/tys/const.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, TypeAlias
 
 from guppylang.error import InternalGuppyError
@@ -20,7 +20,7 @@ class ConstBase(Transformable["Const"], ABC):
     we could have struct constants etc.
     """
 
-    ty: "Type"
+    ty: "Type" = field(hash=False)  # Types are not hashable
 
     def __post_init__(self) -> None:
         if self.ty.unsolved_vars:

--- a/guppylang/tys/param.py
+++ b/guppylang/tys/param.py
@@ -17,6 +17,7 @@ from guppylang.tys.errors import WrongNumberOfTypeArgsError
 from guppylang.tys.var import ExistentialVar
 
 if TYPE_CHECKING:
+    from guppylang.compiler.core import CompilerContext
     from guppylang.tys.ty import Type
 
 
@@ -142,7 +143,7 @@ class TypeParam(ParameterBase):
             BoundTypeVar(self.name, idx, self.must_be_copyable, self.must_be_droppable)
         )
 
-    def to_hugr(self) -> ht.TypeParam:
+    def to_hugr(self, ctx: "CompilerContext") -> ht.TypeParam:
         """Computes the Hugr representation of the parameter."""
         return ht.TypeTypeParam(
             bound=ht.TypeBound.Any if self.can_be_linear else ht.TypeBound.Copyable
@@ -204,7 +205,7 @@ class ConstParam(ParameterBase):
             idx = self.idx
         return ConstArg(BoundConstVar(self.ty, self.name, idx))
 
-    def to_hugr(self) -> ht.TypeParam:
+    def to_hugr(self, ctx: "CompilerContext") -> ht.TypeParam:
         """Computes the Hugr representation of the parameter."""
         from guppylang.tys.ty import NumericType
 
@@ -212,7 +213,7 @@ class ConstParam(ParameterBase):
             case NumericType(kind=NumericType.Kind.Nat):
                 return ht.BoundedNatParam(upper_bound=None)
             case _:
-                assert isinstance(self.ty.to_hugr(), ht.ExtType)
+                assert isinstance(self.ty.to_hugr(ctx), ht.ExtType)
                 return ht.StringParam()
 
 

--- a/guppylang/tys/param.py
+++ b/guppylang/tys/param.py
@@ -11,13 +11,12 @@ from guppylang.checker.errors.generic import ExpectedError
 from guppylang.checker.errors.type_errors import TypeMismatchError
 from guppylang.error import GuppyError, GuppyTypeError, InternalGuppyError
 from guppylang.tys.arg import Argument, ConstArg, TypeArg
-from guppylang.tys.common import ToHugr
+from guppylang.tys.common import ToHugr, ToHugrContext
 from guppylang.tys.const import BoundConstVar, ExistentialConstVar
 from guppylang.tys.errors import WrongNumberOfTypeArgsError
 from guppylang.tys.var import ExistentialVar
 
 if TYPE_CHECKING:
-    from guppylang.compiler.core import CompilerContext
     from guppylang.tys.ty import Type
 
 
@@ -143,7 +142,7 @@ class TypeParam(ParameterBase):
             BoundTypeVar(self.name, idx, self.must_be_copyable, self.must_be_droppable)
         )
 
-    def to_hugr(self, ctx: "CompilerContext") -> ht.TypeParam:
+    def to_hugr(self, ctx: ToHugrContext) -> ht.TypeParam:
         """Computes the Hugr representation of the parameter."""
         return ht.TypeTypeParam(
             bound=ht.TypeBound.Any if self.can_be_linear else ht.TypeBound.Copyable
@@ -205,7 +204,7 @@ class ConstParam(ParameterBase):
             idx = self.idx
         return ConstArg(BoundConstVar(self.ty, self.name, idx))
 
-    def to_hugr(self, ctx: "CompilerContext") -> ht.TypeParam:
+    def to_hugr(self, ctx: ToHugrContext) -> ht.TypeParam:
         """Computes the Hugr representation of the parameter."""
         from guppylang.tys.ty import NumericType
 

--- a/guppylang/tys/ty.py
+++ b/guppylang/tys/ty.py
@@ -17,6 +17,7 @@ from guppylang.tys.param import ConstParam, Parameter
 from guppylang.tys.var import BoundVar, ExistentialVar
 
 if TYPE_CHECKING:
+    from guppylang.compiler.core import CompilerContext
     from guppylang.definition.struct import CheckedStructDef, StructField
     from guppylang.definition.ty import OpaqueTypeDef
     from guppylang.tys.subst import Inst, Subst
@@ -193,7 +194,7 @@ class BoundTypeVar(TypeBase, BoundVar):
         """Casts an implementor of `TypeBase` into a `Type`."""
         return self
 
-    def to_hugr(self) -> ht.Variable:
+    def to_hugr(self, ctx: "CompilerContext") -> ht.Variable:
         """Computes the Hugr representation of the type."""
         return ht.Variable(idx=self.idx, bound=self.hugr_bound)
 
@@ -248,7 +249,7 @@ class ExistentialTypeVar(ExistentialVar, TypeBase):
         """Casts an implementor of `TypeBase` into a `Type`."""
         return self
 
-    def to_hugr(self) -> ht.Type:
+    def to_hugr(self, ctx: "CompilerContext") -> ht.Type:
         """Computes the Hugr representation of the type."""
         raise InternalGuppyError(
             "Tried to convert unsolved existential type variable to Hugr"
@@ -280,7 +281,7 @@ class NoneType(TypeBase):
         """Casts an implementor of `TypeBase` into a `Type`."""
         return self
 
-    def to_hugr(self) -> ht.Tuple:
+    def to_hugr(self, ctx: "CompilerContext") -> ht.Tuple:
         """Computes the Hugr representation of the type."""
         return ht.Tuple()
 
@@ -326,7 +327,7 @@ class NumericType(TypeBase):
         """Casts an implementor of `TypeBase` into a `Type`."""
         return self
 
-    def to_hugr(self) -> ht.ExtType:
+    def to_hugr(self, ctx: "CompilerContext") -> ht.ExtType:
         """Computes the Hugr representation of the type."""
         match self.kind:
             case NumericType.Kind.Nat | NumericType.Kind.Int:
@@ -423,36 +424,42 @@ class FunctionType(ParametrizedTypeBase):
         """Casts an implementor of `TypeBase` into a `Type`."""
         return self
 
-    def to_hugr(self) -> ht.FunctionType:
+    def to_hugr(self, ctx: "CompilerContext") -> ht.FunctionType:
         """Computes the Hugr representation of the type."""
         if self.parametrized:
             raise InternalGuppyError(
                 "Tried to convert parametrised function type to Hugr. Use "
                 "`to_hugr_poly` instead"
             )
-        return self._to_hugr_function_type()
+        return self._to_hugr_function_type(ctx)
 
-    def to_hugr_poly(self) -> ht.PolyFuncType:
+    def to_hugr_poly(self, ctx: "CompilerContext") -> ht.PolyFuncType:
         """Computes the Hugr `PolyFuncType` representation of the type."""
-        func_ty = self._to_hugr_function_type()
-        return ht.PolyFuncType(params=[p.to_hugr() for p in self.params], body=func_ty)
+        func_ty = self._to_hugr_function_type(ctx)
+        return ht.PolyFuncType(
+            params=[p.to_hugr(ctx) for p in self.params], body=func_ty
+        )
 
-    def _to_hugr_function_type(self) -> ht.FunctionType:
+    def _to_hugr_function_type(self, ctx: "CompilerContext") -> ht.FunctionType:
         """Helper method to compute the Hugr `FunctionType` representation of the type.
 
         The resulting `FunctionType` can then be embedded into a Hugr `Type` or a Hugr
         `PolyFuncType`.
         """
         ins = [
-            inp.ty.to_hugr()
+            inp.ty.to_hugr(ctx)
             for inp in self.inputs
             # Comptime inputs are turned into generic args, so are not included here
             if InputFlags.Comptime not in inp.flags
         ]
         outs = [
-            *(t.to_hugr() for t in type_to_row(self.output)),
+            *(t.to_hugr(ctx) for t in type_to_row(self.output)),
             # We might have additional borrowed args that will be also outputted
-            *(inp.ty.to_hugr() for inp in self.inputs if InputFlags.Inout in inp.flags),
+            *(
+                inp.ty.to_hugr(ctx)
+                for inp in self.inputs
+                if InputFlags.Inout in inp.flags
+            ),
         ]
         return ht.FunctionType(input=ins, output=outs)
 
@@ -544,9 +551,9 @@ class TupleType(ParametrizedTypeBase):
         """Casts an implementor of `TypeBase` into a `Type`."""
         return self
 
-    def to_hugr(self) -> ht.Tuple:
+    def to_hugr(self, ctx: "CompilerContext") -> ht.Tuple:
         """Computes the Hugr representation of the type."""
-        return ht.Tuple(*row_to_hugr(self.element_types))
+        return ht.Tuple(*row_to_hugr(self.element_types, ctx))
 
     def transform(self, transformer: Transformer) -> "Type":
         """Accepts a transformer on this type."""
@@ -585,15 +592,15 @@ class SumType(ParametrizedTypeBase):
         """Casts an implementor of `TypeBase` into a `Type`."""
         return self
 
-    def to_hugr(self) -> ht.Sum:
+    def to_hugr(self, ctx: "CompilerContext") -> ht.Sum:
         """Computes the Hugr representation of the type."""
         rows = [type_to_row(ty) for ty in self.element_types]
         if all(len(row) == 0 for row in rows):
             return ht.UnitSum(size=len(rows))
         elif len(rows) == 1:
-            return ht.Tuple(*row_to_hugr(rows[0]))
+            return ht.Tuple(*row_to_hugr(rows[0], ctx))
         else:
-            return ht.Sum(variant_rows=rows_to_hugr(rows))
+            return ht.Sum(variant_rows=rows_to_hugr(rows, ctx))
 
     def transform(self, transformer: Transformer) -> "Type":
         """Accepts a transformer on this type."""
@@ -633,9 +640,9 @@ class OpaqueType(ParametrizedTypeBase):
         """Casts an implementor of `TypeBase` into a `Type`."""
         return self
 
-    def to_hugr(self) -> ht.Type:
+    def to_hugr(self, ctx: "CompilerContext") -> ht.Type:
         """Computes the Hugr representation of the type."""
-        return self.defn.to_hugr(self.args)
+        return self.defn.to_hugr(self.args, ctx)
 
     def transform(self, transformer: Transformer) -> "Type":
         """Accepts a transformer on this type."""
@@ -678,9 +685,9 @@ class StructType(ParametrizedTypeBase):
         """Casts an implementor of `TypeBase` into a `Type`."""
         return self
 
-    def to_hugr(self) -> ht.Tuple:
+    def to_hugr(self, ctx: "CompilerContext") -> ht.Tuple:
         """Computes the Hugr representation of the type."""
-        return ht.Tuple(*(f.ty.to_hugr() for f in self.fields))
+        return ht.Tuple(*(f.ty.to_hugr(ctx) for f in self.fields))
 
     def transform(self, transformer: Transformer) -> "Type":
         """Accepts a transformer on this type."""
@@ -730,14 +737,14 @@ def type_to_row(ty: Type) -> TypeRow:
     return [ty]
 
 
-def row_to_hugr(row: TypeRow) -> ht.TypeRow:
+def row_to_hugr(row: TypeRow, ctx: "CompilerContext") -> ht.TypeRow:
     """Computes the Hugr representation of a type row."""
-    return [ty.to_hugr() for ty in row]
+    return [ty.to_hugr(ctx) for ty in row]
 
 
-def rows_to_hugr(rows: Sequence[TypeRow]) -> list[ht.TypeRow]:
+def rows_to_hugr(rows: Sequence[TypeRow], ctx: "CompilerContext") -> list[ht.TypeRow]:
     """Computes the Hugr representation of a sequence of rows."""
-    return [row_to_hugr(row) for row in rows]
+    return [row_to_hugr(row, ctx) for row in rows]
 
 
 def unify(s: Type | Const, t: Type | Const, subst: "Subst | None") -> "Subst | None":

--- a/tests/error/iter_errors/iter_wrong_type.py
+++ b/tests/error/iter_errors/iter_wrong_type.py
@@ -2,7 +2,7 @@ from guppylang.decorator import guppy
 from guppylang.tys.ty import NoneType
 
 
-@guppy.type(NoneType().to_hugr())
+@guppy.type(lambda _, ctx: NoneType().to_hugr(ctx))
 class MyType:
     """A type where the `__iter__` method has the wrong signature."""
 

--- a/tests/error/iter_errors/next_missing.py
+++ b/tests/error/iter_errors/next_missing.py
@@ -2,7 +2,7 @@ from guppylang.decorator import guppy
 from guppylang.tys.ty import NoneType
 
 
-@guppy.type(NoneType().to_hugr())
+@guppy.type(lambda _, ctx: NoneType().to_hugr(ctx))
 class MyIter:
     """An iterator that is missing the `__next__` method."""
 
@@ -15,7 +15,7 @@ class MyIter:
         ...
 
 
-@guppy.type(NoneType().to_hugr())
+@guppy.type(lambda _, ctx: NoneType().to_hugr(ctx))
 class MyType:
     """Type that produces the iterator above."""
 

--- a/tests/error/iter_errors/next_wrong_type.py
+++ b/tests/error/iter_errors/next_wrong_type.py
@@ -2,7 +2,7 @@ from guppylang.decorator import guppy
 from guppylang.tys.ty import NoneType
 
 
-@guppy.type(NoneType().to_hugr())
+@guppy.type(lambda _, ctx: NoneType().to_hugr(ctx))
 class MyIter:
     """An iterator where the `__next__` method has the wrong signature."""
 
@@ -19,7 +19,7 @@ class MyIter:
         ...
 
 
-@guppy.type(NoneType().to_hugr())
+@guppy.type(lambda _, ctx: NoneType().to_hugr(ctx))
 class MyType:
     """Type that produces the iterator above."""
 

--- a/tests/error/poly_errors/const_var_free.err
+++ b/tests/error/poly_errors/const_var_free.err
@@ -1,0 +1,11 @@
+Error: Free type variable (at $FILE:9:0)
+  | 
+7 | 
+8 | # We don't yet support const vars referencing previously bound parameters
+9 | X = guppy.const_var("X", "array[T, n]")
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Type variable `T` is unbound
+
+Note: Only struct and function definitions can be generic. Other generic values
+or nested types are not supported.
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/poly_errors/const_var_free.py
+++ b/tests/error/poly_errors/const_var_free.py
@@ -1,0 +1,22 @@
+from typing import Generic
+
+from guppylang.decorator import guppy
+
+T = guppy.type_var("T")
+n = guppy.nat_var("n")
+
+# We don't yet support const vars referencing previously bound parameters
+X = guppy.const_var("X", "array[T, n]")
+
+
+@guppy.struct
+class Struct(Generic[T, n, X]):
+    pass
+
+
+@guppy
+def main(_: Struct[T, n, X]) -> None:
+    pass
+
+
+guppy.compile(main)

--- a/tests/error/poly_errors/const_var_invalid_type.err
+++ b/tests/error/poly_errors/const_var_invalid_type.err
@@ -1,0 +1,8 @@
+Error: Non-parametric type (at $FILE:5:0)
+  | 
+3 | from guppylang.decorator import guppy
+4 | 
+5 | X = guppy.const_var("X", "float[int]")
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Type `float` is not parametric
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/poly_errors/const_var_invalid_type.py
+++ b/tests/error/poly_errors/const_var_invalid_type.py
@@ -1,0 +1,18 @@
+from typing import Generic
+
+from guppylang.decorator import guppy
+
+X = guppy.const_var("X", "float[int]")
+
+
+@guppy.struct
+class Struct(Generic[X]):
+    pass
+
+
+@guppy
+def main(_: Struct[X]) -> None:
+    pass
+
+
+guppy.compile(main)

--- a/tests/error/poly_errors/const_var_noncopyable.err
+++ b/tests/error/poly_errors/const_var_noncopyable.err
@@ -1,0 +1,9 @@
+Error: Invalid const variable (at $FILE:6:0)
+  | 
+4 | from guppylang.std.quantum import qubit
+5 | 
+6 | Q = guppy.const_var("Q", "qubit")
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Const variable `Q` is not allowed have non-copyable type
+  |                                   `qubit`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/poly_errors/const_var_noncopyable.py
+++ b/tests/error/poly_errors/const_var_noncopyable.py
@@ -1,0 +1,19 @@
+from typing import Generic
+
+from guppylang.decorator import guppy
+from guppylang.std.quantum import qubit
+
+Q = guppy.const_var("Q", "qubit")
+
+
+@guppy.struct
+class Struct(Generic[Q]):
+    pass
+
+
+@guppy
+def main(_: Struct[Q]) -> None:
+    pass
+
+
+guppy.compile(main)

--- a/tests/error/poly_errors/const_var_nondroppable.err
+++ b/tests/error/poly_errors/const_var_nondroppable.err
@@ -1,0 +1,9 @@
+Error: Invalid const variable (at $FILE:13:0)
+   | 
+11 | 
+12 | 
+13 | X = guppy.const_var("X", "MyType")
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Const variable `X` is not allowed have non-droppable type
+   |                                    `MyType`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/poly_errors/const_var_nondroppable.py
+++ b/tests/error/poly_errors/const_var_nondroppable.py
@@ -1,0 +1,26 @@
+from typing import Generic
+
+from hugr import tys
+
+from guppylang.decorator import guppy
+
+
+@guppy.type(tys.Tuple(), droppable=False)
+class MyType:
+    pass
+
+
+X = guppy.const_var("X", "MyType")
+
+
+@guppy.struct
+class Struct(Generic[X]):
+    pass
+
+
+@guppy
+def main(_: Struct[X]) -> None:
+    pass
+
+
+guppy.compile(main)

--- a/tests/integration/test_comprehension.py
+++ b/tests/integration/test_comprehension.py
@@ -202,14 +202,14 @@ def test_linear_consume_in_iter(validate):
 
 
 def test_linear_next_nonlinear_iter(validate):
-    @guppy.type(NoneType().to_hugr())
+    @guppy.type(lambda _, ctx: NoneType().to_hugr(ctx))
     class MyIter:
         """An iterator that yields linear values but is not linear itself."""
 
         @guppy.declare
         def __next__(self: "MyIter") -> Option[tuple[qubit, "MyIter"]]: ...
 
-    @guppy.type(NoneType().to_hugr())
+    @guppy.type(lambda _, ctx: NoneType().to_hugr(ctx))
     class MyType:
         """Type that produces the iterator above."""
 
@@ -236,7 +236,7 @@ def test_nonlinear_next_linear_iter(validate):
         @guppy.declare
         def __next__(self: "MyIter" @owned) -> Option[tuple[int, "MyIter"]]: ...
 
-    @guppy.type(NoneType().to_hugr())
+    @guppy.type(lambda _, ctx: NoneType().to_hugr(ctx))
     class MyType:
         """Type that produces the iterator above."""
 

--- a/tests/integration/test_linear.py
+++ b/tests/integration/test_linear.py
@@ -346,7 +346,7 @@ def test_for_continue(validate):
 
 
 def test_for_nonlinear_break(validate):
-    @guppy.type(NoneType().to_hugr())
+    @guppy.type(lambda _, ctx: NoneType().to_hugr(ctx))
     class MyIter:
         """An iterator that yields linear values but is not linear itself."""
 
@@ -354,7 +354,7 @@ def test_for_nonlinear_break(validate):
         def __next__(self: "MyIter") -> Option[tuple[qubit, "MyIter"]]: ...
 
 
-    @guppy.type(NoneType().to_hugr())
+    @guppy.type(lambda _, ctx: NoneType().to_hugr(ctx))
     class MyType:
         """Type that produces the iterator above."""
 

--- a/tests/integration/test_poly_const.py
+++ b/tests/integration/test_poly_const.py
@@ -1,0 +1,379 @@
+from collections.abc import Callable
+from typing import Generic
+
+import pytest
+from hugr import Hugr, ops
+
+from guppylang import guppy, array
+from guppylang.std.num import nat
+
+
+def funcs_defs(h: Hugr) -> list[str]:
+    return [h[node].op.f_name for node in h if isinstance(h[node].op, ops.FuncDefn)]
+
+
+def test_bool(validate, run_int_fn):
+    B = guppy.const_var("B", "bool")
+
+    @guppy.struct
+    class Dummy(Generic[B]):
+        """Unit struct type to introduce generic B into the signature of `foo` below.
+
+        This is needed because we don't support the `def foo[B: bool]` syntax yet to
+        introduce type params that are not referenced in the signature.
+        """
+
+    @guppy
+    def foo(_: Dummy[B]) -> bool:
+        return B
+
+    @guppy
+    def main() -> int:
+        s = 0
+        if foo[True](Dummy()):
+            s += 1
+        if foo[False](Dummy()):
+            s += 10
+        if foo[True](Dummy()):
+            s += 100
+        if foo[False](Dummy()):
+            s += 10000
+        return s
+
+    guppy.check(main)
+
+    # TODO: Validate once Hugr lowering is implemented:
+    # compiled = guppy.compile(main)
+    # validate(compiled)
+    #
+    # # Check we have main, and 2 monomorphizations of foo (Dummy constructor is inlined)
+    # assert len(funcs_defs(compiled.module)) == 3
+    #
+    # run_int_fn(compiled, 101)
+
+
+@pytest.mark.xfail(reason="https://github.com/CQCL/guppylang/issues/1030")
+def test_int(validate):
+    I = guppy.const_var("I", "int§")
+
+    @guppy.struct
+    class Dummy(Generic[I]):
+        """Unit struct type to introduce generic I into the signature of `foo` below.
+
+        This is needed because we don't support the `def foo[I: int]` syntax yet to
+        introduce type params that are not referenced in the signature.
+        """
+
+    @guppy
+    def foo(_: Dummy[I]) -> float:
+        return I
+
+    @guppy
+    def main() -> float:
+        return (
+            foo[1](Dummy())
+            + foo[2](Dummy())
+            + foo[-2](Dummy())
+            + foo[3](Dummy())
+            + foo[1](Dummy())
+            + foo[1](Dummy())
+        )
+
+    guppy.check(main)
+
+    # TODO: Validate once Hugr lowering is implemented:
+    # compiled = guppy.compile(main)
+    # validate(compiled)
+    #
+    # # Check we have main, and 4 monomorphizations of foo (Dummy constructor is inlined)
+    # assert len(funcs_defs(compiled.module)) == 5
+
+
+def test_float(validate, run_float_fn_approx):
+    F = guppy.const_var("F", "float")
+
+    @guppy.struct
+    class Dummy(Generic[F]):
+        """Unit struct type to introduce generic F into the signature of `foo` below.
+
+        This is needed because we don't support the `def foo[F: float]` syntax yet to
+        introduce type params that are not referenced in the signature.
+        """
+
+    @guppy
+    def foo(_: Dummy[F]) -> float:
+        return F
+
+    @guppy
+    def main() -> float:
+        return (
+            foo[1.5](Dummy())
+            + foo[2.5](Dummy())
+            + foo[3.5](Dummy())
+            + foo[1.5](Dummy())
+            + foo[1.5](Dummy())
+        )
+
+    guppy.check(main)
+
+    # TODO: Validate once Hugr lowering is implemented:
+    # compiled = guppy.compile(main)
+    # validate(compiled)
+    #
+    # # Check we have main, and 3 monomorphizations of foo (Dummy constructor is inlined)
+    # assert len(funcs_defs(compiled.module)) == 4
+    #
+    # run_float_fn_approx(compiled, 10.5)
+
+
+@pytest.mark.xfail(reason="https://github.com/CQCL/guppylang/issues/1030")
+def test_string(validate):
+    S = guppy.const_var("S", "str")
+
+    @guppy.struct
+    class Dummy(Generic[S]):
+        """Unit struct type to introduce generic S into the signature of `foo` below.
+
+        This is needed because we don't support the `def foo[S: str]` syntax yet to
+        introduce type params that are not referenced in the signature.
+        """
+
+    @guppy
+    def foo(_: Dummy[S]) -> str:
+        return S
+
+    @guppy
+    def main() -> tuple[str, str, str, str, str]:
+        return (
+            foo[""](Dummy()),
+            foo["a"](Dummy()),
+            foo["A"](Dummy()),
+            foo["ä"](Dummy()),
+            foo["a"](Dummy()),
+        )
+
+    guppy.check(main)
+
+    # TODO: Validate once Hugr lowering is implemented:
+    # compiled = guppy.compile(main)
+    # validate(compiled)
+    #
+    # # Check we have main, and 4 monomorphizations of foo (Dummy constructor is inlined)
+    # assert len(funcs_defs(compiled.module)) == 5
+
+
+def test_chain(validate, run_int_fn):
+    B = guppy.const_var("B", "bool")
+
+    @guppy.struct
+    class Dummy(Generic[B]):
+        """Unit struct type to introduce generic B into the signatures below.
+
+        This is needed because we don't support the `def foo[B: bool]` syntax yet to
+        introduce type params that are not referenced in the signature.
+        """
+
+    @guppy
+    def a(x: Dummy[B]) -> bool:
+        return b(x)
+
+    @guppy
+    def b(x: Dummy[B]) -> bool:
+        return c(x)
+
+    @guppy
+    def c(x: Dummy[B]) -> bool:
+        return d(x)
+
+    @guppy
+    def d(_: Dummy[B]) -> bool:
+        return B
+
+    @guppy
+    def main() -> int:
+        x = a[True](Dummy())
+        b[True](Dummy())
+        c[True](Dummy())
+        d[True](Dummy())
+        return 1 if x else 0
+
+    guppy.check(main)
+
+    # TODO: Validate once Hugr lowering is implemented:
+    # compiled = guppy.compile(main)
+    # validate(compiled)
+    #
+    # # Check we have main, and 4 monomorphizations (a, b, c, d)
+    # assert len(funcs_defs(compiled.module)) == 5
+    #
+    # run_int_fn(compiled, 1)
+
+
+def test_recursion(validate):
+    B = guppy.const_var("B", "bool")
+
+    @guppy.struct
+    class Dummy(Generic[B]):
+        """Unit struct type to introduce generic B into the signatures below.
+
+        This is needed because we don't support the `def foo[B: bool]` syntax yet to
+        introduce type params that are not referenced in the signature.
+        """
+
+    @guppy
+    def foo(_: Dummy[B]) -> int:
+        return bar[True](Dummy()) + foo[False](Dummy())
+
+    @guppy
+    def bar(_: Dummy[B]) -> int:
+        return foo[True](Dummy()) + bar[False](Dummy())
+
+    @guppy
+    def baz(d: Dummy[B]) -> int:
+        return foo(d)
+
+    @guppy
+    def main() -> int:
+        return baz[True](Dummy())
+
+    guppy.check(main)
+
+    # TODO: Validate once Hugr lowering is implemented:
+    # compiled = guppy.compile(main)
+    # validate(compiled)
+    #
+    # # Check we have main, and 5 monomorphizations of foo/bar/baz
+    # assert len(funcs_defs(compiled.module)) == 6
+
+
+def test_many(validate):
+    B = guppy.const_var("B", "bool")
+    F = guppy.const_var("F", "float")
+    N = guppy.nat_var("N")
+
+    T1 = guppy.type_var("T1")
+    T2 = guppy.type_var("T2")
+    T3 = guppy.type_var("T3")
+
+    @guppy.struct
+    class MyStruct(Generic[T1, B, T2, N, T3, F]):
+        """Unit struct type to introduce generics into the signatures below.
+
+        This is needed because we don't support the `def foo[S: str]` syntax yet to
+        introduce type params that are not referenced in the signature.
+        """
+        x1: T1
+        x2: T2
+        x3s: array[T3, N]
+
+    @guppy.declare
+    def bar(xs: array[T1, N]) -> None: ...
+
+    @guppy
+    def baz(s: MyStruct[T1, B, T2, N, T3, F]) -> MyStruct[T1, B, T2, N, T3, F]:
+        return baz(s)
+
+    @guppy
+    def foo(s: MyStruct[int, False, T2, N, T3, F]) -> float:
+        bar(s.x3s)
+        baz(s)
+        return N + F
+
+    @guppy
+    def main() -> None:
+        s1: MyStruct[int, False, float, 3, bool, 4.2] = MyStruct(
+            1, 1.0, array(True, False, True)
+        )
+        s1 = baz(baz(s1))
+        bar(s1.x3s)
+        foo(s1)
+
+        s2: MyStruct[int, False, bool, 1, nat, 4.2] = MyStruct(0, False, array(nat(42)))
+        s2 = baz(baz(s2))
+        bar(s2.x3s)
+        foo(s2)
+
+        s3: MyStruct[int, False, bool, 1, float, 1.5] = MyStruct(0, False, array(4.2))
+        s3 = baz(baz(s3))
+        bar(s3.x3s)
+        foo(s3)
+
+    guppy.check(main)
+
+    # TODO: Validate once Hugr lowering is implemented:
+    # compiled = guppy.compile(main)
+    # validate(compiled)
+    #
+    # # Check we have main, and 2 monomorphizations of foo and baz each. Note that `s2`
+    # # doesn't generate a monomorphisation since it shares the relevant mono-parameters
+    # # with `s1`
+    # assert len(funcs_defs(compiled.module)) == 5
+
+
+def test_constructor(validate):
+    B = guppy.const_var("B", "bool")
+    F = guppy.const_var("F", "float")
+
+    @guppy.struct
+    class MyStruct(Generic[B, F]):
+        pass
+
+    @guppy
+    def main() -> None:
+        s1: MyStruct[True, 1.0] = MyStruct()   # This is inlined
+        s2: MyStruct[False, 1.0] = MyStruct()  # This is inlined
+        f1 = MyStruct[True, 2.0]   # This is monomorphized
+        f2 = MyStruct[False, 2.0]  # This is monomorphized
+        f1()
+        f2()
+
+    guppy.check(main)
+
+    # TODO: Validate once Hugr lowering is implemented:
+    # compiled = guppy.compile(main)
+    # validate(compiled)
+    #
+    # # Check we have main, and 2 monomorphizations of the MyStruct constructor
+    # assert len(funcs_defs(compiled.module)) == 3
+
+
+def test_higher_order(validate):
+    B = guppy.const_var("B", "bool")
+    F = guppy.const_var("F", "float")
+
+    @guppy.struct
+    class Struct(Generic[B, F]):
+        pass
+
+    @guppy
+    def fun1(x: Struct[B, F]) -> None:
+        pass
+
+    @guppy
+    def fun2(x: Struct[True, F]) -> None:
+        pass
+
+    @guppy
+    def fun3(x: Struct[B, 42.0]) -> None:
+        pass
+
+    @guppy
+    def foo(f: Callable[[Struct[B, 42.0]], None]) -> None:
+        pass
+
+    @guppy
+    def main() -> None:
+        foo[True](fun1)
+        foo[False](fun1)
+        foo(fun2)
+        foo(fun3[False])
+        foo(fun3[True])
+
+    guppy.check(main)
+
+    # TODO: Validate once Hugr lowering is implemented:
+    # compiled = guppy.compile(main)
+    # validate(compiled)
+    #
+    # # Check we have main, fun2, and 2 monomorphizations of fun1, fun3, and foo each
+    # assert len(funcs_defs(compiled.module)) == 8


### PR DESCRIPTION
Adds a new `guppy.const_var` declaration that generalises `guppy.nat_var` to arbitrary copyable+droppable types. This is part of #1033.

For basic testing, I also updated type argument parsing to accept `bool` and `float` const literals. However, the current solution for this is not ideal (see #1030), but should be addressed in a separate PR.

Also note that Hugr lowering of these const generics is not implemented in this PR, so the integration tests currently only check the code instead of compiling to Hugr. Hugr compilation via monomorphisation will follow in a separate PR.