### PR TITLE
docs: use root README for pypi page

### DIFF
--- a/guppylang/pyproject.toml
+++ b/guppylang/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.21.3"
 requires-python = ">=3.10,<4"
 description = "Pythonic quantum-classical programming language"
 license = { file = "LICENCE" }
-readme = "README.md"
+readme = "../README.md"
 authors = [
     { name = "Mark Koch", email = "mark.koch@quantinuum.com" },
     { name = "TKET development team", email = "tket-support@quantinuum.com" },


### PR DESCRIPTION
I think the README in the repository root with the logo, links etc is a better thing to put on the pypi page than the one inside the `guppylang` subdirectory.

Relevant comment from @aborgna-q 
https://github.com/CQCL/guppylang/pull/1181#discussion_r2269374023

Relative link should work I think? 
https://packaging.python.org/en/latest/specifications/pyproject-toml/#readme