### PR TITLE
fix: update to include pip for guppylang in random_numbers.ipynb

### DIFF
--- a/examples/random_numbers.ipynb
+++ b/examples/random_numbers.ipynb
@@ -27,6 +27,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "pip install guppylang",
     "import random\n",
     "\n",
     "from guppylang import guppy\n",


### PR DESCRIPTION
Needed to add the pip install guppylang to the file