### PR TITLE
ci: Make sure release-please updates `-internals` version in uv.lock

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -33,7 +33,7 @@
         {
           "type": "toml",
           "path": "uv.lock",
-          "jsonpath": "$.package[?(@.name.value=='guppylang_internals')].version"
+          "jsonpath": "$.package[?(@.name.value=='guppylang-internals')].version"
         }
       ]
     }


### PR DESCRIPTION
The last `-internals` didn't update the `uv.lock` due to this typo.