### PR TITLE
docs: fix some docstring formatting

### DIFF
--- a/guppylang/decorator.py
+++ b/guppylang/decorator.py
@@ -193,36 +193,38 @@ class _Guppy:
 
         Consider the following example:
 
-        ```
-        @guppy.declare
-        def variant1(x: int, y: int) -> int: ...
+        .. code-block:: python
 
-        @guppy.declare
-        def variant2(x: float) -> int: ...
+            @guppy.declare
+            def variant1(x: int, y: int) -> int: ...
 
-        @guppy.overload(variant1, variant2)
-        def combined(): ...
-        ```
+            @guppy.declare
+            def variant2(x: float) -> int: ...
+
+            @guppy.overload(variant1, variant2)
+            def combined(): ...
+
 
         Now, `combined` may be called with either one `float` or two `int` arguments,
         delegating to the implementation with the matching signature:
 
-        ```
-        combined(4.2)  # Calls `variant1`
-        combined(42, 43)  # Calls `variant2`
-        ```
+        .. code-block:: python
+
+            combined(4.2)  # Calls `variant1`
+            combined(42, 43)  # Calls `variant2`
+
 
         Note that the compiler will pick the *first* implementation with matching
         signature and ignore all following ones, even if they would also match. For
         example, if we added a third variant
 
-        ```
-        @guppy.declare
-        def variant3(x: int) -> int: ...
+        .. code-block:: python
 
-        @guppy.overload(variant1, variant2, variant3)
-        def combined_new(): ...
-        ```
+            @guppy.declare
+            def variant3(x: int) -> int: ...
+
+            @guppy.overload(variant1, variant2, variant3)
+            def combined_new(): ...
 
         then a call `combined_new(42)` will still select the `variant1` implementation
         `42` is a valid argument for `variant1` and `variant1` comes before `variant3`

--- a/guppylang/defs.py
+++ b/guppylang/defs.py
@@ -71,7 +71,7 @@ class GuppyFunctionDefinition(GuppyDefinition, Generic[P, Out]):
         Args:
             n_qubits: The number of qubits to allocate for the function.
             builder: An optional `EmulatorBuilder` to use for building the emulator
-                instance. If not provided, the default `EmulatorBuilder` will be used.
+            instance. If not provided, the default `EmulatorBuilder` will be used.
 
         Returns:
             An `EmulatorInstance` that can be used to run the function in an emulator.

--- a/guppylang/emulator/state.py
+++ b/guppylang/emulator/state.py
@@ -102,11 +102,12 @@ class PartialVector(PartialState[StateVector]):
     ) -> None:
         """Initialize a PartialVector from a base state vector, total qubits, and
         specified qubits.
+
         Args:
             base_state: The state vector over all qubits in the system.
             total_qubits: Total number of qubits in the system
             specified_qubits: List of specified qubits in the state. Those not in this
-                list are considered traced out.
+            list are considered traced out.
         """
         self._inner = SeleneQuestState(
             state=base_state,

--- a/guppylang/std/quantum/__init__.py
+++ b/guppylang/std/quantum/__init__.py
@@ -154,7 +154,17 @@ def s(q: qubit) -> None:
 
 @hugr_op(quantum_op("V"))
 @no_type_check
-def v(q: qubit) -> None: ...
+def v(q: qubit) -> None:
+    r"""V gate.
+
+    .. math::
+      \mathrm{V}= \frac{1}{\sqrt{2}}
+       \begin{pmatrix}
+            1 & -i \\
+            -i & 1
+           \end{pmatrix}
+
+    """
 
 
 @hugr_op(quantum_op("X"))
@@ -234,7 +244,17 @@ def sdg(q: qubit) -> None:
 
 @hugr_op(quantum_op("Vdg"))
 @no_type_check
-def vdg(q: qubit) -> None: ...
+def vdg(q: qubit) -> None:
+    r"""V gate.
+
+    .. math::
+      \mathrm{V}^\dagger= \frac{1}{\sqrt{2}}
+       \begin{pmatrix}
+            1 & i \\
+            i & 1
+           \end{pmatrix}
+
+    """
 
 
 @custom_function(RotationCompiler("Rz"))

--- a/guppylang/std/quantum/functional.py
+++ b/guppylang/std/quantum/functional.py
@@ -66,6 +66,7 @@ def s(q: qubit @ owned) -> qubit:
 @guppy
 @no_type_check
 def v(q: qubit @ owned) -> qubit:
+    """Functional V gate command."""
     quantum.v(q)
     return q
 
@@ -113,6 +114,7 @@ def sdg(q: qubit @ owned) -> qubit:
 @guppy
 @no_type_check
 def vdg(q: qubit @ owned) -> qubit:
+    """Functional Vdg command."""
     quantum.vdg(q)
     return q
 


### PR DESCRIPTION
fixes some indentation and styling issues that were causing warnings in the docs build.

Driveby add some matrix defs for V and Vdg gates