### PR TITLE
fix: Fix scoping issues with comprehensions in comptime expressions

### DIFF
--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -1309,11 +1309,7 @@ def eval_comptime_expr(node: ComptimeExpr, ctx: Context) -> Any:
         raise GuppyError(ComptimeExprNotCPythonError(node))
 
     try:
-        python_val = eval(  # noqa: S307
-            ast.unparse(node.value),
-            None,
-            DummyEvalDict(ctx, node.value),
-        )
+        python_val = eval(ast.unparse(node.value), DummyEvalDict(ctx, node.value))  # noqa: S307
     except DummyEvalDict.GuppyVarUsedError as e:
         raise GuppyError(ComptimeExprNotStaticError(e.node or node, e.var)) from None
     except Exception as e:

--- a/tests/integration/test_comptime_expr.py
+++ b/tests/integration/test_comptime_expr.py
@@ -131,6 +131,17 @@ def test_strings(validate):
     validate(foo)
 
 
+def test_comprehension(validate):
+    """See https://github.com/CQCL/guppylang/issues/1207"""
+    py_lst = [x for x in range(10)]
+
+    @guppy
+    def main() -> None:
+        comptime([py_lst[i] for i in range(len(py_lst))])
+
+    main.check()
+
+
 def test_func_type_arg(validate):
     n = 10
 


### PR DESCRIPTION
Fixes #1207
 
The problem was that we passed the environment as `locals` to the `eval` call. While evaluating the inside of the comprehension, these locals were no longer available. No idea why the behaviour is different in Python 3.13 though.

The fix is to pass the environemt as `globals` instead.