### PR TITLE
chore!: Delete unused old iterator AST nodes

### DIFF
--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -101,8 +101,6 @@ from guppylang_internals.nodes import (
     FieldAccessAndDrop,
     GenericParamValue,
     GlobalName,
-    IterEnd,
-    IterHasNext,
     IterNext,
     LocalCall,
     MakeIter,
@@ -784,14 +782,6 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
                 raise GuppyTypeError(err)
         return expr, ty
 
-    def visit_IterHasNext(self, node: IterHasNext) -> tuple[ast.expr, Type]:
-        node.value, ty = self.synthesize(node.value)
-        flags = InputFlags.Owned if not ty.copyable else InputFlags.NoFlags
-        exp_sig = FunctionType([FuncInput(ty, flags)], TupleType([bool_type(), ty]))
-        return self.synthesize_instance_func(
-            node.value, [], "__hasnext__", "an iterator", exp_sig, True
-        )
-
     def visit_IterNext(self, node: IterNext) -> tuple[ast.expr, Type]:
         node.value, ty = self.synthesize(node.value)
         flags = InputFlags.Owned if not ty.copyable else InputFlags.NoFlags
@@ -801,14 +791,6 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
         )
         return self.synthesize_instance_func(
             node.value, [], "__next__", "an iterator", exp_sig, True
-        )
-
-    def visit_IterEnd(self, node: IterEnd) -> tuple[ast.expr, Type]:
-        node.value, ty = self.synthesize(node.value)
-        flags = InputFlags.Owned if not ty.copyable else InputFlags.NoFlags
-        exp_sig = FunctionType([FuncInput(ty, flags)], NoneType())
-        return self.synthesize_instance_func(
-            node.value, [], "__end__", "an iterator", exp_sig, True
         )
 
     def visit_ListComp(self, node: ast.ListComp) -> tuple[ast.expr, Type]:

--- a/guppylang-internals/src/guppylang_internals/nodes.py
+++ b/guppylang-internals/src/guppylang_internals/nodes.py
@@ -166,33 +166,10 @@ class MakeIter(ast.expr):
         self.unwrap_size_hint = unwrap_size_hint
 
 
-class IterHasNext(ast.expr):
-    """Checks if an iterator has a next element using the `__hasnext__` magic method.
-
-    This node is inserted in `for` loops and list comprehensions.
-    """
-
-    value: ast.expr
-
-    _fields = ("value",)
-
-
 class IterNext(ast.expr):
     """Obtains the next element of an iterator using the `__next__` magic method.
 
     This node is inserted in `for` loops and list comprehensions.
-    """
-
-    value: ast.expr
-
-    _fields = ("value",)
-
-
-class IterEnd(ast.expr):
-    """Finalises an iterator using the `__end__` magic method.
-
-    This node is inserted in `for` loops and list comprehensions. It is needed to
-    consume linear iterators once they are finished.
     """
 
     value: ast.expr


### PR DESCRIPTION
These are not used and should have been deleted in #833

BREAKING CHANGE: Deleted `guppylang_internals.nodes.{IterHasNext, IterEnd}`