### PR TITLE
fix!: Turn capturing closures into experimental feature

### DIFF
--- a/guppylang/checker/func_checker.py
+++ b/guppylang/checker/func_checker.py
@@ -20,6 +20,7 @@ from guppylang.definition.common import DefId
 from guppylang.diagnostic import Error, Help, Note
 from guppylang.engine import DEF_STORE, ENGINE
 from guppylang.error import GuppyError
+from guppylang.experimental import check_capturing_closures_enabled
 from guppylang.nodes import CheckedNestedFunctionDef, NestedFunctionDef
 from guppylang.tys.parsing import parse_function_io_types
 from guppylang.tys.ty import FunctionType, InputFlags, NoneType
@@ -114,6 +115,12 @@ def check_nested_func_def(
         for x, using_bb in cfg.live_before[cfg.entry_bb].items()
         if x not in func_ty.input_names and x in ctx.locals
     }
+
+    # Capturing closures are an experimental features since they aren't supported
+    # further down the stack yet
+    if captured:
+        _, loc = captured[next(iter(captured.keys()))]
+        check_capturing_closures_enabled(loc)
 
     # Captured variables may never be assigned to
     for bb in cfg.bbs:

--- a/guppylang/experimental.py
+++ b/guppylang/experimental.py
@@ -4,6 +4,7 @@ from types import TracebackType
 from typing import ClassVar
 
 from guppylang.ast_util import AstNode
+from guppylang.checker.errors.generic import UnsupportedError
 from guppylang.diagnostic import Error, Help
 from guppylang.error import GuppyError
 
@@ -84,3 +85,8 @@ def check_function_tensors_enabled(node: expr | None = None) -> None:
 def check_lists_enabled(loc: AstNode | None = None) -> None:
     if not EXPERIMENTAL_FEATURES_ENABLED:
         raise GuppyError(ExperimentalFeatureError(loc, "Lists"))
+
+
+def check_capturing_closures_enabled(loc: AstNode | None = None) -> None:
+    if not EXPERIMENTAL_FEATURES_ENABLED:
+        raise GuppyError(UnsupportedError(loc, "Capturing closures"))

--- a/tests/error/experimental_errors/capturing_closure.err
+++ b/tests/error/experimental_errors/capturing_closure.err
@@ -1,0 +1,8 @@
+Error: Unsupported (at $FILE:9:15)
+  | 
+7 | 
+8 |     def inner() -> int:
+9 |         return x
+  |                ^ Capturing closures are not supported
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/experimental_errors/capturing_closure.py
+++ b/tests/error/experimental_errors/capturing_closure.py
@@ -1,0 +1,12 @@
+from guppylang.decorator import guppy
+
+
+@guppy
+def main() -> None:
+    x = 42
+
+    def inner() -> int:
+        return x
+
+
+guppy.compile(main)

--- a/tests/integration/notebooks/demo.ipynb
+++ b/tests/integration/notebooks/demo.ipynb
@@ -440,6 +440,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import guppylang\n",
+    "guppylang.enable_experimental_features()\n",
+    "\n",
     "@guppy\n",
     "def outer(x: int) -> int:\n",
     "    def nested(y: int) -> int:\n",
@@ -545,7 +548,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.13.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Closes #1060

BREAKING CHANGE: Capturing closures are now disabled by default. Enabling them requires calling `guppylang.enable_experimental_features()`, however note that they are not supported throughout the stack.