### PR TITLE
docs: replace `compile_module` usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ def teleport(src: qubit @ owned, tgt: qubit) -> None:
     if measure(tmp):
         x(tgt)
 
-guppy.compile_module()
+guppy.compile(teleport)
 ```
 
 More examples and tutorials are available [here][examples].

--- a/quickstart.md
+++ b/quickstart.md
@@ -25,5 +25,5 @@ def teleport(src: qubit @ owned, tgt: qubit) -> None:
         x(tgt)
 
 
-guppy.compile_module()
+guppy.compile(teleport)
 ```


### PR DESCRIPTION
Also these two files contain some duplicatated content. Maybe would be worth having `teleport` in a single place.