### PR TITLE
fix: Correctly detect `@custom_guppy_decorator` in nested scopes

### DIFF
--- a/guppylang/decorator.py
+++ b/guppylang/decorator.py
@@ -584,7 +584,7 @@ def custom_guppy_decorator(f: F) -> F:
     If the `custom_guppy_decorator` were missing, then the `@my_guppy` annotation would
     not produce a valid guppy definition.
     """
-    object.__setattr__(f, "__custom_guppy_decorator__", True)
+    f.__code__ = f.__code__.replace(co_name="__custom_guppy_decorator__")
     return f
 
 
@@ -593,11 +593,9 @@ def get_calling_frame() -> FrameType:
     frame = inspect.currentframe()
     while frame:
         # Skip frame if we're inside a user-defined decorator that wraps the `guppy`
-        # decorator. Those are functions that have a `__custom_guppy_decorator__` field.
-        # We can get a reference to the calling function by looking up the code function
-        # name in the frame globals:
-        func = frame.f_globals.get(frame.f_code.co_name)
-        if getattr(func, "__custom_guppy_decorator__", None) is True:
+        # decorator. Those are functions with a special `__code__.co_name` of
+        # "__custom_guppy_decorator__".
+        if frame.f_code.co_name == "__custom_guppy_decorator__":
             frame = frame.f_back
             continue
         module = inspect.getmodule(frame)

--- a/tests/integration/test_custom_decorator.py
+++ b/tests/integration/test_custom_decorator.py
@@ -25,3 +25,59 @@ def test_custom_decorator(validate):
         return foo() + bar() + main()
 
     validate(guppy.compile(main))
+
+
+def test_nested(validate):
+    def my_guppy():
+        @custom_guppy_decorator
+        def inner(f):
+            return guppy(f)
+
+        return inner
+
+    def make():
+        @my_guppy()
+        def foooo() -> int:
+            return 1 + bar()
+
+        return foooo
+
+    foo = make()
+
+    @guppy
+    def bar() -> int:
+        return 2 + foo()
+
+    @my_guppy()
+    def main() -> int:
+        return foo() + bar() + main()
+
+    validate(guppy.compile(main))
+
+
+def test_method(validate):
+    class MyGuppy:
+        @custom_guppy_decorator
+        def decorator(self, f):
+            return guppy(f)
+
+    my_guppy = MyGuppy()
+
+    def make():
+        @my_guppy.decorator
+        def foooo() -> int:
+            return 1 + bar()
+
+        return foooo
+
+    foo = make()
+
+    @guppy
+    def bar() -> int:
+        return 2 + foo()
+
+    @my_guppy.decorator
+    def main() -> int:
+        return foo() + bar() + main()
+
+    validate(guppy.compile(main))


### PR DESCRIPTION
Fixes #1085

The previous approach of trying to get a reference to the calling function failed if the function was defined in a nested scope instead of globally. Now, we avoid the need to lookup a reference to the calling function by flagging custom decorators directly inside the code object