### PR TITLE
fix: update logo display to work on pypi page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![logo](https://raw.githubusercontent.com/CQCL/guppylang/refs/heads/main/assets/guppy_logo.svg)
+![](https://raw.githubusercontent.com/CQCL/guppylang/refs/heads/main/assets/guppy_logo.svg)
 
 # Guppy
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![logo](assets/guppy_logo.svg)
+![logo](https://raw.githubusercontent.com/CQCL/guppylang/refs/heads/main/assets/guppy_logo.svg)
 
 # Guppy
 


### PR DESCRIPTION
in #1227 I made an update to use the root README for the guppylang package description. After the 0.21.4 release I see this has worked and the text is updated.


As you can see, the fish logo isn't showing properly. 

<img width="794" height="318" alt="Screenshot 2025-09-22 at 11 42 13" src="https://github.com/user-attachments/assets/31c708a9-e6a5-441b-9a68-40c12c025950" />


According to https://stackoverflow.com/questions/41983209/how-do-i-add-images-to-a-pypi-readme-that-works-on-github the fix is to link to the raw github user content rather than just the path to the directory. Hopefully this works.
