### PR TITLE
fix(emulator): pass runtime option to selene

### DIFF
--- a/guppylang/emulator/instance.py
+++ b/guppylang/emulator/instance.py
@@ -214,6 +214,7 @@ class EmulatorInstance:
         """Run the Selene instance with the given simulator lazily."""
         return self._instance.run_shots(
             simulator=self.simulator,
+            runtime=self.runtime,
             n_qubits=self.n_qubits,
             n_shots=self.shots,
             event_hook=self._options._event_hook,

--- a/tests/integration/emulator/test_simple.py
+++ b/tests/integration/emulator/test_simple.py
@@ -2,6 +2,12 @@ from guppylang.decorator import guppy
 from guppylang.std.builtins import result
 from guppylang.std.quantum import qubit, measure, h
 from guppylang.emulator import EmulatorResult
+from selene_sim.backends.bundled_runtimes import SoftRZRuntime
+
+from datetime import timedelta
+from selene_sim.backends.bundled_simulators import Stim
+from selene_sim.backends.bundled_error_models import IdealErrorModel
+from selene_sim.event_hooks import NoEventHook
 
 
 def test_basic_emulation() -> None:
@@ -22,6 +28,47 @@ def test_basic_emulation() -> None:
     res = main.emulator(1).statevector_sim().with_seed(42).run()
     expected = EmulatorResult([[("c", True)]])
     assert res == expected
+
+
+
+def test_all_options() -> None:
+    """Test that all configuration options are properly set and accessible."""
+
+    @guppy
+    def main() -> None:
+        return
+
+    em = main.emulator(1)
+
+    # Test all configuration methods
+    configured_em = (
+        em.with_shots(100)
+        .with_simulator(Stim())
+        .with_runtime(SoftRZRuntime())
+        .with_error_model(IdealErrorModel())
+        .with_event_hook(NoEventHook())
+        .with_verbose(True)
+        .with_timeout(timedelta(seconds=30))
+        .with_seed(12345)
+        .with_shot_offset(10)
+        .with_shot_increment(2)
+        .with_n_processes(4)
+    )
+
+    # Verify all properties are set correctly
+    assert configured_em.shots == 100
+    assert isinstance(configured_em.simulator, Stim)
+    assert isinstance(configured_em.runtime, SoftRZRuntime)
+    assert isinstance(configured_em.error_model, IdealErrorModel)
+    assert configured_em.verbose is True
+    assert configured_em.timeout == timedelta(seconds=30)
+    assert configured_em.seed == 12345
+    assert configured_em.shot_offset == 10
+    assert configured_em.shot_increment == 2
+    assert configured_em.n_processes == 4
+
+    result = configured_em.run()
+    assert isinstance(result, EmulatorResult)
 
 
 # TODO more tests


### PR DESCRIPTION
Closes #1173

The test doesn't really check the bug - would succeed without the fix, it is more of a drive-by

The actual behaviour is somewhat subtle to test since you have to use selene logging to check the runtime behaviour. If the reviewer feels strongly this should be included I will investigate.

Unit tests for the emulator module are in progress.

BEGIN_COMMIT_OVERRIDE

fix(emulator): pass runtime option to selene
Release-As: 0.21.2

END_COMMIT_OVERRIDE