### PR TITLE
feat!: Make decorator return types more precise

### DIFF
--- a/guppylang/checker/core.py
+++ b/guppylang/checker/core.py
@@ -338,7 +338,7 @@ class Globals:
     @cache
     def builtin_defs() -> dict[str, Definition]:
         import guppylang.std.builtins
-        from guppylang.tracing.object import GuppyDefinition
+        from guppylang.defs import GuppyDefinition
 
         return BUILTIN_DEFS | {
             name: val.wrapped
@@ -408,7 +408,7 @@ class Globals:
     def __getitem__(self, item: str) -> "ParsedDef | PythonObject": ...
 
     def __getitem__(self, item: DefId | str) -> "ParsedDef | PythonObject":
-        from guppylang.tracing.object import GuppyDefinition
+        from guppylang.defs import GuppyDefinition
 
         match item:
             case DefId() as def_id:

--- a/guppylang/checker/expr_checker.py
+++ b/guppylang/checker/expr_checker.py
@@ -452,8 +452,8 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
                 )
 
     def visit_Attribute(self, node: ast.Attribute) -> tuple[ast.expr, Type]:
+        from guppylang.defs import GuppyDefinition
         from guppylang.engine import ENGINE
-        from guppylang.tracing.object import GuppyDefinition
 
         # A `value.attr` attribute access. Unfortunately, the `attr` is just a string,
         # not an AST node, so we have to compute its span by hand. This is fine since

--- a/guppylang/checker/func_checker.py
+++ b/guppylang/checker/func_checker.py
@@ -150,7 +150,7 @@ def check_nested_func_def(
         if not captured:
             # If there are no captured vars, we treat the function like a global name
             from guppylang.definition.function import ParsedFunctionDef
-            from guppylang.tracing.object import GuppyDefinition
+            from guppylang.defs import GuppyDefinition
 
             func = ParsedFunctionDef(def_id, func_def.name, func_def, func_ty, None)
             DEF_STORE.register_def(func, None)

--- a/guppylang/definition/const.py
+++ b/guppylang/definition/const.py
@@ -9,7 +9,7 @@ from guppylang.ast_util import AstNode
 from guppylang.checker.core import Globals
 from guppylang.compiler.core import CompilerContext, DFContainer
 from guppylang.definition.common import CompilableDef, ParsableDef
-from guppylang.definition.value import CompiledValueDef, ValueDef
+from guppylang.definition.value import CompiledHugrNodeDef, CompiledValueDef, ValueDef
 from guppylang.span import SourceMap
 from guppylang.tys.parsing import type_from_ast
 
@@ -55,10 +55,15 @@ class ConstDef(RawConstDef, ValueDef, CompilableDef):
 
 
 @dataclass(frozen=True)
-class CompiledConstDef(ConstDef, CompiledValueDef):
+class CompiledConstDef(ConstDef, CompiledValueDef, CompiledHugrNodeDef):
     """A constant that has been compiled to a Hugr node."""
 
     const_node: Node
+
+    @property
+    def hugr_node(self) -> Node:
+        """The Hugr node this definition was compiled into."""
+        return self.const_node
 
     def load(self, dfg: DFContainer, ctx: CompilerContext, node: AstNode) -> Wire:
         """Loads the extern value into a local Hugr dataflow graph."""

--- a/guppylang/definition/declaration.py
+++ b/guppylang/definition/declaration.py
@@ -22,7 +22,12 @@ from guppylang.definition.function import (
     load_with_args,
     parse_py_func,
 )
-from guppylang.definition.value import CallableDef, CallReturnWires, CompiledCallableDef
+from guppylang.definition.value import (
+    CallableDef,
+    CallReturnWires,
+    CompiledCallableDef,
+    CompiledHugrNodeDef,
+)
 from guppylang.diagnostic import Error
 from guppylang.error import GuppyError
 from guppylang.nodes import GlobalCall
@@ -130,10 +135,17 @@ class CheckedFunctionDecl(RawFunctionDecl, CompilableDef, CallableDef):
 
 
 @dataclass(frozen=True)
-class CompiledFunctionDecl(CheckedFunctionDecl, CompiledCallableDef):
+class CompiledFunctionDecl(
+    CheckedFunctionDecl, CompiledCallableDef, CompiledHugrNodeDef
+):
     """A function declaration with a corresponding Hugr node."""
 
     declaration: Node
+
+    @property
+    def hugr_node(self) -> Node:
+        """The Hugr node this definition was compiled into."""
+        return self.declaration
 
     def load_with_args(
         self,

--- a/guppylang/definition/extern.py
+++ b/guppylang/definition/extern.py
@@ -8,7 +8,7 @@ from guppylang.ast_util import AstNode
 from guppylang.checker.core import Globals
 from guppylang.compiler.core import CompilerContext, DFContainer
 from guppylang.definition.common import CompilableDef, ParsableDef
-from guppylang.definition.value import CompiledValueDef, ValueDef
+from guppylang.definition.value import CompiledHugrNodeDef, CompiledValueDef, ValueDef
 from guppylang.span import SourceMap
 from guppylang.tys.parsing import type_from_ast
 
@@ -70,10 +70,15 @@ class ExternDef(RawExternDef, ValueDef, CompilableDef):
 
 
 @dataclass(frozen=True)
-class CompiledExternDef(ExternDef, CompiledValueDef):
+class CompiledExternDef(ExternDef, CompiledValueDef, CompiledHugrNodeDef):
     """An extern symbol definition that has been compiled to a Hugr constant."""
 
     const_node: Node
+
+    @property
+    def hugr_node(self) -> Node:
+        """The Hugr node this definition was compiled into."""
+        return self.const_node
 
     def load(self, dfg: DFContainer, ctx: CompilerContext, node: AstNode) -> Wire:
         """Loads the extern value into a local Hugr dataflow graph."""

--- a/guppylang/definition/function.py
+++ b/guppylang/definition/function.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 import hugr.build.function as hf
 import hugr.tys as ht
-from hugr import Wire
+from hugr import Node, Wire
 from hugr.build.dfg import DefinitionBuilder, OpVar
 from hugr.hugr.node_port import ToNode
 
@@ -33,7 +33,12 @@ from guppylang.definition.common import (
     ParsableDef,
     UnknownSourceError,
 )
-from guppylang.definition.value import CallableDef, CallReturnWires, CompiledCallableDef
+from guppylang.definition.value import (
+    CallableDef,
+    CallReturnWires,
+    CompiledCallableDef,
+    CompiledHugrNodeDef,
+)
 from guppylang.error import GuppyError
 from guppylang.ipython_inspect import find_ipython_def, is_running_ipython
 from guppylang.nodes import GlobalCall
@@ -182,7 +187,9 @@ class CheckedFunctionDef(ParsedFunctionDef, MonomorphizableDef):
 
 
 @dataclass(frozen=True)
-class CompiledFunctionDef(CheckedFunctionDef, CompiledCallableDef, MonomorphizedDef):
+class CompiledFunctionDef(
+    CheckedFunctionDef, CompiledCallableDef, MonomorphizedDef, CompiledHugrNodeDef
+):
     """A function definition with a corresponding Hugr node.
 
     Args:
@@ -198,6 +205,11 @@ class CompiledFunctionDef(CheckedFunctionDef, CompiledCallableDef, Monomorphized
     """
 
     func_def: hf.Function
+
+    @property
+    def hugr_node(self) -> Node:
+        """The Hugr node this definition was compiled into."""
+        return self.func_def.parent_node
 
     def load_with_args(
         self,

--- a/guppylang/definition/pytket_circuits.py
+++ b/guppylang/definition/pytket_circuits.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, field
 from typing import Any, cast
 
 import hugr.build.function as hf
-from hugr import Wire, envelope, ops, val
+from hugr import Node, Wire, envelope, ops, val
 from hugr import tys as ht
 from hugr.build.dfg import DefinitionBuilder, OpVar
 from hugr.envelope import EnvelopeConfig
@@ -31,7 +31,13 @@ from guppylang.definition.function import (
     parse_py_func,
 )
 from guppylang.definition.ty import TypeDef
-from guppylang.definition.value import CallableDef, CallReturnWires, CompiledCallableDef
+from guppylang.definition.value import (
+    CallableDef,
+    CallReturnWires,
+    CompiledCallableDef,
+    CompiledHugrNodeDef,
+)
+from guppylang.defs import GuppyDefinition
 from guppylang.error import GuppyError, InternalGuppyError
 from guppylang.nodes import GlobalCall
 from guppylang.span import SourceMap, Span, ToSpan
@@ -42,7 +48,6 @@ from guppylang.std._internal.compiler.array import (
 )
 from guppylang.std._internal.compiler.prelude import build_unwrap
 from guppylang.std._internal.compiler.tket2_bool import OpaqueBool, make_opaque
-from guppylang.tracing.object import GuppyDefinition
 from guppylang.tys.builtin import array_type, bool_type
 from guppylang.tys.subst import Inst, Subst
 from guppylang.tys.ty import (
@@ -304,7 +309,7 @@ class ParsedPytketDef(CallableDef, CompilableDef):
 
 
 @dataclass(frozen=True)
-class CompiledPytketDef(ParsedPytketDef, CompiledCallableDef):
+class CompiledPytketDef(ParsedPytketDef, CompiledCallableDef, CompiledHugrNodeDef):
     """A function definition with a corresponding Hugr node.
 
     Args:
@@ -318,6 +323,11 @@ class CompiledPytketDef(ParsedPytketDef, CompiledCallableDef):
     """
 
     func_def: hf.Function
+
+    @property
+    def hugr_node(self) -> Node:
+        """The Hugr node this definition was compiled into."""
+        return self.func_def.parent_node
 
     def load_with_args(
         self,

--- a/guppylang/definition/struct.py
+++ b/guppylang/definition/struct.py
@@ -31,12 +31,12 @@ from guppylang.definition.custom import (
 from guppylang.definition.function import parse_source
 from guppylang.definition.parameter import ParamDef
 from guppylang.definition.ty import TypeDef
+from guppylang.defs import GuppyDefinition
 from guppylang.diagnostic import Error, Help, Note
 from guppylang.engine import DEF_STORE
 from guppylang.error import GuppyError, InternalGuppyError
 from guppylang.ipython_inspect import find_ipython_def, is_running_ipython
 from guppylang.span import SourceMap, Span, to_span
-from guppylang.tracing.object import GuppyDefinition
 from guppylang.tys.arg import Argument
 from guppylang.tys.param import Parameter, check_all_args
 from guppylang.tys.parsing import type_from_ast

--- a/guppylang/definition/value.py
+++ b/guppylang/definition/value.py
@@ -3,7 +3,7 @@ from abc import abstractmethod
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, NamedTuple
 
-from hugr import Wire
+from hugr import Node, Wire
 
 from guppylang.ast_util import AstNode
 from guppylang.definition.common import CompiledDef, Definition
@@ -104,3 +104,12 @@ class CallReturnWires(NamedTuple):
 
     regular_returns: list[Wire]
     inout_returns: list[Wire]
+
+
+class CompiledHugrNodeDef(Definition):
+    """Abstract base class for definitions that are compiled into a single Hugr node."""
+
+    @property
+    @abstractmethod
+    def hugr_node(self) -> Node:
+        """The Hugr node this definition was compiled into."""

--- a/guppylang/defs.py
+++ b/guppylang/defs.py
@@ -1,0 +1,65 @@
+"""Definition objects that are being exposed to users.
+
+These are the objects returned by the `@guppy` decorator. They should not be confused
+with the compiler-internal definition objects in the `definitions` module.
+"""
+
+from dataclasses import dataclass
+from typing import Any, ClassVar, Generic, ParamSpec, TypeVar, cast
+
+from hugr.package import FuncDefnPointer, ModulePointer
+
+from guppylang.tracing.object import TracingDefMixin
+from guppylang.tracing.util import hide_trace
+
+P = ParamSpec("P")
+Out = TypeVar("Out")
+
+
+@dataclass(frozen=True)
+class GuppyDefinition(TracingDefMixin):
+    """A general Guppy definition."""
+
+    def compile(self) -> ModulePointer:
+        from guppylang.decorator import guppy
+
+        return guppy.compile(self)
+
+
+@dataclass(frozen=True)
+class GuppyFunctionDefinition(GuppyDefinition, Generic[P, Out]):
+    """A Guppy function definition."""
+
+    @hide_trace
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> Out:
+        return cast(Out, super().__call__(*args, **kwargs))
+
+    def compile(self) -> FuncDefnPointer:
+        from guppylang.decorator import guppy
+
+        return guppy.compile_function(self)
+
+
+@dataclass(frozen=True)
+class GuppyTypeVarDefinition(GuppyDefinition):
+    """Definition of a Guppy type variable."""
+
+    # For type variables, we need a `GuppyDefinition` subclass that answers 'yes' to an
+    # instance check on `typing.TypeVar`. This hack is needed since `typing.Generic[T]`
+    # has a runtime check that enforces that the passed `T` is actually a `TypeVar`.
+
+    __class__: ClassVar[type] = TypeVar
+
+    _ty_var: TypeVar
+
+    def __eq__(self, other: object) -> bool:
+        # We need to compare as equal to an equivalent regular type var
+        if isinstance(other, TypeVar):
+            return self._ty_var == other
+        return object.__eq__(self, other)
+
+    def __getattr__(self, name: str) -> Any:
+        # Pretend to be a `TypeVar` by providing all of its attributes
+        if hasattr(self._ty_var, name):
+            return getattr(self._ty_var, name)
+        return object.__getattribute__(self, name)

--- a/guppylang/std/_internal/debug.py
+++ b/guppylang/std/_internal/debug.py
@@ -8,11 +8,11 @@ from guppylang.checker.errors.type_errors import WrongNumberOfArgsError
 from guppylang.checker.expr_checker import ExprChecker, ExprSynthesizer, synthesize_call
 from guppylang.definition.custom import CustomCallChecker
 from guppylang.definition.ty import TypeDef
+from guppylang.defs import GuppyDefinition
 from guppylang.diagnostic import Error
 from guppylang.error import GuppyTypeError
 from guppylang.nodes import StateResultExpr
 from guppylang.std._internal.checker import TAG_MAX_LEN, TooLongError
-from guppylang.tracing.object import GuppyDefinition
 from guppylang.tys.builtin import (
     get_array_length,
     get_element_type,

--- a/guppylang/tracing/unpacking.py
+++ b/guppylang/tracing/unpacking.py
@@ -9,11 +9,12 @@ from guppylang.checker.errors.comptime_errors import IllegalComptimeExpressionEr
 from guppylang.checker.expr_checker import python_value_to_guppy_type
 from guppylang.compiler.core import CompilerContext
 from guppylang.compiler.expr_compiler import python_value_to_hugr
+from guppylang.defs import GuppyDefinition
 from guppylang.error import GuppyComptimeError, GuppyError
 from guppylang.std._internal.compiler.array import array_new, unpack_array
 from guppylang.std._internal.compiler.prelude import build_unwrap
 from guppylang.tracing.frozenlist import frozenlist
-from guppylang.tracing.object import GuppyDefinition, GuppyObject, GuppyStructObject
+from guppylang.tracing.object import GuppyObject, GuppyStructObject
 from guppylang.tracing.state import get_tracing_state
 from guppylang.tys.builtin import (
     array_type,

--- a/guppylang/tys/parsing.py
+++ b/guppylang/tys/parsing.py
@@ -135,7 +135,7 @@ def arg_from_ast(
 def _try_parse_defn(node: AstNode, globals: Globals) -> Definition | None:
     """Tries to parse a (possibly qualified) name into a global definition."""
     from guppylang.checker.cfg_checker import VarNotDefinedError
-    from guppylang.tracing.object import GuppyDefinition
+    from guppylang.defs import GuppyDefinition
 
     match node:
         case ast.Name(id=x):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from selene_hugr_qis_compiler import check_hugr
 
-from guppylang.tracing.object import GuppyDefinition
+from guppylang.defs import GuppyDefinition
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Closes #1114

Adds a new `GuppyFunctionDefinition` objects that is returned from the decorator for all kinds of function definitions (vanilla, comptime, wasm, custom, hugr_op, declare, overload).

As a drive-by, I also added a new `CompiledHugrNodeDefinition` ABC that is implemented by all definitions that compile to a Hugr node

BREAKING CHANGE: `guppylang.tracing.object.GuppyDefinition` moved to `guppylang.defs.GuppyDefinition`
BREAKING CHANGE: `guppylang.tracing.object.TypeVarGuppyDefinition` moved and renamed to `guppylang.defs.GuppyTypeVarDefinition`
