### PR TITLE
fix!: Correctly update borrowed values after calls and catch cases where it's impossible

### DIFF
--- a/guppylang-internals/src/guppylang_internals/tracing/function.py
+++ b/guppylang-internals/src/guppylang_internals/tracing/function.py
@@ -176,10 +176,12 @@ def trace_call(func: CallableDef, *args: Any) -> Any:
     if len(func.ty.inputs) != 0:
         for inp, arg, var in zip(func.ty.inputs, args, arg_vars, strict=True):
             if InputFlags.Inout in inp.flags:
+                # Note that `inp.ty` could refer to bound variables in the function
+                # signature. Instead, make sure to use `var.ty` which will always be a
+                # concrete type and type checking has ensured that they unify.
+                ty = var.ty
                 inout_wire = state.dfg[var]
-                update_packed_value(
-                    arg, GuppyObject(inp.ty, inout_wire), state.dfg.builder
-                )
+                update_packed_value(arg, GuppyObject(ty, inout_wire), state.dfg.builder)
 
     ret_obj = GuppyObject(ret_ty, ret_wire)
     return unpack_guppy_object(ret_obj, state.dfg.builder)

--- a/tests/error/tracing_errors/cannot_borrow1.err
+++ b/tests/error/tracing_errors/cannot_borrow1.err
@@ -1,0 +1,6 @@
+Traceback (most recent call last):
+  File "$FILE", line 12, in <module>
+    test.compile()
+  File "$FILE", line 9, in test
+    mem_swap(x, y)
+guppylang_internals.error.GuppyComptimeError: Cannot borrow Python object of type `int` at comptime

--- a/tests/error/tracing_errors/cannot_borrow1.py
+++ b/tests/error/tracing_errors/cannot_borrow1.py
@@ -1,0 +1,12 @@
+from guppylang.decorator import guppy
+from guppylang.std.mem import mem_swap
+
+
+@guppy.comptime
+def test() -> None:
+    x = 1
+    y = 2
+    mem_swap(x, y)
+
+
+test.compile()

--- a/tests/error/tracing_errors/cannot_borrow2.err
+++ b/tests/error/tracing_errors/cannot_borrow2.err
@@ -1,0 +1,6 @@
+Traceback (most recent call last):
+  File "$FILE", line 12, in <module>
+    test.compile()
+  File "$FILE", line 9, in test
+    mem_swap(x, y)
+guppylang_internals.error.GuppyComptimeError: Cannot borrow Python object of type `(int, int)` at comptime

--- a/tests/error/tracing_errors/cannot_borrow2.py
+++ b/tests/error/tracing_errors/cannot_borrow2.py
@@ -1,0 +1,12 @@
+from guppylang.decorator import guppy
+from guppylang.std.mem import mem_swap
+
+
+@guppy.comptime
+def test() -> None:
+    x = (1, 2)
+    y = (3, 4)
+    mem_swap(x, y)
+
+
+test.compile()

--- a/tests/integration/tracing/test_basic.py
+++ b/tests/integration/tracing/test_basic.py
@@ -2,6 +2,7 @@ from collections.abc import Callable
 
 from guppylang.decorator import guppy
 from guppylang.std.builtins import array, comptime
+from guppylang.std.qsystem.random import RNG
 
 from hugr import ops
 from hugr.std.int import IntVal
@@ -103,3 +104,18 @@ def test_expr_id(run_int_fn):
 
     foo = make(42)
     run_int_fn(foo, 42)
+
+
+def test_inout_type_infer():
+    """See https://github.com/CQCL/guppylang/issues/1249"""
+    n = 10
+
+    @guppy.comptime
+    def main() -> None:
+        id = array(i for i in range(n))
+        rng = RNG(0)
+        rng.shuffle(id)
+        rng.discard()
+
+    main.compile()
+

--- a/tests/integration/tracing/test_basic.py
+++ b/tests/integration/tracing/test_basic.py
@@ -2,10 +2,13 @@ from collections.abc import Callable
 
 from guppylang.decorator import guppy
 from guppylang.std.builtins import array, comptime
+from guppylang.std.mem import mem_swap
 from guppylang.std.qsystem.random import RNG
 
 from hugr import ops
 from hugr.std.int import IntVal
+
+from guppylang_internals.tracing.object import GuppyObject
 
 
 def test_flat(validate):
@@ -115,6 +118,21 @@ def test_inout_type_infer(validate):
         id = array(i for i in range(n))
         rng = RNG(0)
         rng.shuffle(id)
+        # After the shuffle, all list elements should be Guppy objects.
+        # See https://github.com/CQCL/guppylang/issues/1251
+        assert all(isinstance(x, GuppyObject) for x in id)
         rng.discard()
+
+    validate(main.compile())
+
+
+def mem_swap_array(validate):
+    @guppy.comptime
+    def main() -> None:
+        xs = [1]
+        ys = [2]
+        mem_swap(xs, ys)
+        assert isinstance(xs[0], GuppyObject)
+        assert isinstance(ys[0], GuppyObject)
 
     validate(main.compile())

--- a/tests/integration/tracing/test_basic.py
+++ b/tests/integration/tracing/test_basic.py
@@ -106,7 +106,7 @@ def test_expr_id(run_int_fn):
     run_int_fn(foo, 42)
 
 
-def test_inout_type_infer():
+def test_inout_type_infer(validate):
     """See https://github.com/CQCL/guppylang/issues/1249"""
     n = 10
 
@@ -117,5 +117,4 @@ def test_inout_type_infer():
         rng.shuffle(id)
         rng.discard()
 
-    main.compile()
-
+    validate(main.compile())


### PR DESCRIPTION
Fixes #1251

BREAKING CHANGE: `guppylang_internals.tracing.unpacking.update_packed_value` now returns a `bool` signalling whether the operation was successful.

Potential follow-up: Add a std library function to make a copy of Python values as Guppy objects that can then be borrowed and point to that function in the error message