### PR TITLE
fix: Fix builtins mock escaping the tracing scope

### DIFF
--- a/guppylang-internals/src/guppylang_internals/tracing/builtins_mock.py
+++ b/guppylang-internals/src/guppylang_internals/tracing/builtins_mock.py
@@ -7,7 +7,8 @@ the builtins to avoid raising the `TypeError` in that case.
 """
 
 import builtins
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from typing import Any
 
 from guppylang_internals.tracing.object import GuppyObject, GuppyStructObject
@@ -46,10 +47,10 @@ class float(builtins.float, metaclass=_mock_meta(builtins.float)):  # type: igno
 
 
 class int(builtins.int, metaclass=_mock_meta(builtins.int)):  # type: ignore[misc]
-    def __new__(cls, x: Any = 0, /, **kwargs: Any) -> Any:
+    def __new__(cls, x: Any = 0, /, *args: Any, **kwargs: Any) -> Any:
         if isinstance(x, GuppyObject):
-            return x.__int__(**kwargs)
-        return builtins.int(x, **kwargs)
+            return x.__int__(*args, **kwargs)
+        return builtins.int(x, *args, **kwargs)
 
 
 def len(x: Any) -> Any:
@@ -58,5 +59,22 @@ def len(x: Any) -> Any:
     return builtins.len(x)
 
 
-def mock_builtins(f: Callable[..., Any]) -> None:
-    f.__globals__.update({"float": float, "int": int, "len": len})
+@contextmanager
+def mock_builtins(f: Callable[..., Any]) -> Iterator[None]:
+    # References to builtins inside `f` are looked up in `f.__builtins__`.
+    # Unfortunately, this is a readonly attribute so we can't assign a new dict to it.
+    # Mutating in-place is also a bad idea since this would also mutate the `builtins`
+    # module, making us loose an escape hatch to query the original. Instead, let's
+    # mutate `f.__globals__` which makes Python believe that the builtins are shadowed.
+    mock = {"float": float, "int": int, "len": len}
+    old = {x: f.__globals__[x] for x in mock if x in f.__globals__}
+    f.__globals__.update(mock)
+    try:
+        yield
+    finally:
+        # Reset back to the prior state since mutating `f.__globals__` also mutated the
+        # outer globals
+        for x in mock:
+            if x not in old:
+                del f.__globals__[x]
+        f.__globals__.update(old)

--- a/guppylang-internals/src/guppylang_internals/tracing/function.py
+++ b/guppylang-internals/src/guppylang_internals/tracing/function.py
@@ -70,8 +70,7 @@ def trace_function(
             for wire, inp in zip(builder.inputs(), ty.inputs, strict=True)
         ]
 
-        with exception_hook(tracing_except_hook):
-            mock_builtins(python_func)
+        with exception_hook(tracing_except_hook), mock_builtins(python_func):
             py_out = python_func(*inputs)
 
         try:

--- a/tests/integration/tracing/test_mocked_builtins.py
+++ b/tests/integration/tracing/test_mocked_builtins.py
@@ -39,6 +39,9 @@ def test_float(validate):
 
     validate(test.compile())
 
+    # Outside the function, we have the regular builtin
+    assert float is builtins.float
+
 
 def test_int(validate):
     @guppy.comptime
@@ -60,6 +63,7 @@ def test_int(validate):
 
         for v in (True, False, 42, "-123"):
             assert int(v) == builtins.int(v)
+        assert int("1000", 2) == builtins.int("1000", 2)
 
         # But they are not identical
         assert int is not builtins.int
@@ -72,6 +76,9 @@ def test_int(validate):
         return int(x)
 
     validate(test.compile())
+
+    # Outside the function, we have the regular builtin
+    assert int is builtins.int
 
 
 def test_len(validate):
@@ -105,3 +112,6 @@ def test_len(validate):
         return len(s)
 
     validate(test.compile())
+
+    # Outside the function, we have the regular builtin
+    assert len is builtins.len


### PR DESCRIPTION
Fixes #1122

As I driveby I also fixed the `int` mock to accept the base argument during tracing