### PR TITLE
fix: Fix Jupyter notebook diagnostic rendering

### DIFF
--- a/guppylang/definition/struct.py
+++ b/guppylang/definition/struct.py
@@ -4,6 +4,7 @@ import linecache
 import sys
 from collections.abc import Sequence
 from dataclasses import dataclass
+from types import FrameType
 from typing import ClassVar
 
 from hugr import Wire, ops
@@ -34,7 +35,7 @@ from guppylang.definition.ty import TypeDef
 from guppylang.diagnostic import Error, Help, Note
 from guppylang.engine import DEF_STORE
 from guppylang.error import GuppyError, InternalGuppyError
-from guppylang.ipython_inspect import find_ipython_def, is_running_ipython
+from guppylang.ipython_inspect import is_running_ipython
 from guppylang.span import SourceMap, Span, to_span
 from guppylang.tracing.object import GuppyDefinition
 from guppylang.tys.arg import Argument
@@ -112,7 +113,8 @@ class RawStructDef(TypeDef, ParsableDef):
 
     def parse(self, globals: Globals, sources: SourceMap) -> "ParsedStructDef":
         """Parses the raw class object into an AST and checks that it is well-formed."""
-        cls_def = parse_py_class(self.python_class, sources)
+        frame = DEF_STORE.frames[self.id]
+        cls_def = parse_py_class(self.python_class, frame, sources)
         if cls_def.keywords:
             raise GuppyError(UnexpectedError(cls_def.keywords[0], "keyword"))
 
@@ -282,23 +284,25 @@ class CheckedStructDef(TypeDef, CompiledDef):
         return [constructor_def]
 
 
-def parse_py_class(cls: type, sources: SourceMap) -> ast.ClassDef:
+def parse_py_class(
+    cls: type, defining_frame: FrameType, sources: SourceMap
+) -> ast.ClassDef:
     """Parses a Python class object into an AST."""
-    # If we are running IPython, `inspect.getsourcelines` works only for builtins
-    # (guppy stdlib), but not for most/user-defined classes - see:
+    module = inspect.getmodule(cls)
+    if module is None:
+        raise GuppyError(UnknownSourceError(None, cls))
+
+    # If we are running IPython, `inspect.getsourcefile` won't work if the class was
+    # defined inside a cell. See
     #  - https://bugs.python.org/issue33826
     #  - https://github.com/ipython/ipython/issues/11249
     #  - https://github.com/wandb/weave/pull/1864
-    if is_running_ipython():
-        defn = find_ipython_def(cls.__name__)
-        if defn is not None:
-            file_name = f"<{defn.cell_name}>"
-            sources.add_file(file_name, defn.cell_source)
-            annotate_location(defn.node, defn.cell_source, file_name, 1)
-            if not isinstance(defn.node, ast.ClassDef):
-                raise GuppyError(ExpectedError(defn.node, "a class definition"))
-            return defn.node
-        # else, fall through to handle builtins.
+    if is_running_ipython() and module.__name__ == "__main__":
+        file: str | None = defining_frame.f_code.co_filename
+    else:
+        file = inspect.getsourcefile(cls)
+    if file is None:
+        raise GuppyError(UnknownSourceError(None, cls))
 
     # We can't rely on `inspect.getsourcelines` since it doesn't work properly for
     # classes prior to Python 3.13. See https://github.com/CQCL/guppylang/issues/1107.
@@ -306,9 +310,6 @@ def parse_py_class(cls: type, sources: SourceMap) -> ast.ClassDef:
     # attribute. See https://github.com/python/cpython/blob/3.13/Lib/inspect.py#L1052.
     # In the decorator, we make sure that `__firstlineno__` is set, even if we're not
     # on Python 3.13.
-    file = inspect.getsourcefile(cls)
-    if file is None:
-        raise GuppyError(UnknownSourceError(None, cls))
     file_lines = linecache.getlines(file)
     line_offset = cls.__firstlineno__  # type: ignore[attr-defined]
     source_lines = inspect.getblock(file_lines[line_offset - 1 :])

--- a/guppylang/ipython_inspect.py
+++ b/guppylang/ipython_inspect.py
@@ -1,8 +1,5 @@
 """Tools for inspecting source code when running in IPython."""
 
-import ast
-from typing import Any, NamedTuple, cast
-
 
 def is_running_ipython() -> bool:
     """Checks if we are currently running in IPython"""
@@ -12,65 +9,20 @@ def is_running_ipython() -> bool:
         return False
 
 
-def is_ipython_dummy_file(filename: str) -> bool:
-    """Checks whether a given filename is a dummy name generated for an IPython cell."""
-    # TODO: The approach below is false-positive prone. Figure out if there is a better
-    #  way to do this.
-    return (
-        # IPython cells have filenames like "<ipython-input-3-3e9b5833de21>"
-        filename.startswith("<ipython-input-")
-        # Jupyter cells have filenames like "/var/{...}/ipykernel_82076/61218616.py"
-        or "ipykernel_" in filename
-    )
+def normalize_ipython_dummy_files(filename: str) -> str:
+    """Turns dummy file names generated for IPython cells into readable names like
+    "<In[42]>".
 
-
-def get_ipython_cell_sources() -> list[str]:
-    """Returns the source code of all cells in the running IPython session.
-
-    See https://github.com/wandb/weave/pull/1864
+    In vanilla IPython, cells have filenames like "<ipython-input-3-3e9b5833de21>" and
+    in Jupyter, cells have filenames like "/var/{...}/ipykernel_82076/61218616.py".
     """
-    shell = get_ipython()  # type: ignore[name-defined]  # noqa: F821
-    if not hasattr(shell, "user_ns"):
-        raise AttributeError("Cannot access user namespace")
-    cells = cast(list[str], shell.user_ns["In"])
-    # First cell is always empty
-    return cells[1:]
-
-
-class IPythonDef(NamedTuple):
-    """AST of a definition in IPython together with the definition cell name."""
-
-    node: ast.FunctionDef | ast.ClassDef
-    cell_name: str
-    cell_source: str
-
-
-def find_ipython_def(name: str) -> IPythonDef | None:
-    """Tries to find a definition matching a given name in the current IPython session.
-
-    Note that this only finds *top-level* function or class definitions. Nested
-    definitions are not detected.
-
-    See https://github.com/wandb/weave/pull/1864
-    """
-    cell_sources = get_ipython_cell_sources()
-    # Search cells in reverse order to find the most recent version of the definition
-    for i, cell_source in enumerate(reversed(cell_sources)):
-        try:
-            cell_ast = ast.parse(cell_source)
-        except SyntaxError:
-            continue
-        # Search body in reverse order to find the most recent version of the class
-        for node in reversed(cell_ast.body):
-            if isinstance(node, ast.FunctionDef | ast.ClassDef) and node.name == name:
-                cell_name = f"In [{len(cell_sources) - i}]"
-                return IPythonDef(node, cell_name, cell_source)
-    return None
-
-
-def get_ipython_globals() -> dict[str, Any]:
-    """Returns the globals of the current IPython kernel."""
     try:
-        return get_ipython().user_ns  # type: ignore[name-defined, no-any-return]
+        if shell := get_ipython():  # type: ignore[name-defined]
+            res = shell.compile.format_code_name(filename)
+            if res is None:
+                return filename
+            return f"<{res[1]}>"
+        else:
+            return filename
     except NameError:
-        raise RuntimeError("Not running in IPython") from None
+        return filename

--- a/guppylang/span.py
+++ b/guppylang/span.py
@@ -7,6 +7,7 @@ from typing import TypeAlias
 
 from guppylang.ast_util import get_file, get_line_offset
 from guppylang.error import InternalGuppyError
+from guppylang.ipython_inspect import normalize_ipython_dummy_files
 
 
 @dataclass(frozen=True, order=True)
@@ -23,7 +24,8 @@ class Loc:
 
     def __str__(self) -> str:
         """Returns the string representation of this source location."""
-        return f"{self.file}:{self.line}:{self.column}"
+        file = normalize_ipython_dummy_files(self.file)
+        return f"{file}:{self.line}:{self.column}"
 
     def shift_left(self, cols: int) -> "Loc":
         """Returns a new location shifted to left by the given number of columns."""

--- a/tests/integration/notebooks/comptime.ipynb
+++ b/tests/integration/notebooks/comptime.ipynb
@@ -362,7 +362,7 @@
    "outputs": [
     {
      "ename": "GuppyComptimeError",
-     "evalue": "Value with non-copyable type `qubit` was already used\n\nPrevious use occurred in <In [10]>:3 as an argument to `cx`",
+     "evalue": "Value with non-copyable type `qubit` was already used\n\nPrevious use occurred in <In[10]>:3 as an argument to `cx`",
      "output_type": "error",
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
@@ -370,7 +370,7 @@
       "    \u001b[0;31m[... skipping hidden 1 frame]\u001b[0m\n",
       "Cell \u001b[0;32mIn[10], line 5\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;129m@guppy\u001b[39m\u001b[38;5;241m.\u001b[39mcomptime\n\u001b[1;32m      2\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21mbad\u001b[39m(q: qubit) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m      3\u001b[0m     cx(q, q)\n\u001b[0;32m----> 5\u001b[0m \u001b[43mguppy\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcompile\u001b[49m\u001b[43m(\u001b[49m\u001b[43mbad\u001b[49m\u001b[43m)\u001b[49m\n",
       "Cell \u001b[0;32mIn[10], line 3\u001b[0m, in \u001b[0;36mbad\u001b[0;34m(q)\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;129m@guppy\u001b[39m\u001b[38;5;241m.\u001b[39mcomptime\n\u001b[1;32m      2\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21mbad\u001b[39m(q: qubit) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m----> 3\u001b[0m     \u001b[43mcx\u001b[49m\u001b[43m(\u001b[49m\u001b[43mq\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mq\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[0;31mGuppyComptimeError\u001b[0m: Value with non-copyable type `qubit` was already used\n\nPrevious use occurred in <In [10]>:3 as an argument to `cx`"
+      "\u001b[0;31mGuppyComptimeError\u001b[0m: Value with non-copyable type `qubit` was already used\n\nPrevious use occurred in <In[10]>:3 as an argument to `cx`"
      ]
     }
    ],
@@ -400,7 +400,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Error: Error in comptime function return (at <In [11]>:2:0)\n",
+      "Error: Error in comptime function return (at <In[11]>:2:0)\n",
       "  | \n",
       "1 | @guppy.comptime\n",
       "2 | def bad(q: qubit) -> qubit:\n",
@@ -411,7 +411,7 @@
       "Argument `q` is borrowed, so it is implicitly returned to the caller. Value with\n",
       "non-copyable type `qubit` was already used\n",
       "\n",
-      "Previous use occurred in <In [?]>:5.\n",
+      "Previous use occurred in <In[11]>:5.\n",
       "\n",
       "Guppy compilation failed due to 1 previous error\n"
      ]
@@ -443,7 +443,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Error: Error in comptime function return (at <In [12]>:2:0)\n",
+      "Error: Error in comptime function return (at <In[12]>:2:0)\n",
       "  | \n",
       "1 | @guppy.comptime\n",
       "2 | def bad(q: qubit) -> None:\n",
@@ -484,7 +484,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.10.18"
   }
  },
  "nbformat": 4,

--- a/tests/integration/notebooks/demo.ipynb
+++ b/tests/integration/notebooks/demo.ipynb
@@ -144,7 +144,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Error: Operator not defined (at <In [5]>:4:11)\n",
+      "Error: Operator not defined (at <In[5]>:4:11)\n",
       "  | \n",
       "2 | def bad(x: int) -> int:\n",
       "3 |     # Try to add a tuple to an int\n",
@@ -186,7 +186,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Error: Variable not defined (at <In [6]>:5:11)\n",
+      "Error: Variable not defined (at <In[6]>:5:11)\n",
       "  | \n",
       "3 |     if b:\n",
       "4 |         x = 4\n",
@@ -232,7 +232,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Error: Different types (at <In [7]>:7:15)\n",
+      "Error: Different types (at <In[7]>:7:15)\n",
       "  | \n",
       "5 |     else:\n",
       "6 |         x = True\n",
@@ -285,7 +285,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Error: Copy violation (at <In [8]>:3:10)\n",
+      "Error: Copy violation (at <In[8]>:3:10)\n",
       "  | \n",
       "1 | @guppy\n",
       "2 | def bad(q: qubit @owned) -> qubit:\n",
@@ -331,7 +331,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Error: Drop violation (at <In [9]>:3:4)\n",
+      "Error: Drop violation (at <In[9]>:3:4)\n",
       "  | \n",
       "1 | @guppy\n",
       "2 | def bad(q: qubit @owned) -> qubit:\n",
@@ -474,7 +474,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Error: Illegal assignment (at <In [13]>:4:8)\n",
+      "Error: Illegal assignment (at <In[13]>:4:8)\n",
       "  | \n",
       "2 | def outer(x: int) -> int:\n",
       "3 |     def nested() -> None:\n",
@@ -548,7 +548,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.0"
+   "version": "3.10.18"
   }
  },
  "nbformat": 4,

--- a/tests/integration/notebooks/misc_notebook_tests.ipynb
+++ b/tests/integration/notebooks/misc_notebook_tests.ipynb
@@ -42,11 +42,11 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Error: Type mismatch (at <In [?]>:3:15)\n",
+      "Error: Type mismatch (at <In[2]>:4:15)\n",
       "  | \n",
-      "1 |     @guppy\n",
-      "2 |     def foo() -> int:    \n",
-      "3 |         return 1.0\n",
+      "2 |     @guppy\n",
+      "3 |     def foo() -> int:\n",
+      "4 |         return 1.0\n",
       "  |                ^^^ Expected return value of type `int`, got `float`\n",
       "\n",
       "Guppy compilation failed due to 1 previous error\n"
@@ -69,6 +69,158 @@
     "\n",
     "guppy.compile(main);"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "7935e897-1f8c-49f5-8d32-64bdf86f58f5",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Error: Operator not defined (at <In[3]>:6:8)\n",
+      "  | \n",
+      "4 |     @guppy\n",
+      "5 |     def f() -> None:\n",
+      "6 |         1 + False  # Any type error here will do\n",
+      "  |         ^^^^^^^^^ Binary operator `+` not defined for `int` and `bool`\n",
+      "\n",
+      "Guppy compilation failed due to 1 previous error\n"
+     ]
+    }
+   ],
+   "source": [
+    "# See https://github.com/CQCL/guppylang/issues/1053\n",
+    "\n",
+    "def make():\n",
+    "    @guppy\n",
+    "    def f() -> None:\n",
+    "        1 + False  # Any type error here will do\n",
+    "\n",
+    "    return f\n",
+    "\n",
+    "make().compile()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "62686805-be6d-409e-be0a-1aac97889831",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Error: Not enough arguments (at <In[4]>:16:19)\n",
+      "   | \n",
+      "14 | @guppy\n",
+      "15 | def main() -> MyStruct:\n",
+      "16 |     return MyStruct()\n",
+      "   |                    ^^ Missing argument (expected 1, got 0)\n",
+      "\n",
+      "Note: Function signature is `int -> MyStruct`\n",
+      "\n",
+      "Guppy compilation failed due to 1 previous error\n"
+     ]
+    }
+   ],
+   "source": [
+    "@guppy.struct\n",
+    "class MyStruct:\n",
+    "    pass\n",
+    "\n",
+    "def make():\n",
+    "    @guppy.struct\n",
+    "    class MyStruct:\n",
+    "        x: int\n",
+    "\n",
+    "    return MyStruct\n",
+    "\n",
+    "MyStruct = make()\n",
+    "\n",
+    "@guppy\n",
+    "def main() -> MyStruct:\n",
+    "    return MyStruct()\n",
+    "\n",
+    "main.compile()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "82b85f1d-99bc-4207-95da-22be44c4f4ca",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Error: Drop violation (at <In[5]>:12:14)\n",
+      "   | \n",
+      "10 | \n",
+      "11 |     @guppy\n",
+      "12 |     def wrong(self: \"Struct\" @ owned) -> None:\n",
+      "   |               ^^^^^^^^^^^^^^^^^^^^^^ Field `self.q` with non-droppable type `qubit` is leaked\n",
+      "\n",
+      "Help: Make sure that `self.q` is consumed or returned to avoid the leak\n",
+      "\n",
+      "Guppy compilation failed due to 1 previous error\n"
+     ]
+    }
+   ],
+   "source": [
+    "# See https://github.com/CQCL/guppylang/issues/937\n",
+    "\n",
+    "from guppylang.std.quantum import discard\n",
+    "from guppylang.std.builtins import owned\n",
+    "from guppylang.std.quantum import qubit\n",
+    "\n",
+    "@guppy.struct\n",
+    "class Struct:\n",
+    "    q: qubit\n",
+    "\n",
+    "    @guppy\n",
+    "    def wrong(self: \"Struct\" @ owned) -> None:\n",
+    "        pass # self.discard() would work\n",
+    "\n",
+    "    @guppy\n",
+    "    def discard(self: \"Struct\" @ owned) -> None:\n",
+    "        discard(self.q)\n",
+    "\n",
+    "@guppy\n",
+    "def main() -> None:\n",
+    "    Struct(qubit()).wrong()\n",
+    "\n",
+    "    \n",
+    "guppy.compile(main)"
+   ]
   }
  ],
  "metadata": {
@@ -87,7 +239,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.10.18"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes #1053 and fixes #937

I finally found a way to fix our notebook problems in a way that's hopefully more stable than previous hacks. It relies on the internal [`format_code_name`](https://ipython.readthedocs.io/en/9.1.0/api/generated/IPython.core.compilerop.html#IPython.core.compilerop.CachingCompiler.format_code_name) IPython method that allows us to translate dummy file names generated by IPython into their corresponding cells. This allows us to get rid of previous attempts to find definitions by walking the AST of cells.