### PR TITLE
feat!: Lower const generics via monomorphization

### DIFF
--- a/guppylang/compiler/func_compiler.py
+++ b/guppylang/compiler/func_compiler.py
@@ -48,6 +48,9 @@ def compile_local_func_def(
         func.name, closure_ty.input, closure_ty.output
     )
 
+    # Nested functions are not generic, so no need to worry about monomorphization
+    mono_args = ()
+
     # If we have captured variables and the body contains a recursive occurrence of
     # the function itself, then we provide the partially applied function as a local
     # variable
@@ -70,16 +73,17 @@ def compile_local_func_def(
         # Otherwise, we treat the function like a normal global variable
         from guppylang.definition.function import CompiledFunctionDef
 
-        ctx.compiled[func.def_id] = CompiledFunctionDef(
+        ctx.compiled[func.def_id, mono_args] = CompiledFunctionDef(
             func.def_id,
             func.name,
             func,
+            mono_args,
             func.ty,
             None,
             func.cfg,
             func_builder,
         )
-        ctx.worklist[func.def_id] = None  # will compile the CFG later
+        ctx.worklist[func.def_id, mono_args] = None  # will compile the CFG later
 
     # Finally, load the function into the local data-flow graph
     loaded = dfg.builder.load_function(func_builder, closure_ty)

--- a/guppylang/definition/common.py
+++ b/guppylang/definition/common.py
@@ -1,7 +1,7 @@
 import ast
 import itertools
 from abc import ABC, abstractmethod
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, ClassVar, TypeAlias
 
@@ -12,12 +12,13 @@ from guppylang.span import SourceMap
 
 if TYPE_CHECKING:
     from guppylang.checker.core import Globals
-    from guppylang.compiler.core import CompilerContext
+    from guppylang.compiler.core import CompilerContext, PartiallyMonomorphizedArgs
+    from guppylang.tys.param import Parameter
 
 
 RawDef: TypeAlias = "ParsableDef | ParsedDef"
 ParsedDef: TypeAlias = "CheckableDef | CheckedDef"
-CheckedDef: TypeAlias = "CompilableDef | CompiledDef"
+CheckedDef: TypeAlias = "CompilableDef | MonomorphizableDef | CompiledDef"
 
 
 @dataclass(frozen=True)
@@ -138,6 +139,36 @@ class CompilableDef(Definition):
         """
 
 
+class MonomorphizableDef(Definition):
+    """Abstract base class for definitions that require monomorphization when compiling
+    to Hugr.
+
+    Args:
+        id: The unique definition identifier.
+        name: The name of the definition.
+        defined_at: The AST node where the definition was defined.
+    """
+
+    @property
+    @abstractmethod
+    def params(self) -> "Sequence[Parameter]":
+        """Generic parameters of this definition."""
+
+    @abstractmethod
+    def monomorphize(
+        self,
+        module: DefinitionBuilder[OpVar],
+        mono_args: "PartiallyMonomorphizedArgs",
+        ctx: "CompilerContext",
+    ) -> "MonomorphizedDef":
+        """Adds a Hugr node for the (partially) monomorphized definition to the provided
+        Hugr module.
+
+        See `MonomorphizedDef.compile_inner()` for the hook to compile the inside of the
+        node. This two-step process enables things like mutual recursion.
+        """
+
+
 class CompiledDef(Definition):
     """Abstract base class for definitions that have been added to a Hugr.
 
@@ -153,6 +184,21 @@ class CompiledDef(Definition):
         Opposed to `CompilableDef.compile()`, we have access to all other compiled
         definitions here, which allows things like mutual recursion.
         """
+
+
+@dataclass(frozen=True)
+class MonomorphizedDef(CompiledDef):
+    """Abstract base class for definitions that have been added to a Hugr and have been
+    partially monomorphized.
+
+    Args:
+        id: The unique definition identifier.
+        name: The name of the definition.
+        defined_at: The AST node where the definition was defined.
+        mono_args: Partial monomorphization of the generic parameters.
+    """
+
+    mono_args: "PartiallyMonomorphizedArgs"
 
 
 @dataclass(frozen=True)

--- a/guppylang/definition/custom.py
+++ b/guppylang/definition/custom.py
@@ -12,7 +12,13 @@ from guppylang.ast_util import AstNode, get_type, has_empty_body, with_loc, with
 from guppylang.checker.core import Context, Globals
 from guppylang.checker.expr_checker import check_call, synthesize_call
 from guppylang.checker.func_checker import check_signature
-from guppylang.compiler.core import CompilerContext, DFContainer, GlobalConstId
+from guppylang.compiler.core import (
+    CompilerContext,
+    DFContainer,
+    GlobalConstId,
+    partially_monomorphize_args,
+    requires_monomorphization,
+)
 from guppylang.definition.common import ParsableDef
 from guppylang.definition.value import CallReturnWires, CompiledCallableDef
 from guppylang.diagnostic import Error, Help
@@ -229,21 +235,31 @@ class CustomFunctionDef(CompiledCallableDef):
             raise GuppyError(NotHigherOrderError(node, self.name))
         assert len(self.ty.params) == len(type_args)
 
+        # Partially monomorphize the function if required
+        mono_args = partially_monomorphize_args(self.ty.params, type_args, ctx)
+
         # We create a generic `FunctionDef` that takes some inputs, compiles a call to
         # the function, and returns the results
         func, already_defined = ctx.declare_global_func(
-            self.higher_order_func_id, self.ty.to_hugr_poly(ctx)
+            self.higher_order_func_id,
+            self.ty.instantiate_partial(mono_args).to_hugr_poly(ctx),
+            mono_args,
         )
         if not already_defined:
-            func_dfg = DFContainer(func, ctx, dfg.locals.copy())
-            args: list[Wire] = list(func.inputs())
-            generic_ty_args = [param.to_bound() for param in self.ty.params]
-            returns = self.compile_call(args, generic_ty_args, func_dfg, ctx, node)
-            func.set_outputs(*returns.regular_returns, *returns.inout_returns)
+            with ctx.set_monomorphized_args(mono_args):
+                func_dfg = DFContainer(func, ctx, dfg.locals.copy())
+                args: list[Wire] = list(func.inputs())
+                generic_ty_args = [param.to_bound() for param in self.ty.params]
+                returns = self.compile_call(args, generic_ty_args, func_dfg, ctx, node)
+                func.set_outputs(*returns.regular_returns, *returns.inout_returns)
 
         # Finally, load the function into the local DFG
         mono_ty = self.ty.instantiate(type_args).to_hugr(ctx)
-        hugr_ty_args = [arg.to_hugr(ctx) for arg in type_args]
+        hugr_ty_args = [
+            arg.to_hugr(ctx)
+            for param, arg in zip(self.ty.params, type_args, strict=True)
+            if not requires_monomorphization(param)
+        ]
         return dfg.builder.load_function(func, mono_ty, hugr_ty_args)
 
     def compile_call(

--- a/guppylang/definition/declaration.py
+++ b/guppylang/definition/declaration.py
@@ -10,7 +10,11 @@ from guppylang.ast_util import AstNode, has_empty_body, with_loc, with_type
 from guppylang.checker.core import Context, Globals
 from guppylang.checker.expr_checker import check_call, synthesize_call
 from guppylang.checker.func_checker import check_signature
-from guppylang.compiler.core import CompilerContext, DFContainer
+from guppylang.compiler.core import (
+    CompilerContext,
+    DFContainer,
+    requires_monomorphization,
+)
 from guppylang.definition.common import CompilableDef, ParsableDef
 from guppylang.definition.function import (
     PyFunc,
@@ -23,6 +27,7 @@ from guppylang.diagnostic import Error
 from guppylang.error import GuppyError
 from guppylang.nodes import GlobalCall
 from guppylang.span import SourceMap
+from guppylang.tys.param import Parameter
 from guppylang.tys.subst import Inst, Subst
 from guppylang.tys.ty import Type
 
@@ -32,6 +37,16 @@ class BodyNotEmptyError(Error):
     title: ClassVar[str] = "Unexpected function body"
     span_label: ClassVar[str] = "Body of declared function `{name}` must be empty"
     name: str
+
+
+@dataclass(frozen=True)
+class MonomorphizeError(Error):
+    title: ClassVar[str] = "Invalid function declaration"
+    span_label: ClassVar[str] = (
+        "Function declaration `{name}` is not allowed to be generic over `{param}`"
+    )
+    name: str
+    param: Parameter
 
 
 @dataclass(frozen=True)
@@ -51,6 +66,10 @@ class RawFunctionDecl(ParsableDef):
         ty = check_signature(func_ast, globals)
         if not has_empty_body(func_ast):
             raise GuppyError(BodyNotEmptyError(func_ast.body[0], self.name))
+        # Make sure we won't need monomorphization to compile this declaration
+        for param in ty.params:
+            if requires_monomorphization(param):
+                raise GuppyError(MonomorphizeError(func_ast, self.name, param))
         return CheckedFunctionDecl(
             self.id,
             self.name,

--- a/guppylang/engine.py
+++ b/guppylang/engine.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from types import FrameType
+from typing import TYPE_CHECKING
 
 import hugr.build.function as hf
 from hugr.package import ModulePointer, Package
@@ -32,6 +33,9 @@ from guppylang.tys.builtin import (
     string_type_def,
     tuple_type_def,
 )
+
+if TYPE_CHECKING:
+    from guppylang.compiler.core import MonoDefId
 
 BUILTIN_DEFS_LIST: list[RawDef] = [
     callable_type_def,
@@ -98,7 +102,7 @@ class CompilationEngine:
 
     parsed: dict[DefId, ParsedDef]
     checked: dict[DefId, CheckedDef]
-    compiled: dict[DefId, CompiledDef]
+    compiled: dict["MonoDefId", CompiledDef]
 
     types_to_check_worklist: dict[DefId, ParsedDef]
     to_check_worklist: dict[DefId, ParsedDef]
@@ -201,10 +205,7 @@ class CompilationEngine:
         from guppylang.compiler.core import CompilerContext
 
         ctx = CompilerContext(graph)
-        # Iterate over copy of the checked values since in some cases, compiling can
-        # kick of checking calls that would change the size of `self.checked`
-        for defn in list(self.checked.values()):
-            ctx.compile(defn)
+        ctx.compile(self.checked[id])
         self.compiled = ctx.compiled
 
         # TODO: Currently we just include a hardcoded list of extensions. We should

--- a/guppylang/tracing/function.py
+++ b/guppylang/tracing/function.py
@@ -11,7 +11,7 @@ from guppylang.checker.core import ComptimeVariable, Context, Locals, Variable
 from guppylang.checker.errors.type_errors import TypeMismatchError
 from guppylang.compiler.core import CompilerContext, DFContainer
 from guppylang.compiler.expr_compiler import ExprCompiler
-from guppylang.definition.value import CompiledCallableDef
+from guppylang.definition.value import CallableDef
 from guppylang.diagnostic import Error
 from guppylang.error import GuppyComptimeError, GuppyError, exception_hook
 from guppylang.nodes import PlaceNode
@@ -137,7 +137,7 @@ def trace_function(
 
 
 @capture_guppy_errors
-def trace_call(func: CompiledCallableDef, *args: Any) -> Any:
+def trace_call(func: CallableDef, *args: Any) -> Any:
     """Handles calls to Guppy functions during tracing.
 
     Checks that the passed arguments match the signature of the function and also

--- a/guppylang/tys/arg.py
+++ b/guppylang/tys/arg.py
@@ -87,12 +87,13 @@ class ConstArg(ArgumentBase):
             case ConstValue(value=v, ty=NumericType(kind=NumericType.Kind.Nat)):
                 assert isinstance(v, int)
                 return ht.BoundedNatArg(n=v)
-            case BoundConstVar(idx=idx, ty=NumericType(kind=NumericType.Kind.Nat)):
-                param = ht.BoundedNatParam(upper_bound=None)
-                return ht.VariableArg(idx=idx, param=param)
-            case ConstValue() | BoundConstVar():
-                # TODO: Handle other cases besides nats
-                raise NotImplementedError
+            case BoundConstVar() as var:
+                return ctx.const_var_to_hugr(var)
+            case ConstValue():
+                raise InternalGuppyError(
+                    "Tried to convert non-nat const type argument to Hugr. This should "
+                    "have been erased."
+                )
             case ExistentialConstVar():
                 raise InternalGuppyError(
                     "Tried to convert unsolved constant variable to Hugr"

--- a/guppylang/tys/common.py
+++ b/guppylang/tys/common.py
@@ -1,5 +1,14 @@
 from abc import ABC, abstractmethod
-from typing import Any, Generic, Protocol, TypeVar
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar
+
+from hugr import tys as ht
+
+if TYPE_CHECKING:
+    from guppylang.tys.const import BoundConstVar
+    from guppylang.tys.param import Parameter
+    from guppylang.tys.ty import BoundTypeVar
 
 T = TypeVar("T")
 
@@ -8,8 +17,41 @@ class ToHugrContext(Protocol):
     """Protocol for the context capabilities required to translate Guppy types into Hugr
     types.
 
-    This is empty for now, but will soon be used for partial monomorphization.
+    Currently, the only required capability is translating bound type and const
+    variables into Hugr, taking into account partial monomorphization.
     """
+
+    def type_var_to_hugr(self, var: "BoundTypeVar") -> ht.Type:
+        """Compiles a bound Guppy type variable into a Hugr type.
+
+        Should take care of performing partial monomorphization as specified in the
+        current context.
+        """
+
+    def const_var_to_hugr(self, var: "BoundConstVar") -> ht.TypeArg:
+        """Compiles a bound Guppy const variable into a Hugr type argument.
+
+        Should take care of performing partial monomorphization as specified in the
+        current context.
+        """
+
+
+@dataclass(frozen=True)
+class QuantifiedToHugrContext(ToHugrContext):
+    """Concrete implementation of a `ToHugrContext` that should be used when moving
+    inside a quantifier.
+
+    This prevents the outer context from touching variables that are bound by a tighter
+    quantifier.
+    """
+
+    params: Sequence["Parameter"]
+
+    def type_var_to_hugr(self, var: "BoundTypeVar") -> ht.Type:
+        return ht.Variable(var.idx, var.hugr_bound)
+
+    def const_var_to_hugr(self, var: "BoundConstVar") -> ht.TypeArg:
+        return ht.VariableArg(var.idx, self.params[var.idx].to_hugr(self))
 
 
 class ToHugr(ABC, Generic[T]):

--- a/guppylang/tys/param.py
+++ b/guppylang/tys/param.py
@@ -148,6 +148,10 @@ class TypeParam(ParameterBase):
             bound=ht.TypeBound.Any if self.can_be_linear else ht.TypeBound.Copyable
         )
 
+    def __str__(self) -> str:
+        """User-facing string representation of the parameter."""
+        return self.name
+
 
 @dataclass(frozen=True)
 class ConstParam(ParameterBase):
@@ -212,8 +216,14 @@ class ConstParam(ParameterBase):
             case NumericType(kind=NumericType.Kind.Nat):
                 return ht.BoundedNatParam(upper_bound=None)
             case _:
-                assert isinstance(self.ty.to_hugr(ctx), ht.ExtType)
-                return ht.StringParam()
+                raise InternalGuppyError(
+                    "Tried to convert non-nat const type parameter to Hugr. This "
+                    "should have been erased."
+                )
+
+    def __str__(self) -> str:
+        """User-facing string representation of the parameter."""
+        return f"{self.name}: {self.ty}"
 
 
 def check_all_args(

--- a/guppylang/tys/subst.py
+++ b/guppylang/tys/subst.py
@@ -17,6 +17,7 @@ from guppylang.tys.var import ExistentialVar
 
 Subst = dict[ExistentialVar, Type | Const]
 Inst = Sequence[Argument]
+PartialInst = Sequence["Argument | None"]
 
 
 class Substituter(Transformer):

--- a/tests/error/poly_errors/polymorphic_decl.err
+++ b/tests/error/poly_errors/polymorphic_decl.err
@@ -1,0 +1,9 @@
+Error: Invalid function declaration (at $FILE:14:0)
+   | 
+12 | 
+13 | @guppy.declare
+14 | def main(_: Struct[F]) -> float: ...
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Function declaration `main` is not allowed to be generic
+   |                                      over `F: float`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/poly_errors/polymorphic_decl.py
+++ b/tests/error/poly_errors/polymorphic_decl.py
@@ -1,0 +1,17 @@
+from typing import Generic
+
+from guppylang.decorator import guppy
+
+F = guppy.const_var("F", "float")
+
+
+@guppy.struct
+class Struct(Generic[F]):
+    pass
+
+
+@guppy.declare
+def main(_: Struct[F]) -> float: ...
+
+
+guppy.compile(main)

--- a/tests/error/poly_errors/polymorphic_entrypoint.err
+++ b/tests/error/poly_errors/polymorphic_entrypoint.err
@@ -1,0 +1,11 @@
+Error: Invalid entry point (at $FILE:14:0)
+   | 
+12 | 
+13 | @guppy
+14 | def main(_: Struct[F]) -> float:
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+15 |     return F
+   | ^^^^^^^^^^^^ Function `main` is not a valid compilation entry point since
+   |              the value of generic paramater `F: float` is not known
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/poly_errors/polymorphic_entrypoint.py
+++ b/tests/error/poly_errors/polymorphic_entrypoint.py
@@ -1,0 +1,18 @@
+from typing import Generic
+
+from guppylang.decorator import guppy
+
+F = guppy.const_var("F", "float")
+
+
+@guppy.struct
+class Struct(Generic[F]):
+    pass
+
+
+@guppy
+def main(_: Struct[F]) -> float:
+    return F
+
+
+guppy.compile(main)

--- a/tests/integration/test_poly_const.py
+++ b/tests/integration/test_poly_const.py
@@ -40,16 +40,13 @@ def test_bool(validate, run_int_fn):
             s += 10000
         return s
 
-    guppy.check(main)
+    compiled = guppy.compile(main)
+    validate(compiled)
 
-    # TODO: Validate once Hugr lowering is implemented:
-    # compiled = guppy.compile(main)
-    # validate(compiled)
-    #
-    # # Check we have main, and 2 monomorphizations of foo (Dummy constructor is inlined)
-    # assert len(funcs_defs(compiled.module)) == 3
-    #
-    # run_int_fn(compiled, 101)
+    # Check we have main, and 2 monomorphizations of foo (Dummy constructor is inlined)
+    assert len(funcs_defs(compiled.module)) == 3
+
+    run_int_fn(compiled, 101)
 
 
 @pytest.mark.xfail(reason="https://github.com/CQCL/guppylang/issues/1030")
@@ -79,14 +76,11 @@ def test_int(validate):
             + foo[1](Dummy())
         )
 
-    guppy.check(main)
+    compiled = guppy.compile(main)
+    validate(compiled)
 
-    # TODO: Validate once Hugr lowering is implemented:
-    # compiled = guppy.compile(main)
-    # validate(compiled)
-    #
-    # # Check we have main, and 4 monomorphizations of foo (Dummy constructor is inlined)
-    # assert len(funcs_defs(compiled.module)) == 5
+    # Check we have main, and 4 monomorphizations of foo (Dummy constructor is inlined)
+    assert len(funcs_defs(compiled.module)) == 5
 
 
 def test_float(validate, run_float_fn_approx):
@@ -114,16 +108,14 @@ def test_float(validate, run_float_fn_approx):
             + foo[1.5](Dummy())
         )
 
-    guppy.check(main)
-
     # TODO: Validate once Hugr lowering is implemented:
-    # compiled = guppy.compile(main)
-    # validate(compiled)
-    #
-    # # Check we have main, and 3 monomorphizations of foo (Dummy constructor is inlined)
-    # assert len(funcs_defs(compiled.module)) == 4
-    #
-    # run_float_fn_approx(compiled, 10.5)
+    compiled = guppy.compile(main)
+    validate(compiled)
+
+    # Check we have main, and 3 monomorphizations of foo (Dummy constructor is inlined)
+    assert len(funcs_defs(compiled.module)) == 4
+
+    run_float_fn_approx(compiled, 10.5)
 
 
 @pytest.mark.xfail(reason="https://github.com/CQCL/guppylang/issues/1030")
@@ -152,14 +144,11 @@ def test_string(validate):
             foo["a"](Dummy()),
         )
 
-    guppy.check(main)
+    compiled = guppy.compile(main)
+    validate(compiled)
 
-    # TODO: Validate once Hugr lowering is implemented:
-    # compiled = guppy.compile(main)
-    # validate(compiled)
-    #
-    # # Check we have main, and 4 monomorphizations of foo (Dummy constructor is inlined)
-    # assert len(funcs_defs(compiled.module)) == 5
+    # Check we have main, and 4 monomorphizations of foo (Dummy constructor is inlined)
+    assert len(funcs_defs(compiled.module)) == 5
 
 
 def test_chain(validate, run_int_fn):
@@ -197,16 +186,13 @@ def test_chain(validate, run_int_fn):
         d[True](Dummy())
         return 1 if x else 0
 
-    guppy.check(main)
+    compiled = guppy.compile(main)
+    validate(compiled)
 
-    # TODO: Validate once Hugr lowering is implemented:
-    # compiled = guppy.compile(main)
-    # validate(compiled)
-    #
-    # # Check we have main, and 4 monomorphizations (a, b, c, d)
-    # assert len(funcs_defs(compiled.module)) == 5
-    #
-    # run_int_fn(compiled, 1)
+    # Check we have main, and 4 monomorphizations (a, b, c, d)
+    assert len(funcs_defs(compiled.module)) == 5
+
+    run_int_fn(compiled, 1)
 
 
 def test_recursion(validate):
@@ -236,14 +222,11 @@ def test_recursion(validate):
     def main() -> int:
         return baz[True](Dummy())
 
-    guppy.check(main)
+    compiled = guppy.compile(main)
+    validate(compiled)
 
-    # TODO: Validate once Hugr lowering is implemented:
-    # compiled = guppy.compile(main)
-    # validate(compiled)
-    #
-    # # Check we have main, and 5 monomorphizations of foo/bar/baz
-    # assert len(funcs_defs(compiled.module)) == 6
+    # Check we have main, and 5 monomorphizations of foo/bar/baz
+    assert len(funcs_defs(compiled.module)) == 6
 
 
 def test_many(validate):
@@ -298,16 +281,13 @@ def test_many(validate):
         bar(s3.x3s)
         foo(s3)
 
-    guppy.check(main)
+    compiled = guppy.compile(main)
+    validate(compiled)
 
-    # TODO: Validate once Hugr lowering is implemented:
-    # compiled = guppy.compile(main)
-    # validate(compiled)
-    #
-    # # Check we have main, and 2 monomorphizations of foo and baz each. Note that `s2`
-    # # doesn't generate a monomorphisation since it shares the relevant mono-parameters
-    # # with `s1`
-    # assert len(funcs_defs(compiled.module)) == 5
+    # Check we have main, and 2 monomorphizations of foo and baz each. Note that `s2`
+    # doesn't generate a monomorphisation since it shares the relevant mono-parameters
+    # with `s1`
+    assert len(funcs_defs(compiled.module)) == 5
 
 
 def test_constructor(validate):
@@ -327,14 +307,11 @@ def test_constructor(validate):
         f1()
         f2()
 
-    guppy.check(main)
+    compiled = guppy.compile(main)
+    validate(compiled)
 
-    # TODO: Validate once Hugr lowering is implemented:
-    # compiled = guppy.compile(main)
-    # validate(compiled)
-    #
-    # # Check we have main, and 2 monomorphizations of the MyStruct constructor
-    # assert len(funcs_defs(compiled.module)) == 3
+    # Check we have main, and 2 monomorphizations of the MyStruct constructor
+    assert len(funcs_defs(compiled.module)) == 3
 
 
 def test_higher_order(validate):
@@ -369,11 +346,8 @@ def test_higher_order(validate):
         foo(fun3[False])
         foo(fun3[True])
 
-    guppy.check(main)
+    compiled = guppy.compile(main)
+    validate(compiled)
 
-    # TODO: Validate once Hugr lowering is implemented:
-    # compiled = guppy.compile(main)
-    # validate(compiled)
-    #
-    # # Check we have main, fun2, and 2 monomorphizations of fun1, fun3, and foo each
-    # assert len(funcs_defs(compiled.module)) == 8
+    # Check we have main, fun2, and 2 monomorphizations of fun1, fun3, and foo each
+    assert len(funcs_defs(compiled.module)) == 8


### PR DESCRIPTION
Lowers the const generic introduced in #1034 to Hugr via monomorphization.

* In `definition.common`, we add new `MonomorphizableDef` abstract base classes to mark definitions that need to be lowered via monomorphisation. `CheckedFunctionDef` is changed to implement `MonomorphizableDef` instead of `CompileableDef`. All other definitions are unchanged.

* The `checker.core.CompilerContext` is the main driver for monomorphisation:
  * When calling `CompilerContext.build_compiled_def`, we now also need to pass the type arguments for the definition we want to compile.
  * If the to be compiled function is a `MonomorphizableDef`, the context decides which of its parameters will need to be monomorphised. This is done by the `requires_monomorphization` function. Currently, those are exactly the non-nat const parameters of the functio (not that nat params can be lowered to Hugr bounded nats, so monomorphization is not needed)
  * From the provided type arguments, the context picks the subset that correspond to these to-be-monomorphized parameters, which is done via the `partially_monomorphize_args` function. We represent these partial monomorphizations using the `PartiallyMonomorphizedArgs` type.
  * A `mono_args: PartiallyMonomorphizedArgs` is a sequence of `Argument | None`, so that `mono_args[i] == None` means that the argument with index `i` is not part of the monomorphization. Otherwise, `mono_args[i]` specifies the monomorphic instantiation for parameter `i`. So a function with 3 parameters where no monomorphization is required at all, will have `mono_args = (None, None, None)`.
  * The worklist and compilation store in the `CompilerContext` are now indexed via a pair of `DefId` and optional `PartiallyMonomorphizedArgs`. This way, the worklist can contain the same definition multiple times, but with different monomorphized args.
  * The same also applies to the `global_funcs` stored in the context. By taking potential mono-arguments into account, we can create multiple global functions corresponding to the same `GlobalConstId`. This is used in `CustomFunctionDef.load_with_args` to support custom functions with params that require monomorphization.

* The context also has two new methods: `type_var_to_hugr` and `const_var_to_hugr`. Those are used when compiling types and type arguments to Hugr. The context stores the current monomorphisation of the function that is being compiled, and when we request to lower a variable to Hugr, the context makes sure that the de Bruijn indices are down-shifted to account for the monomorphized parameters.
* Similarly, `ExprCompiler.visit_GenericParamValue` looks up the value corresponding to the current monomorphization in the context

BREAKING CHANGE: `CheckedFunctionDef` now implements `MonomorphizableDef` instead of `CompileableDef`
BREAKING CHANGE: `CompilerContext.build_compiled_def` now requires an instantiation for the definitions type parameters
BREAKING CHANGE: The `ToHugrContext` protocol now requires two additional methods:  `type_var_to_hugr` and `const_var_to_hugr`
BREAKING CHANGE: `CompilerContext.{compiled, worklist}` and `CompilationEngine.compiled` are now indexed by a tuple of `DefId` and optional `PartiallyMonomorphizedArgs`
