### PR TITLE
fix: Stop showing temporary variables in comptime diagnostics

### DIFF
--- a/guppylang/checker/expr_checker.py
+++ b/guppylang/checker/expr_checker.py
@@ -39,7 +39,7 @@ from guppylang.ast_util import (
     with_loc,
     with_type,
 )
-from guppylang.cfg.builder import tmp_vars
+from guppylang.cfg.builder import is_tmp_var, tmp_vars
 from guppylang.checker.core import (
     Context,
     DummyEvalDict,
@@ -1083,7 +1083,7 @@ def check_comptime_arg(
             match arg:
                 case PlaceNode(place=place) if place.root.is_func_input:
                     s = ComptimeUnknownError.InputHint(place.defined_at, place)
-                case PlaceNode(place=place):
+                case PlaceNode(place=place) if not is_tmp_var(place.root.name):
                     s = ComptimeUnknownError.VariableHint(place.defined_at, place)
                 case arg:
                     s = ComptimeUnknownError.FallbackHint(arg)

--- a/tests/error/comptime_arg_errors/unknown_cf_expr.err
+++ b/tests/error/comptime_arg_errors/unknown_cf_expr.err
@@ -1,0 +1,16 @@
+Error: Not known at compile-time (at $FILE:12:15)
+   | 
+10 | @guppy
+11 | def main(b: bool) -> nat:
+12 |     return foo(nat(1) if b else nat(2))
+   |                ^^^^^^^^^^^^^^^^^^^^^^^ Value of this argument must be known at compile-time
+   | 
+12 |     return foo(nat(1) if b else nat(2))
+   |                ----------------------- This expression involves a dynamic computation, so its value
+   |                                        is not statically known
+
+Note: We are currently investigating ways to make Guppy's compile-time reasoning
+smarter. Please leave your feedback at
+https://github.com/CQCL/guppylang/discussions/987
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/comptime_arg_errors/unknown_cf_expr.py
+++ b/tests/error/comptime_arg_errors/unknown_cf_expr.py
@@ -1,0 +1,15 @@
+from guppylang import guppy
+from guppylang.std.builtins import comptime, nat
+
+
+@guppy
+def foo(n: nat @comptime) -> nat:
+    return n
+
+
+@guppy
+def main(b: bool) -> nat:
+    return foo(nat(1) if b else nat(2))
+
+
+guppy.compile(main)


### PR DESCRIPTION
Fixes #1111