### PR TITLE
fix: Update adaptive-qpe.ipynb to add pip install guppylang at the start of the notebook

### DIFF
--- a/examples/adaptive-qpe.ipynb
+++ b/examples/adaptive-qpe.ipynb
@@ -22,6 +22,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "pip install guppylang",
     "import math\n",
     "from guppylang import guppy\n",
     "from guppylang.std.angles import angle\n",


### PR DESCRIPTION
fix: needed to add pip install guppylang at the start of the notebook