### PR TITLE
fix: Allow struct redefinitions for Python < 3.13

### DIFF
--- a/tests/integration/test_struct.py
+++ b/tests/integration/test_struct.py
@@ -174,3 +174,20 @@ def test_field_access_and_drop(validate):
         return MyStruct(42, 3.14, (1, 2)).y
 
     validate(guppy.compile(foo))
+
+
+def test_redefine(validate):
+    """See https://github.com/CQCL/guppylang/issues/1107"""
+    @guppy.struct
+    class MyStruct:
+        x: int
+
+    @guppy.struct
+    class MyStruct:
+        pass
+
+    @guppy
+    def foo() -> MyStruct:
+        return MyStruct()
+
+    validate(guppy.compile(foo))


### PR DESCRIPTION
Fixes #1107