### PR TITLE
fix: Fix nested function definitions in Python 3.12

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -19,10 +19,14 @@ env:
 
 jobs:
   check:
-    name: Check Python (3.10)
+    name: Check Python (${{ matrix.python-version }})
     runs-on: ubuntu-latest
     env:
-      PYTHON_VERSION: '3.10'
+      PYTHON_VERSION: ${{ matrix.python-version }}
+
+    strategy:
+      matrix:
+        python-version: [ '3.10', '3.12' ]
 
     steps:
       - uses: actions/checkout@v4

--- a/guppylang/cfg/builder.py
+++ b/guppylang/cfg/builder.py
@@ -259,12 +259,7 @@ class CFGBuilder(AstVisitor[BB | None]):
             cfg,
             func_ty,
             docstring=docstring,
-            name=node.name,
-            args=node.args,
-            body=node.body,
-            decorator_list=node.decorator_list,
-            returns=node.returns,
-            type_comment=node.type_comment,
+            **dict(ast.iter_fields(node)),
         )
         set_location_from(new_node, node)
         bb.statements.append(new_node)


### PR DESCRIPTION
Fixes #1061

The issue was that the `NestedFunctionDef.type_params` field was not being set. Now, we rely on `ast.iter_fields` to copy all fields of the `ast.FunctionDef` into our `NestedFunctionDef` node.