### PR TITLE
ci: Use `uv` ecosystem for dependabot python updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,12 @@
 
 version: 2
 updates:
-  # NOTE: This won't update the `uv.lock` file yet, so that should be updated
-  # manually when needed.
-  # https://github.com/dependabot/dependabot-core/issues/10478
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directories: # Location of package manifests
       - "/"
+      - "/guppylang"
+      - "/guppylang-internals"
+      - "/miette-py"
     schedule:
       interval: "weekly"
     commit-message:


### PR DESCRIPTION
https://github.blog/changelog/2025-03-13-dependabot-version-updates-now-support-uv-in-general-availability/