### PR TITLE
feat: `compile_entrypoint` and `compile_function` methods

### DIFF
--- a/guppylang/src/guppylang/defs.py
+++ b/guppylang/src/guppylang/defs.py
@@ -4,12 +4,12 @@ These are the objects returned by the `@guppy` decorator. They should not be con
 with the compiler-internal definition objects in the `definitions` module.
 """
 
+import ast
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, ClassVar, Generic, ParamSpec, TypeVar, cast
 
 import guppylang_internals
-from guppylang_internals.definition.function import CheckedFunctionDef
 from guppylang_internals.definition.value import CompiledCallableDef
 from guppylang_internals.diagnostic import Error
 from guppylang_internals.engine import ENGINE, CoreMetadataKeys
@@ -45,7 +45,7 @@ def _update_generator_metadata(hugr: Hugr[Any]) -> None:
 class EntrypointArgsError(Error):
     title: ClassVar[str] = "Entrypoint function has arguments"
     span_label: ClassVar[str] = (
-        "Entrypoint function must have no input parameters, found {input_names}."
+        "Entrypoint function must have no input parameters, found ({input_names})."
     )
     args: Sequence[str]
 
@@ -129,9 +129,9 @@ class GuppyFunctionDefinition(GuppyDefinition, Generic[P, Out]):
             and len(compiled_def.ty.inputs) > 0
         ):
             # Check if the entrypoint being has arguments
-            checked = cast(CheckedFunctionDef, ENGINE.checked[self.id])
-            start = to_span(checked.defined_at.args.args[0])
-            end = to_span(checked.defined_at.args.args[-1])
+            defined_at = cast(ast.FunctionDef, compiled_def.defined_at)
+            start = to_span(defined_at.args.args[0])
+            end = to_span(defined_at.args.args[-1])
             span = Span(start=start.start, end=end.end)
             raise GuppyError(
                 EntrypointArgsError(

--- a/guppylang/src/guppylang/defs.py
+++ b/guppylang/src/guppylang/defs.py
@@ -44,7 +44,9 @@ def _update_generator_metadata(hugr: Hugr[Any]) -> None:
 @dataclass(frozen=True)
 class EntrypointArgsError(Error):
     title: ClassVar[str] = "Entrypoint function has arguments"
-    span_label: ClassVar[str] = "Entrypoint function has arguments: {input_names}."
+    span_label: ClassVar[str] = (
+        "Entrypoint function must have no input parameters, found {input_names}."
+    )
     args: Sequence[str]
 
     @property

--- a/guppylang/src/guppylang/defs.py
+++ b/guppylang/src/guppylang/defs.py
@@ -127,6 +127,15 @@ class GuppyFunctionDefinition(GuppyDefinition, Generic[P, Out]):
         return self.compile_entrypoint()
 
     def compile_entrypoint(self) -> Package:
+        """
+        Compiles an execution entrypoint function definition to a HUGR package
+
+        Returns:
+            Package: The compiled package object.
+        Raises:
+            GuppyError: If the entrypoint has arguments.
+        """
+
         pack = self.compile_function()
         # entrypoint cannot be polymorphic
         monomorphized_id = (self.id, ())

--- a/tests/error/array_errors/non_copyable_copy.py
+++ b/tests/error/array_errors/non_copyable_copy.py
@@ -8,4 +8,4 @@ def main(xs: array[qubit, 2] @ owned) -> array[int, 2]:
    ys = xs.copy()
    return ys
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/array_errors/non_copyable_copy.py
+++ b/tests/error/array_errors/non_copyable_copy.py
@@ -8,4 +8,4 @@ def main(xs: array[qubit, 2] @ owned) -> array[int, 2]:
    ys = xs.copy()
    return ys
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/array_errors/non_static_comprehension.py
+++ b/tests/error/array_errors/non_static_comprehension.py
@@ -7,4 +7,4 @@ def main(n: int) -> None:
     array(i for i in range(n))
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/array_errors/non_static_comprehension.py
+++ b/tests/error/array_errors/non_static_comprehension.py
@@ -7,4 +7,4 @@ def main(n: int) -> None:
     array(i for i in range(n))
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/array_errors/subscript_after_use.py
+++ b/tests/error/array_errors/subscript_after_use.py
@@ -12,4 +12,4 @@ def main(qs: array[qubit, 42] @owned) -> array[qubit, 42]:
     return foo(qs, qs[0])
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/array_errors/subscript_after_use.py
+++ b/tests/error/array_errors/subscript_after_use.py
@@ -12,4 +12,4 @@ def main(qs: array[qubit, 42] @owned) -> array[qubit, 42]:
     return foo(qs, qs[0])
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/array_errors/subscript_non_inout.py
+++ b/tests/error/array_errors/subscript_non_inout.py
@@ -9,4 +9,4 @@ def main(qs: array[qubit, 42]) -> tuple[qubit, array[qubit, 42]]:
     return q, qs
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/array_errors/subscript_non_inout.py
+++ b/tests/error/array_errors/subscript_non_inout.py
@@ -9,4 +9,4 @@ def main(qs: array[qubit, 42]) -> tuple[qubit, array[qubit, 42]]:
     return q, qs
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/array_errors/use_after_implicit_copy.py
+++ b/tests/error/array_errors/use_after_implicit_copy.py
@@ -7,4 +7,4 @@ def main(xs: array[int, 2] @ owned) -> array[int, 2]:
    ys = xs
    return xs
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/array_errors/use_after_implicit_copy.py
+++ b/tests/error/array_errors/use_after_implicit_copy.py
@@ -7,4 +7,4 @@ def main(xs: array[int, 2] @ owned) -> array[int, 2]:
    ys = xs
    return xs
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/array_errors/use_after_subscript.py
+++ b/tests/error/array_errors/use_after_subscript.py
@@ -12,4 +12,4 @@ def main(qs: array[qubit, 42] @owned) -> array[qubit, 42]:
     return foo(qs[0], qs)
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/array_errors/use_after_subscript.py
+++ b/tests/error/array_errors/use_after_subscript.py
@@ -12,4 +12,4 @@ def main(qs: array[qubit, 42] @owned) -> array[qubit, 42]:
     return foo(qs[0], qs)
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/comptime_arg_errors/callable.py
+++ b/tests/error/comptime_arg_errors/callable.py
@@ -9,4 +9,4 @@ def main(f: Callable[[nat @comptime], None]) -> None:
     pass
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/comptime_arg_errors/callable.py
+++ b/tests/error/comptime_arg_errors/callable.py
@@ -9,4 +9,4 @@ def main(f: Callable[[nat @comptime], None]) -> None:
     pass
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/comptime_arg_errors/const_mismatch2.py
+++ b/tests/error/comptime_arg_errors/const_mismatch2.py
@@ -12,4 +12,4 @@ def main(n: nat @ comptime) -> None:
     foo[n](42)
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/comptime_arg_errors/const_mismatch2.py
+++ b/tests/error/comptime_arg_errors/const_mismatch2.py
@@ -12,4 +12,4 @@ def main(n: nat @ comptime) -> None:
     foo[n](42)
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/comptime_arg_errors/const_mismatch3.py
+++ b/tests/error/comptime_arg_errors/const_mismatch3.py
@@ -12,4 +12,4 @@ def main(n: nat @ comptime, m: nat @ comptime) -> None:
     foo[n](m)
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/comptime_arg_errors/const_mismatch3.py
+++ b/tests/error/comptime_arg_errors/const_mismatch3.py
@@ -12,4 +12,4 @@ def main(n: nat @ comptime, m: nat @ comptime) -> None:
     foo[n](m)
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/comptime_arg_errors/const_mismatch4.py
+++ b/tests/error/comptime_arg_errors/const_mismatch4.py
@@ -12,4 +12,4 @@ def main(n: nat @ comptime) -> None:
     foo[42](n)
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/comptime_arg_errors/const_mismatch4.py
+++ b/tests/error/comptime_arg_errors/const_mismatch4.py
@@ -12,4 +12,4 @@ def main(n: nat @ comptime) -> None:
     foo[42](n)
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/comptime_arg_errors/dependent_mismatch2.py
+++ b/tests/error/comptime_arg_errors/dependent_mismatch2.py
@@ -11,4 +11,4 @@ def main(n: nat @comptime, m: nat @comptime) -> None:
     foo(n, array(i for i in range(m)))
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/comptime_arg_errors/dependent_mismatch2.py
+++ b/tests/error/comptime_arg_errors/dependent_mismatch2.py
@@ -11,4 +11,4 @@ def main(n: nat @comptime, m: nat @comptime) -> None:
     foo(n, array(i for i in range(m)))
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/comptime_arg_errors/left_to_right.py
+++ b/tests/error/comptime_arg_errors/left_to_right.py
@@ -7,4 +7,4 @@ def main(xs: "array[int, num]", num: nat @comptime) -> None:
     pass
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/comptime_arg_errors/left_to_right.py
+++ b/tests/error/comptime_arg_errors/left_to_right.py
@@ -7,4 +7,4 @@ def main(xs: "array[int, num]", num: nat @comptime) -> None:
     pass
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/comptime_arg_errors/non_copyable.py
+++ b/tests/error/comptime_arg_errors/non_copyable.py
@@ -7,4 +7,4 @@ def main(q: qubit @comptime) -> None:
     pass
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/comptime_arg_errors/non_copyable.py
+++ b/tests/error/comptime_arg_errors/non_copyable.py
@@ -7,4 +7,4 @@ def main(q: qubit @comptime) -> None:
     pass
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/comptime_arg_errors/non_droppable.py
+++ b/tests/error/comptime_arg_errors/non_droppable.py
@@ -10,4 +10,4 @@ def main(q: T @comptime) -> None:
     pass
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/comptime_arg_errors/non_droppable.py
+++ b/tests/error/comptime_arg_errors/non_droppable.py
@@ -10,4 +10,4 @@ def main(q: T @comptime) -> None:
     pass
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/comptime_arg_errors/shadow.py
+++ b/tests/error/comptime_arg_errors/shadow.py
@@ -9,4 +9,4 @@ def main(xs: array[int, n], n: nat @comptime) -> None:
     pass
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/comptime_arg_errors/shadow.py
+++ b/tests/error/comptime_arg_errors/shadow.py
@@ -9,4 +9,4 @@ def main(xs: array[int, n], n: nat @comptime) -> None:
     pass
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/comptime_arg_errors/unknown_arg.py
+++ b/tests/error/comptime_arg_errors/unknown_arg.py
@@ -12,4 +12,4 @@ def main(b: bool, m: nat) -> None:
         foo(m)
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/comptime_arg_errors/unknown_arg.py
+++ b/tests/error/comptime_arg_errors/unknown_arg.py
@@ -12,4 +12,4 @@ def main(b: bool, m: nat) -> None:
         foo(m)
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/comptime_arg_errors/unknown_cf_expr.py
+++ b/tests/error/comptime_arg_errors/unknown_cf_expr.py
@@ -12,4 +12,4 @@ def main(b: bool) -> nat:
     return foo(nat(1) if b else nat(2))
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/comptime_arg_errors/unknown_cf_expr.py
+++ b/tests/error/comptime_arg_errors/unknown_cf_expr.py
@@ -12,4 +12,4 @@ def main(b: bool) -> nat:
     return foo(nat(1) if b else nat(2))
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/errors_on_usage/shadow_global1.py
+++ b/tests/error/errors_on_usage/shadow_global1.py
@@ -11,4 +11,4 @@ def main(b: bool) -> float:
     return x
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/errors_on_usage/shadow_global1.py
+++ b/tests/error/errors_on_usage/shadow_global1.py
@@ -11,4 +11,4 @@ def main(b: bool) -> float:
     return x
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/errors_on_usage/shadow_global2.py
+++ b/tests/error/errors_on_usage/shadow_global2.py
@@ -18,4 +18,4 @@ def main(b: bool) -> None:
     bar()
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/errors_on_usage/shadow_global2.py
+++ b/tests/error/errors_on_usage/shadow_global2.py
@@ -18,4 +18,4 @@ def main(b: bool) -> None:
     bar()
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/errors_on_usage/shadow_global3.py
+++ b/tests/error/errors_on_usage/shadow_global3.py
@@ -20,4 +20,4 @@ def main(b: bool) -> None:
     bar()
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/errors_on_usage/shadow_global3.py
+++ b/tests/error/errors_on_usage/shadow_global3.py
@@ -20,4 +20,4 @@ def main(b: bool) -> None:
     bar()
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/errors_on_usage/shadow_global4.py
+++ b/tests/error/errors_on_usage/shadow_global4.py
@@ -13,4 +13,4 @@ def main(b: bool) -> None:
         return x
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/errors_on_usage/shadow_global4.py
+++ b/tests/error/errors_on_usage/shadow_global4.py
@@ -13,4 +13,4 @@ def main(b: bool) -> None:
         return x
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/errors_on_usage/shadow_param.py
+++ b/tests/error/errors_on_usage/shadow_param.py
@@ -11,4 +11,4 @@ def main(b: bool) -> nat:
     return n
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/errors_on_usage/shadow_param.py
+++ b/tests/error/errors_on_usage/shadow_param.py
@@ -11,4 +11,4 @@ def main(b: bool) -> nat:
     return n
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/experimental_errors/list_type.py
+++ b/tests/error/experimental_errors/list_type.py
@@ -6,4 +6,4 @@ def main(x: list[int]) -> list[int]:
     return x
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/experimental_errors/list_type.py
+++ b/tests/error/experimental_errors/list_type.py
@@ -6,4 +6,4 @@ def main(x: list[int]) -> list[int]:
     return x
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/misc_errors/entrypoint_with_args.err
+++ b/tests/error/misc_errors/entrypoint_with_args.err
@@ -1,0 +1,8 @@
+Error: Entrypoint function has arguments (at $FILE:4:8)
+  | 
+2 | 
+3 | @guppy
+4 | def foo(x: bool) -> bool:
+  |         ^^^^^^^ Entrypoint function has arguments: `x`.
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/misc_errors/entrypoint_with_args.err
+++ b/tests/error/misc_errors/entrypoint_with_args.err
@@ -3,6 +3,7 @@ Error: Entrypoint function has arguments (at $FILE:4:8)
 2 | 
 3 | @guppy
 4 | def foo(x: bool) -> bool:
-  |         ^^^^^^^ Entrypoint function has arguments: `x`.
+  |         ^^^^^^^ Entrypoint function must have no input parameters, found
+  |                 (`x`).
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/misc_errors/entrypoint_with_args.err
+++ b/tests/error/misc_errors/entrypoint_with_args.err
@@ -6,4 +6,7 @@ Error: Entrypoint function has arguments (at $FILE:4:8)
   |         ^^^^^^^ Entrypoint function must have no input parameters, found
   |                 (`x`).
 
+Note: If the function is not an execution entrypoint, consider using
+`foo.compile_function()`
+
 Guppy compilation failed due to 1 previous error

--- a/tests/error/misc_errors/entrypoint_with_args.py
+++ b/tests/error/misc_errors/entrypoint_with_args.py
@@ -1,0 +1,8 @@
+from guppylang.decorator import guppy
+
+@guppy
+def foo(x: bool) -> bool:
+    return x
+
+
+foo.compile()

--- a/tests/error/poly_errors/arg_mismatch1.py
+++ b/tests/error/poly_errors/arg_mismatch1.py
@@ -13,4 +13,4 @@ def main(x: bool, y: tuple[bool]) -> None:
     foo(x, y)
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/poly_errors/arg_mismatch1.py
+++ b/tests/error/poly_errors/arg_mismatch1.py
@@ -13,4 +13,4 @@ def main(x: bool, y: tuple[bool]) -> None:
     foo(x, y)
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/poly_errors/arg_mismatch3.py
+++ b/tests/error/poly_errors/arg_mismatch3.py
@@ -14,4 +14,4 @@ def main(x: array[int, 42], y: array[int, 43]) -> None:
     foo(x, y)
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/poly_errors/arg_mismatch3.py
+++ b/tests/error/poly_errors/arg_mismatch3.py
@@ -14,4 +14,4 @@ def main(x: array[int, 42], y: array[int, 43]) -> None:
     foo(x, y)
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/poly_errors/arg_mismatch4.py
+++ b/tests/error/poly_errors/arg_mismatch4.py
@@ -7,4 +7,4 @@ def main(x: array[int, bool]) -> None:
     pass
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/poly_errors/arg_mismatch4.py
+++ b/tests/error/poly_errors/arg_mismatch4.py
@@ -7,4 +7,4 @@ def main(x: array[int, bool]) -> None:
     pass
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/poly_errors/arg_mismatch5.py
+++ b/tests/error/poly_errors/arg_mismatch5.py
@@ -6,4 +6,4 @@ def main(x: list[42]) -> None:
     pass
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/poly_errors/arg_mismatch5.py
+++ b/tests/error/poly_errors/arg_mismatch5.py
@@ -6,4 +6,4 @@ def main(x: list[42]) -> None:
     pass
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/poly_errors/arg_mismatch6.py
+++ b/tests/error/poly_errors/arg_mismatch6.py
@@ -13,4 +13,4 @@ def main(x: float) -> None:
     foo[int](x)
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/poly_errors/arg_mismatch6.py
+++ b/tests/error/poly_errors/arg_mismatch6.py
@@ -13,4 +13,4 @@ def main(x: float) -> None:
     foo[int](x)
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/poly_errors/arg_mismatch7.py
+++ b/tests/error/poly_errors/arg_mismatch7.py
@@ -14,4 +14,4 @@ def main(xs: array[int, 42]) -> None:
     foo[43](xs)
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/poly_errors/arg_mismatch7.py
+++ b/tests/error/poly_errors/arg_mismatch7.py
@@ -14,4 +14,4 @@ def main(xs: array[int, 42]) -> None:
     foo[43](xs)
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/poly_errors/arg_mismatch8.py
+++ b/tests/error/poly_errors/arg_mismatch8.py
@@ -14,4 +14,4 @@ def main(x: float) -> None:
     f(x)
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/poly_errors/arg_mismatch8.py
+++ b/tests/error/poly_errors/arg_mismatch8.py
@@ -14,4 +14,4 @@ def main(x: float) -> None:
     f(x)
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/poly_errors/arg_mismatch9.py
+++ b/tests/error/poly_errors/arg_mismatch9.py
@@ -14,4 +14,4 @@ def main(x: int, y: float) -> None:
     foo[float, int](x, y)
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/poly_errors/arg_mismatch9.py
+++ b/tests/error/poly_errors/arg_mismatch9.py
@@ -14,4 +14,4 @@ def main(x: int, y: float) -> None:
     foo[float, int](x, y)
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/poly_errors/const_var_free.py
+++ b/tests/error/poly_errors/const_var_free.py
@@ -19,4 +19,4 @@ def main(_: Struct[T, n, X]) -> None:
     pass
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/poly_errors/const_var_free.py
+++ b/tests/error/poly_errors/const_var_free.py
@@ -19,4 +19,4 @@ def main(_: Struct[T, n, X]) -> None:
     pass
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/poly_errors/const_var_invalid_type.py
+++ b/tests/error/poly_errors/const_var_invalid_type.py
@@ -15,4 +15,4 @@ def main(_: Struct[X]) -> None:
     pass
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/poly_errors/const_var_invalid_type.py
+++ b/tests/error/poly_errors/const_var_invalid_type.py
@@ -15,4 +15,4 @@ def main(_: Struct[X]) -> None:
     pass
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/poly_errors/const_var_noncopyable.py
+++ b/tests/error/poly_errors/const_var_noncopyable.py
@@ -16,4 +16,4 @@ def main(_: Struct[Q]) -> None:
     pass
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/poly_errors/const_var_noncopyable.py
+++ b/tests/error/poly_errors/const_var_noncopyable.py
@@ -16,4 +16,4 @@ def main(_: Struct[Q]) -> None:
     pass
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/poly_errors/const_var_nondroppable.py
+++ b/tests/error/poly_errors/const_var_nondroppable.py
@@ -23,4 +23,4 @@ def main(_: Struct[X]) -> None:
     pass
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/poly_errors/const_var_nondroppable.py
+++ b/tests/error/poly_errors/const_var_nondroppable.py
@@ -23,4 +23,4 @@ def main(_: Struct[X]) -> None:
     pass
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/poly_errors/inst_return_mismatch.py
+++ b/tests/error/poly_errors/inst_return_mismatch.py
@@ -13,4 +13,4 @@ def main(x: bool) -> None:
     y: None = foo(x)
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/error/poly_errors/inst_return_mismatch.py
+++ b/tests/error/poly_errors/inst_return_mismatch.py
@@ -13,4 +13,4 @@ def main(x: bool) -> None:
     y: None = foo(x)
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/poly_errors/inst_return_mismatch_nested.py
+++ b/tests/error/poly_errors/inst_return_mismatch_nested.py
@@ -13,4 +13,4 @@ def main(x: bool) -> None:
     y: None = foo(foo(foo(x)))
 
 
-main.compile(entrypoint=False)
+main.compile_function()

--- a/tests/error/poly_errors/inst_return_mismatch_nested.py
+++ b/tests/error/poly_errors/inst_return_mismatch_nested.py
@@ -13,4 +13,4 @@ def main(x: bool) -> None:
     y: None = foo(foo(foo(x)))
 
 
-main.compile()
+main.compile(entrypoint=False)

--- a/tests/integration/notebooks/demo.ipynb
+++ b/tests/integration/notebooks/demo.ipynb
@@ -161,7 +161,7 @@
     "    # Try to add a tuple to an int\n",
     "    return x + (x, x)\n",
     "\n",
-    "bad.compile()  # Raises an error"
+    "bad.check()  # Raises an error"
    ]
   },
   {
@@ -384,7 +384,7 @@
     "        return False\n",
     "    return is_even(x-1)\n",
     "\n",
-    "program = is_even.compile()"
+    "is_even.check()"
    ]
   },
   {
@@ -449,7 +449,7 @@
     "        return x + y\n",
     "    return nested(42)\n",
     "\n",
-    "program = outer.compile()"
+    "outer.check()"
    ]
   },
   {
@@ -528,13 +528,13 @@
     "    inc5 = increment_by(5)\n",
     "    return inc5(x)\n",
     "\n",
-    "program = main.compile()"
+    "main.check()"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "venv",
    "language": "python",
    "name": "python3"
   },
@@ -548,7 +548,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.18"
+   "version": "3.13.6"
   }
  },
  "nbformat": 4,

--- a/tests/integration/std/test_futures.py
+++ b/tests/integration/std/test_futures.py
@@ -12,4 +12,4 @@ def test_read(validate):
         z.discard()
         return 0
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())

--- a/tests/integration/std/test_futures.py
+++ b/tests/integration/std/test_futures.py
@@ -12,4 +12,4 @@ def test_read(validate):
         z.discard()
         return 0
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))

--- a/tests/integration/std/test_mem.py
+++ b/tests/integration/std/test_mem.py
@@ -12,4 +12,4 @@ def test_with_owned(validate):
 
         return with_owned(q, helper)
 
-    validate(measure_and_reset.compile())
+    validate(measure_and_reset.compile(entrypoint=False))

--- a/tests/integration/std/test_mem.py
+++ b/tests/integration/std/test_mem.py
@@ -12,4 +12,4 @@ def test_with_owned(validate):
 
         return with_owned(q, helper)
 
-    validate(measure_and_reset.compile(entrypoint=False))
+    validate(measure_and_reset.compile_function())

--- a/tests/integration/test_arithmetic.py
+++ b/tests/integration/test_arithmetic.py
@@ -122,7 +122,7 @@ def test_angle_arith(validate):
         a3 += 2 * a1
         return a3 / 3 == -a2
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_angle_arith_float(validate):
@@ -133,7 +133,7 @@ def test_angle_arith_float(validate):
         a3 += 2.2 * a1
         return a3 / 3.9 == -a2
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_implicit_coercion(validate):
@@ -153,7 +153,7 @@ def test_angle_float_coercion(validate):
         a = angle(f)
         return a, float(a)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_angle_pi(validate):
@@ -164,7 +164,7 @@ def test_angle_pi(validate):
         a += 3 * pi / 2
         return a
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_shortcircuit_assign1(validate):

--- a/tests/integration/test_arithmetic.py
+++ b/tests/integration/test_arithmetic.py
@@ -122,7 +122,7 @@ def test_angle_arith(validate):
         a3 += 2 * a1
         return a3 / 3 == -a2
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_angle_arith_float(validate):
@@ -133,7 +133,7 @@ def test_angle_arith_float(validate):
         a3 += 2.2 * a1
         return a3 / 3.9 == -a2
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_implicit_coercion(validate):
@@ -153,7 +153,7 @@ def test_angle_float_coercion(validate):
         a = angle(f)
         return a, float(a)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_angle_pi(validate):
@@ -164,7 +164,7 @@ def test_angle_pi(validate):
         a += 3 * pi / 2
         return a
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_shortcircuit_assign1(validate):

--- a/tests/integration/test_array.py
+++ b/tests/integration/test_array.py
@@ -15,7 +15,7 @@ def test_len_execute(validate, run_int_fn):
     def main(xs: array[float, 42]) -> int:
         return len(xs)
 
-    compiled = main.compile()
+    compiled = main.compile(entrypoint=False)
     validate(compiled)
     if run_int_fn is not None:
         run_int_fn(compiled, expected=42)
@@ -30,7 +30,7 @@ def test_len_linear(validate):
     def main(qs: array[qubit, 42]) -> int:
         return len(qs)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_len_generic(validate):
@@ -43,7 +43,7 @@ def test_len_generic(validate):
                 return True
         return False
 
-    package = main.compile()
+    package = main.compile(entrypoint=False)
     validate(package)
 
     hg = package.modules[0]
@@ -100,7 +100,7 @@ def test_new_array_check_nested_length(validate):
     def main() -> None:
         foo(array(array(1, 2, 3)))
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_return_linear_array(validate):
@@ -109,7 +109,7 @@ def test_return_linear_array(validate):
         a = array(qubit(), qubit())
         return a
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 def test_subscript_drop_rest(validate):
@@ -120,7 +120,7 @@ def test_subscript_drop_rest(validate):
     def main() -> int:
         return foo()[0]
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_linear_subscript(validate):
@@ -132,7 +132,7 @@ def test_linear_subscript(validate):
         foo(qs[i])
         return qs
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_inout_subscript(validate):
@@ -143,7 +143,7 @@ def test_inout_subscript(validate):
     def main(qs: array[qubit, 42], i: int) -> None:
         foo(qs[i])
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_multi_subscripts(validate):
@@ -156,7 +156,7 @@ def test_multi_subscripts(validate):
         foo(qs[0], qs[0])  # Will panic at runtime
         return qs
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_struct_array(validate):
@@ -176,7 +176,7 @@ def test_struct_array(validate):
         foo(ss[0].q1, ss[0].q2)
         return ss
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_nested_subscripts(validate):
@@ -195,7 +195,7 @@ def test_nested_subscripts(validate):
         bar(qs[0][0], qs[0][1], qs[1][0], qs[1][1])
         return qs
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_struct_nested_subscript(validate):
@@ -223,7 +223,7 @@ def test_struct_nested_subscript(validate):
         foo(a.xs[i].ys[j][k].c)
         return a
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_generic_function(validate):
@@ -240,7 +240,7 @@ def test_generic_function(validate):
         ys = array(qubit(), qubit())
         return foo(xs), foo(ys)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_linear_for_loop(validate):
@@ -250,7 +250,7 @@ def test_linear_for_loop(validate):
         for q in qs:
             discard(q)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_exec_array(run_int_fn):
@@ -289,7 +289,7 @@ def test_mem_swap(validate):
         foo(a[0], a[1])
         return a
 
-    package = main.compile()
+    package = main.compile(entrypoint=False)
     validate(package)
 
 
@@ -618,5 +618,5 @@ def test_assign_dataflow(validate):
         for i in range(2):
             ys[xs[i]] = 0
 
-    test1.compile()
-    test2.compile()
+    test1.compile(entrypoint=False)
+    test2.compile(entrypoint=False)

--- a/tests/integration/test_array.py
+++ b/tests/integration/test_array.py
@@ -15,7 +15,7 @@ def test_len_execute(validate, run_int_fn):
     def main(xs: array[float, 42]) -> int:
         return len(xs)
 
-    compiled = main.compile(entrypoint=False)
+    compiled = main.compile_function()
     validate(compiled)
     if run_int_fn is not None:
         run_int_fn(compiled, expected=42)
@@ -30,7 +30,7 @@ def test_len_linear(validate):
     def main(qs: array[qubit, 42]) -> int:
         return len(qs)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_len_generic(validate):
@@ -43,7 +43,7 @@ def test_len_generic(validate):
                 return True
         return False
 
-    package = main.compile(entrypoint=False)
+    package = main.compile_function()
     validate(package)
 
     hg = package.modules[0]
@@ -100,7 +100,7 @@ def test_new_array_check_nested_length(validate):
     def main() -> None:
         foo(array(array(1, 2, 3)))
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_return_linear_array(validate):
@@ -109,7 +109,7 @@ def test_return_linear_array(validate):
         a = array(qubit(), qubit())
         return a
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 def test_subscript_drop_rest(validate):
@@ -120,7 +120,7 @@ def test_subscript_drop_rest(validate):
     def main() -> int:
         return foo()[0]
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_linear_subscript(validate):
@@ -132,7 +132,7 @@ def test_linear_subscript(validate):
         foo(qs[i])
         return qs
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_inout_subscript(validate):
@@ -143,7 +143,7 @@ def test_inout_subscript(validate):
     def main(qs: array[qubit, 42], i: int) -> None:
         foo(qs[i])
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_multi_subscripts(validate):
@@ -156,7 +156,7 @@ def test_multi_subscripts(validate):
         foo(qs[0], qs[0])  # Will panic at runtime
         return qs
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_struct_array(validate):
@@ -176,7 +176,7 @@ def test_struct_array(validate):
         foo(ss[0].q1, ss[0].q2)
         return ss
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_nested_subscripts(validate):
@@ -195,7 +195,7 @@ def test_nested_subscripts(validate):
         bar(qs[0][0], qs[0][1], qs[1][0], qs[1][1])
         return qs
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_struct_nested_subscript(validate):
@@ -223,7 +223,7 @@ def test_struct_nested_subscript(validate):
         foo(a.xs[i].ys[j][k].c)
         return a
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_generic_function(validate):
@@ -240,7 +240,7 @@ def test_generic_function(validate):
         ys = array(qubit(), qubit())
         return foo(xs), foo(ys)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_linear_for_loop(validate):
@@ -250,7 +250,7 @@ def test_linear_for_loop(validate):
         for q in qs:
             discard(q)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_exec_array(run_int_fn):
@@ -289,7 +289,7 @@ def test_mem_swap(validate):
         foo(a[0], a[1])
         return a
 
-    package = main.compile(entrypoint=False)
+    package = main.compile_function()
     validate(package)
 
 
@@ -618,5 +618,5 @@ def test_assign_dataflow(validate):
         for i in range(2):
             ys[xs[i]] = 0
 
-    test1.compile(entrypoint=False)
-    test2.compile(entrypoint=False)
+    test1.compile_function()
+    test2.compile_function()

--- a/tests/integration/test_array_comprehension.py
+++ b/tests/integration/test_array_comprehension.py
@@ -25,7 +25,7 @@ def test_basic_linear(validate):
     def test() -> array[qubit, 42]:
         return array(qubit() for _ in range(42))
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_zero_length(run_int_fn):
@@ -66,7 +66,7 @@ def test_capture_struct(validate):
     def test(s: MyStruct) -> array[int, 42]:
         return array(i + s.x for i in range(42))
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_scope(validate):
@@ -102,7 +102,7 @@ def test_generic_size(validate):
     def test(xs: array[int, n] @ owned) -> array[int, n]:
         return array(x + 1 for x in xs)
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_generic_elem(validate):
@@ -112,7 +112,7 @@ def test_generic_elem(validate):
     def foo(x: T) -> array[T, 10]:
         return array(x for _ in range(10))
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 def test_borrow(validate):
@@ -125,7 +125,7 @@ def test_borrow(validate):
     def test(q: qubit) -> array[int, n]:
         return array(foo(q) for _ in range(n))
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_borrow_twice(validate):
@@ -138,7 +138,7 @@ def test_borrow_twice(validate):
     def test(q: qubit) -> array[int, n]:
         return array(foo(q) + foo(q) for _ in range(n))
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_borrow_struct(validate):
@@ -156,7 +156,7 @@ def test_borrow_struct(validate):
     def test(s: MyStruct) -> array[int, n]:
         return array(foo(s) for _ in range(n))
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_borrow_and_consume(validate):
@@ -172,4 +172,4 @@ def test_borrow_and_consume(validate):
     def test(qs: array[qubit, n] @ owned) -> array[int, n]:
         return array(foo(q) + bar(q) for q in qs)
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))

--- a/tests/integration/test_array_comprehension.py
+++ b/tests/integration/test_array_comprehension.py
@@ -25,7 +25,7 @@ def test_basic_linear(validate):
     def test() -> array[qubit, 42]:
         return array(qubit() for _ in range(42))
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_zero_length(run_int_fn):
@@ -66,7 +66,7 @@ def test_capture_struct(validate):
     def test(s: MyStruct) -> array[int, 42]:
         return array(i + s.x for i in range(42))
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_scope(validate):
@@ -102,7 +102,7 @@ def test_generic_size(validate):
     def test(xs: array[int, n] @ owned) -> array[int, n]:
         return array(x + 1 for x in xs)
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_generic_elem(validate):
@@ -112,7 +112,7 @@ def test_generic_elem(validate):
     def foo(x: T) -> array[T, 10]:
         return array(x for _ in range(10))
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 def test_borrow(validate):
@@ -125,7 +125,7 @@ def test_borrow(validate):
     def test(q: qubit) -> array[int, n]:
         return array(foo(q) for _ in range(n))
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_borrow_twice(validate):
@@ -138,7 +138,7 @@ def test_borrow_twice(validate):
     def test(q: qubit) -> array[int, n]:
         return array(foo(q) + foo(q) for _ in range(n))
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_borrow_struct(validate):
@@ -156,7 +156,7 @@ def test_borrow_struct(validate):
     def test(s: MyStruct) -> array[int, n]:
         return array(foo(s) for _ in range(n))
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_borrow_and_consume(validate):
@@ -172,4 +172,4 @@ def test_borrow_and_consume(validate):
     def test(qs: array[qubit, n] @ owned) -> array[int, n]:
         return array(foo(q) + bar(q) for q in qs)
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -67,7 +67,7 @@ def test_func_decl_name():
     @guppy.declare
     def func_name() -> None: ...
 
-    hugr = func_name.compile(entrypoint=False).modules[0]
+    hugr = func_name.compile_function().modules[0]
     [def_op] = [
         data.op for n, data in hugr.nodes() if isinstance(data.op, ops.FuncDecl)
     ]
@@ -81,7 +81,7 @@ def test_compile_again():
     def identity(x: int) -> int:
         return x
 
-    hugr = identity.compile(entrypoint=False).module
+    hugr = identity.compile_function().module
 
     # Compiling again should return the same Hugr
-    assert hugr is identity.compile(entrypoint=False)
+    assert hugr is identity.compile_function()

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -67,7 +67,7 @@ def test_func_decl_name():
     @guppy.declare
     def func_name() -> None: ...
 
-    hugr = func_name.compile().modules[0]
+    hugr = func_name.compile(entrypoint=False).modules[0]
     [def_op] = [
         data.op for n, data in hugr.nodes() if isinstance(data.op, ops.FuncDecl)
     ]
@@ -81,7 +81,7 @@ def test_compile_again():
     def identity(x: int) -> int:
         return x
 
-    hugr = identity.compile().module
+    hugr = identity.compile(entrypoint=False).module
 
     # Compiling again should return the same Hugr
-    assert hugr is identity.compile()
+    assert hugr is identity.compile(entrypoint=False)

--- a/tests/integration/test_call.py
+++ b/tests/integration/test_call.py
@@ -10,7 +10,7 @@ def test_call(validate):
     def bar() -> int:
         return foo()
 
-    validate(bar.compile(entrypoint=False))
+    validate(bar.compile_function())
 
 
 def test_call_back(validate):
@@ -22,7 +22,7 @@ def test_call_back(validate):
     def bar(x: int) -> int:
         return x
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 def test_recursion(validate):
@@ -30,7 +30,7 @@ def test_recursion(validate):
     def main(x: int) -> int:
         return main(x)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_mutual_recursion(validate):
@@ -42,7 +42,7 @@ def test_mutual_recursion(validate):
     def bar(x: int) -> int:
         return foo(x)
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 def test_unary_tuple(validate):
@@ -55,7 +55,7 @@ def test_unary_tuple(validate):
         (y,) = foo(x)
         return y
 
-    validate(bar.compile(entrypoint=False))
+    validate(bar.compile_function())
 
 
 def test_method_call(validate):
@@ -63,4 +63,4 @@ def test_method_call(validate):
     def foo(x: int) -> int:
         return x.__add__(2)
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())

--- a/tests/integration/test_call.py
+++ b/tests/integration/test_call.py
@@ -10,7 +10,7 @@ def test_call(validate):
     def bar() -> int:
         return foo()
 
-    validate(bar.compile())
+    validate(bar.compile(entrypoint=False))
 
 
 def test_call_back(validate):
@@ -22,7 +22,7 @@ def test_call_back(validate):
     def bar(x: int) -> int:
         return x
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 def test_recursion(validate):
@@ -30,7 +30,7 @@ def test_recursion(validate):
     def main(x: int) -> int:
         return main(x)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_mutual_recursion(validate):
@@ -42,7 +42,7 @@ def test_mutual_recursion(validate):
     def bar(x: int) -> int:
         return foo(x)
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 def test_unary_tuple(validate):
@@ -55,7 +55,7 @@ def test_unary_tuple(validate):
         (y,) = foo(x)
         return y
 
-    validate(bar.compile())
+    validate(bar.compile(entrypoint=False))
 
 
 def test_method_call(validate):
@@ -63,4 +63,4 @@ def test_method_call(validate):
     def foo(x: int) -> int:
         return x.__add__(2)
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))

--- a/tests/integration/test_comprehension.py
+++ b/tests/integration/test_comprehension.py
@@ -24,7 +24,7 @@ def test_basic_linear(validate):
     def test(qs: list[qubit] @ owned) -> list[qubit]:
         return [h(q) for q in qs]
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_guarded(validate):
@@ -52,7 +52,7 @@ def test_multiple_struct(validate):
     def test(ss: list[MyStruct] @ owned) -> list[qubit]:
         return [h(q) for s in ss for q in s.qs]
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_tuple_pat(validate):
@@ -68,7 +68,7 @@ def test_tuple_pat_linear(validate):
     def test(qs: list[tuple[int, qubit, qubit]] @ owned) -> list[tuple[qubit, qubit]]:
         return [cx(q1, q2) for _, q1, q2 in qs]
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_tuple_return(validate):
@@ -87,7 +87,7 @@ def test_dependent(validate):
     def test(xs: list[float]) -> list[float]:
         return [x * y for x in xs if x > 0 for y in process(x) if y > x]
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_capture(validate):
@@ -108,7 +108,7 @@ def test_capture_struct(validate):
     def test(xs: list[int], s: MyStruct) -> list[int]:
         return [x + s.x for x in xs if x > s.y]
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_scope(validate):
@@ -142,7 +142,7 @@ def test_nested_linear(validate):
     def test(qs: list[qubit] @ owned) -> list[qubit]:
         return [h(q) for q in [h(q) for q in qs]]
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_classical_list_comp(validate):
@@ -150,7 +150,7 @@ def test_classical_list_comp(validate):
     def test(xs: list[int]) -> list[int]:
         return [x for x in xs]
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_linear_discard(validate):
@@ -161,7 +161,7 @@ def test_linear_discard(validate):
     def test(qs: list[qubit] @ owned) -> list[None]:
         return [discard(q) for q in qs]
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_linear_discard_struct(validate):
@@ -177,7 +177,7 @@ def test_linear_discard_struct(validate):
     def test(ss: list[MyStruct] @ owned) -> list[None]:
         return [discard(s.q1, s.q2) for s in ss]
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_linear_consume_in_guard(validate):
@@ -188,7 +188,7 @@ def test_linear_consume_in_guard(validate):
     def test(qs: list[tuple[int, qubit]] @ owned) -> list[int]:
         return [x for x, q in qs if cond(q)]
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_linear_consume_in_iter(validate):
@@ -199,7 +199,7 @@ def test_linear_consume_in_iter(validate):
     def test(qs: list[qubit] @ owned) -> list[int]:
         return [x for q in qs for x in make_list(q)]
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_linear_next_nonlinear_iter(validate):
@@ -222,7 +222,7 @@ def test_linear_next_nonlinear_iter(validate):
         # We can use `mt` in an inner loop since it's not linear
         return [(x, q) for x in xs for q in mt]
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_nonlinear_next_linear_iter(validate):
@@ -251,7 +251,7 @@ def test_nonlinear_next_linear_iter(validate):
         # We can use `mt` in an outer loop since the target `x` is not linear
         return [(x, x + y) for x in mt for y in xs]
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_borrow(validate):
@@ -262,7 +262,7 @@ def test_borrow(validate):
     def test(q: qubit, n: int) -> list[int]:
         return [foo(q) for _ in range(n)]
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_borrow_nested(validate):
@@ -273,7 +273,7 @@ def test_borrow_nested(validate):
     def test(q: qubit, n: int, m: int) -> list[int]:
         return [foo(q) for _ in range(n) for _ in range(m)]
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_borrow_guarded(validate):
@@ -284,7 +284,7 @@ def test_borrow_guarded(validate):
     def test(q: qubit, n: int) -> list[int]:
         return [foo(q) for i in range(n) if i % 2 == 0]
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_borrow_twice(validate):
@@ -295,7 +295,7 @@ def test_borrow_twice(validate):
     def test(q: qubit, n: int) -> list[int]:
         return [foo(q) + foo(q) for _ in range(n)]
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_borrow_in_guard(validate):
@@ -309,7 +309,7 @@ def test_borrow_in_guard(validate):
     def test(q: qubit, n: int) -> list[int]:
         return [foo(q) for _ in range(n) if bar(q)]
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_borrow_in_iter(validate):
@@ -320,7 +320,7 @@ def test_borrow_in_iter(validate):
     def test(q: qubit @ owned) -> tuple[list[int], qubit]:
         return [foo(q) for _ in range(foo(q))], q
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_borrow_struct(validate):
@@ -336,7 +336,7 @@ def test_borrow_struct(validate):
     def test(s: MyStruct, n: int) -> list[int]:
         return [foo(s) for _ in range(n)]
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_borrow_and_consume(validate):
@@ -350,4 +350,4 @@ def test_borrow_and_consume(validate):
     def test(qs: list[qubit] @ owned) -> list[int]:
         return [foo(q) + bar(q) for q in qs]
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())

--- a/tests/integration/test_comprehension.py
+++ b/tests/integration/test_comprehension.py
@@ -24,7 +24,7 @@ def test_basic_linear(validate):
     def test(qs: list[qubit] @ owned) -> list[qubit]:
         return [h(q) for q in qs]
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_guarded(validate):
@@ -52,7 +52,7 @@ def test_multiple_struct(validate):
     def test(ss: list[MyStruct] @ owned) -> list[qubit]:
         return [h(q) for s in ss for q in s.qs]
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_tuple_pat(validate):
@@ -68,7 +68,7 @@ def test_tuple_pat_linear(validate):
     def test(qs: list[tuple[int, qubit, qubit]] @ owned) -> list[tuple[qubit, qubit]]:
         return [cx(q1, q2) for _, q1, q2 in qs]
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_tuple_return(validate):
@@ -87,7 +87,7 @@ def test_dependent(validate):
     def test(xs: list[float]) -> list[float]:
         return [x * y for x in xs if x > 0 for y in process(x) if y > x]
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_capture(validate):
@@ -108,7 +108,7 @@ def test_capture_struct(validate):
     def test(xs: list[int], s: MyStruct) -> list[int]:
         return [x + s.x for x in xs if x > s.y]
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_scope(validate):
@@ -142,7 +142,7 @@ def test_nested_linear(validate):
     def test(qs: list[qubit] @ owned) -> list[qubit]:
         return [h(q) for q in [h(q) for q in qs]]
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_classical_list_comp(validate):
@@ -150,7 +150,7 @@ def test_classical_list_comp(validate):
     def test(xs: list[int]) -> list[int]:
         return [x for x in xs]
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_linear_discard(validate):
@@ -161,7 +161,7 @@ def test_linear_discard(validate):
     def test(qs: list[qubit] @ owned) -> list[None]:
         return [discard(q) for q in qs]
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_linear_discard_struct(validate):
@@ -177,7 +177,7 @@ def test_linear_discard_struct(validate):
     def test(ss: list[MyStruct] @ owned) -> list[None]:
         return [discard(s.q1, s.q2) for s in ss]
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_linear_consume_in_guard(validate):
@@ -188,7 +188,7 @@ def test_linear_consume_in_guard(validate):
     def test(qs: list[tuple[int, qubit]] @ owned) -> list[int]:
         return [x for x, q in qs if cond(q)]
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_linear_consume_in_iter(validate):
@@ -199,7 +199,7 @@ def test_linear_consume_in_iter(validate):
     def test(qs: list[qubit] @ owned) -> list[int]:
         return [x for q in qs for x in make_list(q)]
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_linear_next_nonlinear_iter(validate):
@@ -222,7 +222,7 @@ def test_linear_next_nonlinear_iter(validate):
         # We can use `mt` in an inner loop since it's not linear
         return [(x, q) for x in xs for q in mt]
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_nonlinear_next_linear_iter(validate):
@@ -251,7 +251,7 @@ def test_nonlinear_next_linear_iter(validate):
         # We can use `mt` in an outer loop since the target `x` is not linear
         return [(x, x + y) for x in mt for y in xs]
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_borrow(validate):
@@ -262,7 +262,7 @@ def test_borrow(validate):
     def test(q: qubit, n: int) -> list[int]:
         return [foo(q) for _ in range(n)]
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_borrow_nested(validate):
@@ -273,7 +273,7 @@ def test_borrow_nested(validate):
     def test(q: qubit, n: int, m: int) -> list[int]:
         return [foo(q) for _ in range(n) for _ in range(m)]
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_borrow_guarded(validate):
@@ -284,7 +284,7 @@ def test_borrow_guarded(validate):
     def test(q: qubit, n: int) -> list[int]:
         return [foo(q) for i in range(n) if i % 2 == 0]
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_borrow_twice(validate):
@@ -295,7 +295,7 @@ def test_borrow_twice(validate):
     def test(q: qubit, n: int) -> list[int]:
         return [foo(q) + foo(q) for _ in range(n)]
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_borrow_in_guard(validate):
@@ -309,7 +309,7 @@ def test_borrow_in_guard(validate):
     def test(q: qubit, n: int) -> list[int]:
         return [foo(q) for _ in range(n) if bar(q)]
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_borrow_in_iter(validate):
@@ -320,7 +320,7 @@ def test_borrow_in_iter(validate):
     def test(q: qubit @ owned) -> tuple[list[int], qubit]:
         return [foo(q) for _ in range(foo(q))], q
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_borrow_struct(validate):
@@ -336,7 +336,7 @@ def test_borrow_struct(validate):
     def test(s: MyStruct, n: int) -> list[int]:
         return [foo(s) for _ in range(n)]
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_borrow_and_consume(validate):
@@ -350,4 +350,4 @@ def test_borrow_and_consume(validate):
     def test(qs: list[qubit] @ owned) -> list[int]:
         return [foo(q) + bar(q) for q in qs]
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))

--- a/tests/integration/test_comptime_args.py
+++ b/tests/integration/test_comptime_args.py
@@ -11,7 +11,7 @@ def test_basic_nat(validate):
     def main() -> nat:
         return foo(42)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_basic_int(validate):
@@ -23,7 +23,7 @@ def test_basic_int(validate):
     def main() -> int:
         return foo(42)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_basic_float(validate):
@@ -35,7 +35,7 @@ def test_basic_float(validate):
     def main() -> float:
         return foo(42.0)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_basic_bool(validate):
@@ -47,7 +47,7 @@ def test_basic_bool(validate):
     def main() -> bool:
         return foo(True)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_multiple(validate):
@@ -61,7 +61,7 @@ def test_multiple(validate):
     def main() -> nat:
         return foo(1, 2, 3, 4, 5, 6)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_comptime_expr(validate):
@@ -72,7 +72,7 @@ def test_comptime_expr(validate):
     def main() -> nat:
         return foo(comptime(42 + 1))
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_dependent(validate):
@@ -86,7 +86,7 @@ def test_dependent(validate):
         foo(1, array(1))
         foo(2, array(1, 2))
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_dependent_generic(validate):
@@ -100,7 +100,7 @@ def test_dependent_generic(validate):
     def main(xs: array[int, x]) -> None:
         foo(x, xs)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_type_apply(validate):
@@ -118,4 +118,4 @@ def test_type_apply(validate):
         g = foo[nat, m]
         g(42, m)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))

--- a/tests/integration/test_comptime_args.py
+++ b/tests/integration/test_comptime_args.py
@@ -11,7 +11,7 @@ def test_basic_nat(validate):
     def main() -> nat:
         return foo(42)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_basic_int(validate):
@@ -23,7 +23,7 @@ def test_basic_int(validate):
     def main() -> int:
         return foo(42)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_basic_float(validate):
@@ -35,7 +35,7 @@ def test_basic_float(validate):
     def main() -> float:
         return foo(42.0)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_basic_bool(validate):
@@ -47,7 +47,7 @@ def test_basic_bool(validate):
     def main() -> bool:
         return foo(True)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_multiple(validate):
@@ -61,7 +61,7 @@ def test_multiple(validate):
     def main() -> nat:
         return foo(1, 2, 3, 4, 5, 6)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_comptime_expr(validate):
@@ -72,7 +72,7 @@ def test_comptime_expr(validate):
     def main() -> nat:
         return foo(comptime(42 + 1))
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_dependent(validate):
@@ -86,7 +86,7 @@ def test_dependent(validate):
         foo(1, array(1))
         foo(2, array(1, 2))
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_dependent_generic(validate):
@@ -100,7 +100,7 @@ def test_dependent_generic(validate):
     def main(xs: array[int, x]) -> None:
         foo(x, xs)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_type_apply(validate):
@@ -118,4 +118,4 @@ def test_type_apply(validate):
         g = foo[nat, m]
         g(42, m)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())

--- a/tests/integration/test_comptime_expr.py
+++ b/tests/integration/test_comptime_expr.py
@@ -17,7 +17,7 @@ def test_basic(validate):
     def foo() -> int:
         return comptime(x + 1)
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 def test_py_alias(validate):
@@ -27,7 +27,7 @@ def test_py_alias(validate):
     def foo() -> int:
         return py(x + 1)
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 def test_builtin(validate):
@@ -47,7 +47,7 @@ def test_if(validate):
             return 0
         return 1
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 def test_redeclare_after(validate):
@@ -59,7 +59,7 @@ def test_redeclare_after(validate):
 
     x = False
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 def test_tuple(validate):
@@ -156,6 +156,6 @@ def test_func_type_arg(validate):
     class Baz:
         xs: array[int, comptime(n)]
 
-    validate(foo.compile(entrypoint=False))
-    validate(bar.compile(entrypoint=False))
-    validate(Baz.compile(entrypoint=False))
+    validate(foo.compile_function())
+    validate(bar.compile_function())
+    validate(Baz.compile())

--- a/tests/integration/test_comptime_expr.py
+++ b/tests/integration/test_comptime_expr.py
@@ -17,7 +17,7 @@ def test_basic(validate):
     def foo() -> int:
         return comptime(x + 1)
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 def test_py_alias(validate):
@@ -27,7 +27,7 @@ def test_py_alias(validate):
     def foo() -> int:
         return py(x + 1)
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 def test_builtin(validate):
@@ -47,7 +47,7 @@ def test_if(validate):
             return 0
         return 1
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 def test_redeclare_after(validate):
@@ -59,7 +59,7 @@ def test_redeclare_after(validate):
 
     x = False
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 def test_tuple(validate):
@@ -156,6 +156,6 @@ def test_func_type_arg(validate):
     class Baz:
         xs: array[int, comptime(n)]
 
-    validate(foo.compile())
-    validate(bar.compile())
-    validate(Baz.compile())
+    validate(foo.compile(entrypoint=False))
+    validate(bar.compile(entrypoint=False))
+    validate(Baz.compile(entrypoint=False))

--- a/tests/integration/test_custom_decorator.py
+++ b/tests/integration/test_custom_decorator.py
@@ -24,7 +24,7 @@ def test_custom_decorator(validate):
     def main() -> int:
         return foo() + bar() + main()
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_nested(validate):
@@ -52,7 +52,7 @@ def test_nested(validate):
     def main() -> int:
         return foo() + bar() + main()
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_method(validate):
@@ -80,4 +80,4 @@ def test_method(validate):
     def main() -> int:
         return foo() + bar() + main()
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())

--- a/tests/integration/test_custom_decorator.py
+++ b/tests/integration/test_custom_decorator.py
@@ -24,7 +24,7 @@ def test_custom_decorator(validate):
     def main() -> int:
         return foo() + bar() + main()
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_nested(validate):
@@ -52,7 +52,7 @@ def test_nested(validate):
     def main() -> int:
         return foo() + bar() + main()
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_method(validate):
@@ -80,4 +80,4 @@ def test_method(validate):
     def main() -> int:
         return foo() + bar() + main()
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))

--- a/tests/integration/test_custom_signature.py
+++ b/tests/integration/test_custom_signature.py
@@ -30,7 +30,7 @@ def test_custom_signature_success(validate):
     def test_func() -> None:
         fake_iadd(1, 1)
 
-    validate(test_func.compile(entrypoint=False))
+    validate(test_func.compile_function())
 
 
 def test_custom_signature_fail(validate):
@@ -39,6 +39,6 @@ def test_custom_signature_fail(validate):
         fake_iadd(1.0, 1.0)
 
     try:
-        validate(test_func_fail.compile(entrypoint=False))
+        validate(test_func_fail.compile_function())
     except GuppyTypeError as e:
         assert True

--- a/tests/integration/test_custom_signature.py
+++ b/tests/integration/test_custom_signature.py
@@ -30,7 +30,7 @@ def test_custom_signature_success(validate):
     def test_func() -> None:
         fake_iadd(1, 1)
 
-    validate(test_func.compile())
+    validate(test_func.compile(entrypoint=False))
 
 
 def test_custom_signature_fail(validate):
@@ -39,6 +39,6 @@ def test_custom_signature_fail(validate):
         fake_iadd(1.0, 1.0)
 
     try:
-        validate(test_func_fail.compile())
+        validate(test_func_fail.compile(entrypoint=False))
     except GuppyTypeError as e:
         assert True

--- a/tests/integration/test_docstring.py
+++ b/tests/integration/test_docstring.py
@@ -31,6 +31,6 @@ def test_docstring(validate):
             string.
             """
 
-    validate(f.compile())
-    validate(g.compile())
-    validate(nested.compile())
+    validate(f.compile(entrypoint=False))
+    validate(g.compile(entrypoint=False))
+    validate(nested.compile(entrypoint=False))

--- a/tests/integration/test_docstring.py
+++ b/tests/integration/test_docstring.py
@@ -31,6 +31,6 @@ def test_docstring(validate):
             string.
             """
 
-    validate(f.compile(entrypoint=False))
-    validate(g.compile(entrypoint=False))
-    validate(nested.compile(entrypoint=False))
+    validate(f.compile_function())
+    validate(g.compile_function())
+    validate(nested.compile_function())

--- a/tests/integration/test_drop_insertion.py
+++ b/tests/integration/test_drop_insertion.py
@@ -38,7 +38,7 @@ def test_drop(validate):
     def main(x: AffineTy @ owned) -> None:
         pass
 
-    hugr = main.compile(entrypoint=False)
+    hugr = main.compile_function()
     assert num_drops(hugr) == 1
     validate(hugr)
 
@@ -58,7 +58,7 @@ def test_drop_nested(validate):
     ) -> None:
         pass
 
-    hugr = main.compile(entrypoint=False)
+    hugr = main.compile_function()
     assert num_drops(hugr) == 4
     validate(hugr)
 
@@ -71,7 +71,7 @@ def test_drop_inout(validate):
     def main() -> None:
         foo(make())  # Drops inout return
 
-    hugr = main.compile(entrypoint=False)
+    hugr = main.compile_function()
     assert num_drops(hugr) == 1
     validate(hugr)
 
@@ -85,7 +85,7 @@ def test_drop_comprehension(validate):
         array(foo(x) for _ in range(10))
         # Drops x and the resulting array
 
-    hugr = main.compile(entrypoint=False)
+    hugr = main.compile_function()
     assert num_drops(hugr) == 2
     validate(hugr)
 
@@ -97,7 +97,7 @@ def test_drop_reassign(validate):
         x = make()  # Drops previous x
         return x
 
-    hugr = main.compile(entrypoint=False)
+    hugr = main.compile_function()
     assert num_drops(hugr) == 1
     validate(hugr)
 
@@ -110,7 +110,7 @@ def test_drop_if(validate):
             x = make()  # Drops previous x
         return x
 
-    hugr = main.compile(entrypoint=False)
+    hugr = main.compile_function()
     assert num_drops(hugr) == 1
     validate(hugr)
 
@@ -133,6 +133,6 @@ def test_drop_while(validate):
             x = make()  # Drops x
         return y
 
-    hugr = main.compile(entrypoint=False)
+    hugr = main.compile_function()
     assert num_drops(hugr) == 4
     validate(hugr)

--- a/tests/integration/test_drop_insertion.py
+++ b/tests/integration/test_drop_insertion.py
@@ -1,11 +1,10 @@
-from hugr.package import ModulePointer
 from guppylang.decorator import guppy
 from guppylang.std.array import array
 from guppylang_internals.std._internal.compiler.tket_exts import GUPPY_EXTENSION
 from guppylang.std.lang import owned
 
 from hugr import tys, ops
-
+from hugr.package import Package
 from hugr.std.collections.array import Array
 
 
@@ -22,9 +21,9 @@ def make() -> AffineTy:
     """Creates an instance of `AffineTy`."""
 
 
-def num_drops(ptr: ModulePointer) -> int:
+def num_drops(pkg: Package) -> int:
     drop_op = GUPPY_EXTENSION.get_op("drop")
-    h = ptr.module
+    h = pkg.modules[0]
     n = 0
     for node in h:
         match h[node].op:
@@ -39,7 +38,7 @@ def test_drop(validate):
     def main(x: AffineTy @ owned) -> None:
         pass
 
-    hugr = guppy.compile(main)
+    hugr = main.compile(entrypoint=False)
     assert num_drops(hugr) == 1
     validate(hugr)
 
@@ -59,7 +58,7 @@ def test_drop_nested(validate):
     ) -> None:
         pass
 
-    hugr = guppy.compile(main)
+    hugr = main.compile(entrypoint=False)
     assert num_drops(hugr) == 4
     validate(hugr)
 
@@ -72,7 +71,7 @@ def test_drop_inout(validate):
     def main() -> None:
         foo(make())  # Drops inout return
 
-    hugr = guppy.compile(main)
+    hugr = main.compile(entrypoint=False)
     assert num_drops(hugr) == 1
     validate(hugr)
 
@@ -86,7 +85,7 @@ def test_drop_comprehension(validate):
         array(foo(x) for _ in range(10))
         # Drops x and the resulting array
 
-    hugr = guppy.compile(main)
+    hugr = main.compile(entrypoint=False)
     assert num_drops(hugr) == 2
     validate(hugr)
 
@@ -98,7 +97,7 @@ def test_drop_reassign(validate):
         x = make()  # Drops previous x
         return x
 
-    hugr = guppy.compile(main)
+    hugr = main.compile(entrypoint=False)
     assert num_drops(hugr) == 1
     validate(hugr)
 
@@ -111,7 +110,7 @@ def test_drop_if(validate):
             x = make()  # Drops previous x
         return x
 
-    hugr = guppy.compile(main)
+    hugr = main.compile(entrypoint=False)
     assert num_drops(hugr) == 1
     validate(hugr)
 
@@ -134,6 +133,6 @@ def test_drop_while(validate):
             x = make()  # Drops x
         return y
 
-    hugr = guppy.compile(main)
+    hugr = main.compile(entrypoint=False)
     assert num_drops(hugr) == 4
     validate(hugr)

--- a/tests/integration/test_extern.py
+++ b/tests/integration/test_extern.py
@@ -12,7 +12,7 @@ def test_extern_float(validate):
     def main() -> float:
         return ext + ext
 
-    package = main.compile(entrypoint=False)
+    package = main.compile_function()
     validate(package)
 
     hg = package.modules[0]
@@ -28,7 +28,7 @@ def test_extern_alt_symbol(validate):
     def main() -> int:
         return ext
 
-    package = main.compile(entrypoint=False)
+    package = main.compile_function()
     validate(package)
 
     hg = package.modules[0]
@@ -45,7 +45,7 @@ def test_extern_tuple(validate):
         x, y = ext
         return x + y
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 @pytest.mark.skip("See https://github.com/CQCL/guppylang/issues/827")
@@ -58,4 +58,4 @@ def test_extern_conditional_assign(validate):
             x = 4
         return x
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())

--- a/tests/integration/test_extern.py
+++ b/tests/integration/test_extern.py
@@ -12,7 +12,7 @@ def test_extern_float(validate):
     def main() -> float:
         return ext + ext
 
-    package = main.compile()
+    package = main.compile(entrypoint=False)
     validate(package)
 
     hg = package.modules[0]
@@ -28,7 +28,7 @@ def test_extern_alt_symbol(validate):
     def main() -> int:
         return ext
 
-    package = main.compile()
+    package = main.compile(entrypoint=False)
     validate(package)
 
     hg = package.modules[0]
@@ -45,7 +45,7 @@ def test_extern_tuple(validate):
         x, y = ext
         return x + y
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 @pytest.mark.skip("See https://github.com/CQCL/guppylang/issues/827")
@@ -58,4 +58,4 @@ def test_extern_conditional_assign(validate):
             x = 4
         return x
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))

--- a/tests/integration/test_frozenarray.py
+++ b/tests/integration/test_frozenarray.py
@@ -123,4 +123,4 @@ def test_nested_struct(validate):
                 s += x
         return s
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))

--- a/tests/integration/test_frozenarray.py
+++ b/tests/integration/test_frozenarray.py
@@ -123,4 +123,4 @@ def test_nested_struct(validate):
                 s += x
         return s
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())

--- a/tests/integration/test_higher_order.py
+++ b/tests/integration/test_higher_order.py
@@ -13,7 +13,7 @@ def test_basic(validate):
     def foo() -> Callable[[int], bool]:
         return bar
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 def test_call_1(validate):
@@ -29,7 +29,7 @@ def test_call_1(validate):
     def baz() -> bool:
         return foo()()
 
-    validate(baz.compile(entrypoint=False))
+    validate(baz.compile_function())
 
 
 def test_call_2(validate):
@@ -45,7 +45,7 @@ def test_call_2(validate):
     def baz(y: int) -> None:
         return foo()(y)(y)
 
-    validate(baz.compile(entrypoint=False))
+    validate(baz.compile_function())
 
 
 def test_conditional(validate):
@@ -63,7 +63,7 @@ def test_conditional(validate):
             baz = bar
         return baz()
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_method(validate):
@@ -72,7 +72,7 @@ def test_method(validate):
         f = x.__add__
         return f(1), f
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 def test_nested(validate):
@@ -98,7 +98,7 @@ def test_nested_capture_struct(validate):
 
         return bar
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 def test_curry(validate):
@@ -133,7 +133,7 @@ def test_curry(validate):
         uncurried(x, y)
         curry(uncurry(curry(gt)))(y)(x)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_y_combinator(validate):
@@ -154,4 +154,4 @@ def test_y_combinator(validate):
     def fac(x: int) -> int:
         return Y(fac_)(x)
 
-    validate(fac.compile(entrypoint=False))
+    validate(fac.compile_function())

--- a/tests/integration/test_higher_order.py
+++ b/tests/integration/test_higher_order.py
@@ -13,7 +13,7 @@ def test_basic(validate):
     def foo() -> Callable[[int], bool]:
         return bar
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 def test_call_1(validate):
@@ -29,7 +29,7 @@ def test_call_1(validate):
     def baz() -> bool:
         return foo()()
 
-    validate(baz.compile())
+    validate(baz.compile(entrypoint=False))
 
 
 def test_call_2(validate):
@@ -45,7 +45,7 @@ def test_call_2(validate):
     def baz(y: int) -> None:
         return foo()(y)(y)
 
-    validate(baz.compile())
+    validate(baz.compile(entrypoint=False))
 
 
 def test_conditional(validate):
@@ -63,7 +63,7 @@ def test_conditional(validate):
             baz = bar
         return baz()
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_method(validate):
@@ -72,7 +72,7 @@ def test_method(validate):
         f = x.__add__
         return f(1), f
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 def test_nested(validate):
@@ -98,7 +98,7 @@ def test_nested_capture_struct(validate):
 
         return bar
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 def test_curry(validate):
@@ -133,7 +133,7 @@ def test_curry(validate):
         uncurried(x, y)
         curry(uncurry(curry(gt)))(y)(x)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_y_combinator(validate):
@@ -154,4 +154,4 @@ def test_y_combinator(validate):
     def fac(x: int) -> int:
         return Y(fac_)(x)
 
-    validate(fac.compile())
+    validate(fac.compile(entrypoint=False))

--- a/tests/integration/test_imports.py
+++ b/tests/integration/test_imports.py
@@ -8,7 +8,7 @@ def test_import_func(validate):
     def test(x: int) -> int:
         return f(x) + g()
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_import_type(validate):
@@ -19,7 +19,7 @@ def test_import_type(validate):
         # Check that we've correctly imported the __neg__ method
         return -x
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_func_alias(validate):
@@ -29,7 +29,7 @@ def test_func_alias(validate):
     def test(x: int) -> int:
         return g(x)
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_type_alias(validate):
@@ -40,7 +40,7 @@ def test_type_alias(validate):
         # Check that we still have the __neg__ method
         return -x
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_type_transitive(validate):
@@ -52,7 +52,7 @@ def test_type_transitive(validate):
         x = g()  # Type of x was defined in `mod_a`
         return int(-x)  # Call method that was defined in `mod_a`
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_type_transitive_conflict(validate):
@@ -64,7 +64,7 @@ def test_type_transitive_conflict(validate):
         ty_a = g()  # g returns a type with the same name `MyType`
         return +ty_b
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_func_transitive(validate):
@@ -75,7 +75,7 @@ def test_func_transitive(validate):
     def test(x: int) -> int:
         return h(x)
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_qualified(validate):
@@ -86,7 +86,7 @@ def test_qualified(validate):
     def test(x: int, y: bool) -> tuple[int, bool]:
         return mod_a.f(x), mod_b.f(y)
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_qualified_types(validate):
@@ -97,4 +97,4 @@ def test_qualified_types(validate):
     def test(x: mod_a.MyType, y: mod_b.MyType) -> tuple[mod_a.MyType, mod_b.MyType]:
         return -x, +y
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))

--- a/tests/integration/test_imports.py
+++ b/tests/integration/test_imports.py
@@ -8,7 +8,7 @@ def test_import_func(validate):
     def test(x: int) -> int:
         return f(x) + g()
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_import_type(validate):
@@ -19,7 +19,7 @@ def test_import_type(validate):
         # Check that we've correctly imported the __neg__ method
         return -x
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_func_alias(validate):
@@ -29,7 +29,7 @@ def test_func_alias(validate):
     def test(x: int) -> int:
         return g(x)
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_type_alias(validate):
@@ -40,7 +40,7 @@ def test_type_alias(validate):
         # Check that we still have the __neg__ method
         return -x
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_type_transitive(validate):
@@ -52,7 +52,7 @@ def test_type_transitive(validate):
         x = g()  # Type of x was defined in `mod_a`
         return int(-x)  # Call method that was defined in `mod_a`
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_type_transitive_conflict(validate):
@@ -64,7 +64,7 @@ def test_type_transitive_conflict(validate):
         ty_a = g()  # g returns a type with the same name `MyType`
         return +ty_b
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_func_transitive(validate):
@@ -75,7 +75,7 @@ def test_func_transitive(validate):
     def test(x: int) -> int:
         return h(x)
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_qualified(validate):
@@ -86,7 +86,7 @@ def test_qualified(validate):
     def test(x: int, y: bool) -> tuple[int, bool]:
         return mod_a.f(x), mod_b.f(y)
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_qualified_types(validate):
@@ -97,4 +97,4 @@ def test_qualified_types(validate):
     def test(x: mod_a.MyType, y: mod_b.MyType) -> tuple[mod_a.MyType, mod_b.MyType]:
         return -x, +y
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())

--- a/tests/integration/test_inout.py
+++ b/tests/integration/test_inout.py
@@ -12,7 +12,7 @@ def test_basic(validate):
         foo(q)
         return q
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_mixed(validate):
@@ -24,7 +24,7 @@ def test_mixed(validate):
         q2 = foo(q1, q2)
         return q1, q2
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_local(validate):
@@ -37,7 +37,7 @@ def test_local(validate):
         f(q)
         return q
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_nested_calls(validate):
@@ -49,7 +49,7 @@ def test_nested_calls(validate):
         # This is legal since function arguments and tuples are evaluated left to right
         return foo(foo(foo(0, q), q), q), q
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_struct(validate):
@@ -77,8 +77,8 @@ def test_struct(validate):
         bar(a)
         return a
 
-    validate(test1.compile(entrypoint=False))
-    validate(test2.compile(entrypoint=False))
+    validate(test1.compile_function())
+    validate(test2.compile_function())
 
 
 def test_control_flow(validate):
@@ -114,7 +114,7 @@ def test_control_flow(validate):
             i += 1
         return q1, q2
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_tensor(validate):
@@ -151,7 +151,7 @@ def test_tensor(validate):
         c1 = (foo, (bar, baz))(a, b.x, c1.x, b, c1, c2)
         return a, b, c1, c2
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_basic_def(validate):
@@ -169,7 +169,7 @@ def test_basic_def(validate):
         foo(q)
         return q
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_empty_def(validate):
@@ -182,7 +182,7 @@ def test_empty_def(validate):
         test(q)
         return q
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_mixed_def(validate):
@@ -196,7 +196,7 @@ def test_mixed_def(validate):
         foo(c)
         return e, b + d
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_move_back(validate):
@@ -228,7 +228,7 @@ def test_move_back(validate):
         use(t.q)
         return s
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_move_back_branch(validate):
@@ -263,7 +263,7 @@ def test_move_back_branch(validate):
         test(s, False, 5, qubit(), qubit())
         return s
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_self(validate):
@@ -284,7 +284,7 @@ def test_self(validate):
     def main(s: MyStruct) -> None:
         s.bar(False)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_subtype(validate):
@@ -297,7 +297,7 @@ def test_subtype(validate):
         foo(q)
         return q
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_shadow_check(validate):
@@ -309,7 +309,7 @@ def test_shadow_check(validate):
         if True:
             foo(i)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_self_qubit(validate):
@@ -322,7 +322,7 @@ def test_self_qubit(validate):
         qubit().discard()
         return result
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_non_terminating(validate):
@@ -358,6 +358,6 @@ def test_non_terminating(validate):
         while True:
             pass
 
-    validate(test1.compile(entrypoint=False))
-    validate(test2.compile(entrypoint=False))
-    validate(test3.compile(entrypoint=False))
+    validate(test1.compile_function())
+    validate(test2.compile_function())
+    validate(test3.compile_function())

--- a/tests/integration/test_inout.py
+++ b/tests/integration/test_inout.py
@@ -12,7 +12,7 @@ def test_basic(validate):
         foo(q)
         return q
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_mixed(validate):
@@ -24,7 +24,7 @@ def test_mixed(validate):
         q2 = foo(q1, q2)
         return q1, q2
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_local(validate):
@@ -37,7 +37,7 @@ def test_local(validate):
         f(q)
         return q
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_nested_calls(validate):
@@ -49,7 +49,7 @@ def test_nested_calls(validate):
         # This is legal since function arguments and tuples are evaluated left to right
         return foo(foo(foo(0, q), q), q), q
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_struct(validate):
@@ -77,8 +77,8 @@ def test_struct(validate):
         bar(a)
         return a
 
-    validate(test1.compile())
-    validate(test2.compile())
+    validate(test1.compile(entrypoint=False))
+    validate(test2.compile(entrypoint=False))
 
 
 def test_control_flow(validate):
@@ -114,7 +114,7 @@ def test_control_flow(validate):
             i += 1
         return q1, q2
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_tensor(validate):
@@ -151,7 +151,7 @@ def test_tensor(validate):
         c1 = (foo, (bar, baz))(a, b.x, c1.x, b, c1, c2)
         return a, b, c1, c2
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_basic_def(validate):
@@ -169,7 +169,7 @@ def test_basic_def(validate):
         foo(q)
         return q
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_empty_def(validate):
@@ -182,7 +182,7 @@ def test_empty_def(validate):
         test(q)
         return q
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_mixed_def(validate):
@@ -196,7 +196,7 @@ def test_mixed_def(validate):
         foo(c)
         return e, b + d
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_move_back(validate):
@@ -228,7 +228,7 @@ def test_move_back(validate):
         use(t.q)
         return s
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_move_back_branch(validate):
@@ -263,7 +263,7 @@ def test_move_back_branch(validate):
         test(s, False, 5, qubit(), qubit())
         return s
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_self(validate):
@@ -284,7 +284,7 @@ def test_self(validate):
     def main(s: MyStruct) -> None:
         s.bar(False)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_subtype(validate):
@@ -297,7 +297,7 @@ def test_subtype(validate):
         foo(q)
         return q
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_shadow_check(validate):
@@ -309,7 +309,7 @@ def test_shadow_check(validate):
         if True:
             foo(i)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_self_qubit(validate):
@@ -322,7 +322,7 @@ def test_self_qubit(validate):
         qubit().discard()
         return result
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_non_terminating(validate):
@@ -358,6 +358,6 @@ def test_non_terminating(validate):
         while True:
             pass
 
-    validate(test1.compile())
-    validate(test2.compile())
-    validate(test3.compile())
+    validate(test1.compile(entrypoint=False))
+    validate(test2.compile(entrypoint=False))
+    validate(test3.compile(entrypoint=False))

--- a/tests/integration/test_linear.py
+++ b/tests/integration/test_linear.py
@@ -13,7 +13,7 @@ def test_id(validate):
     def test(q: qubit @ owned) -> qubit:
         return q
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_assign(validate):
@@ -23,7 +23,7 @@ def test_assign(validate):
         s = r
         return s
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_linear_return_order(validate):
@@ -33,7 +33,7 @@ def test_linear_return_order(validate):
     def test(q: qubit @ owned) -> tuple[qubit, bool]:
         return project_z(q)
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_interleave(validate):
@@ -52,7 +52,7 @@ def test_interleave(validate):
         b, c = g(b, c)
         return a, b, c, d
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_linear_struct(validate):
@@ -80,7 +80,7 @@ def test_linear_struct(validate):
         s.q2, t.q1 = g(t.q1, s.q2)
         return s.q1, s.q2, t.q1, t.q2
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_mixed_classical_linear_struct(validate):
@@ -106,8 +106,8 @@ def test_mixed_classical_linear_struct(validate):
         u.q = f(u.q)
         return u, s.x, t.x, u.x
 
-    validate(test1.compile())
-    validate(test2.compile())
+    validate(test1.compile(entrypoint=False))
+    validate(test2.compile(entrypoint=False))
 
 
 def test_drop_classical_field(validate):
@@ -123,7 +123,7 @@ def test_drop_classical_field(validate):
     def test() -> qubit:
         return f().q
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_if(validate):
@@ -136,7 +136,7 @@ def test_if(validate):
             q = qubit()
         return q
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_if_return(validate):
@@ -149,7 +149,7 @@ def test_if_return(validate):
             q = qubit()
         return q
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_if_struct_rebuild(validate):
@@ -169,8 +169,8 @@ def test_if_struct_rebuild(validate):
             s.q = s.q
         return s
 
-    validate(test1.compile())
-    validate(test2.compile())
+    validate(test1.compile(entrypoint=False))
+    validate(test2.compile(entrypoint=False))
 
 
 def test_struct_reassign(validate):
@@ -195,7 +195,7 @@ def test_struct_reassign(validate):
             s = MyStruct1(MyStruct2(qubit()))
         return s.x
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_struct_reassign2(validate):
@@ -218,7 +218,7 @@ def test_struct_reassign2(validate):
         s.q2 = qubit()
         return s
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_measure(validate):
@@ -227,7 +227,7 @@ def test_measure(validate):
         b = measure(q)
         return x
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_return_call(validate):
@@ -238,7 +238,7 @@ def test_return_call(validate):
     def test(q: qubit @ owned) -> qubit:
         return op(q)
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_while(validate):
@@ -249,7 +249,7 @@ def test_while(validate):
             q = h(q)
         return q
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_while_break(validate):
@@ -262,7 +262,7 @@ def test_while_break(validate):
                 break
         return q
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_while_continue(validate):
@@ -275,7 +275,7 @@ def test_while_continue(validate):
             q = h(q)
         return q
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_while_reset(validate):
@@ -290,7 +290,7 @@ def test_while_reset(validate):
             i -= 1
         return b
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 def test_while_move_back(validate):
@@ -308,7 +308,7 @@ def test_while_move_back(validate):
             s.q = qubit()
             return s
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_for(validate):
@@ -321,7 +321,7 @@ def test_for(validate):
             rs.append(q2)
         return rs
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_for_measure(validate):
@@ -332,7 +332,7 @@ def test_for_measure(validate):
             parity |= measure(q)
         return parity
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_for_continue(validate):
@@ -345,7 +345,7 @@ def test_for_continue(validate):
             x += 1
         return x
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_for_nonlinear_break(validate):
@@ -373,7 +373,7 @@ def test_for_nonlinear_break(validate):
             if measure(q):
                 break
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_rus(validate):
@@ -386,7 +386,7 @@ def test_rus(validate):
                 break
         return q
 
-    validate(repeat_until_success.compile())
+    validate(repeat_until_success.compile(entrypoint=False))
 
 
 def test_list_iter_arg(validate):
@@ -395,7 +395,7 @@ def test_list_iter_arg(validate):
         qs = [h(q) for q in qs]
         return qs
 
-    validate(owned_arg.compile())
+    validate(owned_arg.compile(entrypoint=False))
 
 
 def test_list_iter(validate):
@@ -405,7 +405,7 @@ def test_list_iter(validate):
         qs = [h(q) for q in qs]
         return qs
 
-    validate(owned_arg.compile())
+    validate(owned_arg.compile(entrypoint=False))
 
 
 def test_non_terminating(validate):
@@ -415,4 +415,4 @@ def test_non_terminating(validate):
         while True:
             q = h(q)
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))

--- a/tests/integration/test_linear.py
+++ b/tests/integration/test_linear.py
@@ -13,7 +13,7 @@ def test_id(validate):
     def test(q: qubit @ owned) -> qubit:
         return q
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_assign(validate):
@@ -23,7 +23,7 @@ def test_assign(validate):
         s = r
         return s
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_linear_return_order(validate):
@@ -33,7 +33,7 @@ def test_linear_return_order(validate):
     def test(q: qubit @ owned) -> tuple[qubit, bool]:
         return project_z(q)
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_interleave(validate):
@@ -52,7 +52,7 @@ def test_interleave(validate):
         b, c = g(b, c)
         return a, b, c, d
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_linear_struct(validate):
@@ -80,7 +80,7 @@ def test_linear_struct(validate):
         s.q2, t.q1 = g(t.q1, s.q2)
         return s.q1, s.q2, t.q1, t.q2
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_mixed_classical_linear_struct(validate):
@@ -106,8 +106,8 @@ def test_mixed_classical_linear_struct(validate):
         u.q = f(u.q)
         return u, s.x, t.x, u.x
 
-    validate(test1.compile(entrypoint=False))
-    validate(test2.compile(entrypoint=False))
+    validate(test1.compile_function())
+    validate(test2.compile_function())
 
 
 def test_drop_classical_field(validate):
@@ -123,7 +123,7 @@ def test_drop_classical_field(validate):
     def test() -> qubit:
         return f().q
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_if(validate):
@@ -136,7 +136,7 @@ def test_if(validate):
             q = qubit()
         return q
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_if_return(validate):
@@ -149,7 +149,7 @@ def test_if_return(validate):
             q = qubit()
         return q
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_if_struct_rebuild(validate):
@@ -169,8 +169,8 @@ def test_if_struct_rebuild(validate):
             s.q = s.q
         return s
 
-    validate(test1.compile(entrypoint=False))
-    validate(test2.compile(entrypoint=False))
+    validate(test1.compile_function())
+    validate(test2.compile_function())
 
 
 def test_struct_reassign(validate):
@@ -195,7 +195,7 @@ def test_struct_reassign(validate):
             s = MyStruct1(MyStruct2(qubit()))
         return s.x
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_struct_reassign2(validate):
@@ -218,7 +218,7 @@ def test_struct_reassign2(validate):
         s.q2 = qubit()
         return s
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_measure(validate):
@@ -227,7 +227,7 @@ def test_measure(validate):
         b = measure(q)
         return x
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_return_call(validate):
@@ -238,7 +238,7 @@ def test_return_call(validate):
     def test(q: qubit @ owned) -> qubit:
         return op(q)
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_while(validate):
@@ -249,7 +249,7 @@ def test_while(validate):
             q = h(q)
         return q
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_while_break(validate):
@@ -262,7 +262,7 @@ def test_while_break(validate):
                 break
         return q
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_while_continue(validate):
@@ -275,7 +275,7 @@ def test_while_continue(validate):
             q = h(q)
         return q
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_while_reset(validate):
@@ -290,7 +290,7 @@ def test_while_reset(validate):
             i -= 1
         return b
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 def test_while_move_back(validate):
@@ -308,7 +308,7 @@ def test_while_move_back(validate):
             s.q = qubit()
             return s
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_for(validate):
@@ -321,7 +321,7 @@ def test_for(validate):
             rs.append(q2)
         return rs
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_for_measure(validate):
@@ -332,7 +332,7 @@ def test_for_measure(validate):
             parity |= measure(q)
         return parity
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_for_continue(validate):
@@ -345,7 +345,7 @@ def test_for_continue(validate):
             x += 1
         return x
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_for_nonlinear_break(validate):
@@ -373,7 +373,7 @@ def test_for_nonlinear_break(validate):
             if measure(q):
                 break
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_rus(validate):
@@ -386,7 +386,7 @@ def test_rus(validate):
                 break
         return q
 
-    validate(repeat_until_success.compile(entrypoint=False))
+    validate(repeat_until_success.compile_function())
 
 
 def test_list_iter_arg(validate):
@@ -395,7 +395,7 @@ def test_list_iter_arg(validate):
         qs = [h(q) for q in qs]
         return qs
 
-    validate(owned_arg.compile(entrypoint=False))
+    validate(owned_arg.compile_function())
 
 
 def test_list_iter(validate):
@@ -405,7 +405,7 @@ def test_list_iter(validate):
         qs = [h(q) for q in qs]
         return qs
 
-    validate(owned_arg.compile(entrypoint=False))
+    validate(owned_arg.compile_function())
 
 
 def test_non_terminating(validate):
@@ -415,4 +415,4 @@ def test_non_terminating(validate):
         while True:
             q = h(q)
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())

--- a/tests/integration/test_list.py
+++ b/tests/integration/test_list.py
@@ -39,7 +39,7 @@ def test_literal_linear(validate):
     def test(q1: qubit @ owned, q2: qubit @ owned) -> list[qubit]:
         return [q1, h(q2)]
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_push_pop(validate):
@@ -72,7 +72,7 @@ def test_arith_linear(validate):
         xs += [q]
         return xs + ys
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_subscript(validate):
@@ -89,7 +89,7 @@ def test_linear(validate):
         xs.append(q)
         return len(xs)
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_subscript_drop_rest(validate):
@@ -100,7 +100,7 @@ def test_subscript_drop_rest(validate):
     def main() -> int:
         return foo()[0]
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_linear_subscript(validate):
@@ -112,7 +112,7 @@ def test_linear_subscript(validate):
         foo(qs[i])
         return qs
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_inout_subscript(validate):
@@ -123,7 +123,7 @@ def test_inout_subscript(validate):
     def main(qs: list[qubit], i: int) -> None:
         foo(qs[i])
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_multi_subscripts(validate):
@@ -136,7 +136,7 @@ def test_multi_subscripts(validate):
         foo(qs[0], qs[0])  # Will panic at runtime
         return qs
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_struct_list(validate):
@@ -156,7 +156,7 @@ def test_struct_list(validate):
         foo(ss[0].q1, ss[0].q2)
         return ss
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_nested_subscripts(validate):
@@ -175,7 +175,7 @@ def test_nested_subscripts(validate):
         bar(qs[0][0], qs[0][1], qs[1][0], qs[1][1])
         return qs
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_struct_nested_subscript(validate):
@@ -203,7 +203,7 @@ def test_struct_nested_subscript(validate):
         foo(a.xs[i].ys[j][k].c)
         return a
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_phase_gadget(validate):
@@ -216,4 +216,4 @@ def test_phase_gadget(validate):
         for i in range(n - 1):
             cx(qs[n - i - 1], qs[n - i - 2])
 
-    validate(paulig.compile(entrypoint=False))
+    validate(paulig.compile_function())

--- a/tests/integration/test_list.py
+++ b/tests/integration/test_list.py
@@ -39,7 +39,7 @@ def test_literal_linear(validate):
     def test(q1: qubit @ owned, q2: qubit @ owned) -> list[qubit]:
         return [q1, h(q2)]
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_push_pop(validate):
@@ -72,7 +72,7 @@ def test_arith_linear(validate):
         xs += [q]
         return xs + ys
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_subscript(validate):
@@ -89,7 +89,7 @@ def test_linear(validate):
         xs.append(q)
         return len(xs)
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_subscript_drop_rest(validate):
@@ -100,7 +100,7 @@ def test_subscript_drop_rest(validate):
     def main() -> int:
         return foo()[0]
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_linear_subscript(validate):
@@ -112,7 +112,7 @@ def test_linear_subscript(validate):
         foo(qs[i])
         return qs
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_inout_subscript(validate):
@@ -123,7 +123,7 @@ def test_inout_subscript(validate):
     def main(qs: list[qubit], i: int) -> None:
         foo(qs[i])
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_multi_subscripts(validate):
@@ -136,7 +136,7 @@ def test_multi_subscripts(validate):
         foo(qs[0], qs[0])  # Will panic at runtime
         return qs
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_struct_list(validate):
@@ -156,7 +156,7 @@ def test_struct_list(validate):
         foo(ss[0].q1, ss[0].q2)
         return ss
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_nested_subscripts(validate):
@@ -175,7 +175,7 @@ def test_nested_subscripts(validate):
         bar(qs[0][0], qs[0][1], qs[1][0], qs[1][1])
         return qs
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_struct_nested_subscript(validate):
@@ -203,7 +203,7 @@ def test_struct_nested_subscript(validate):
         foo(a.xs[i].ys[j][k].c)
         return a
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_phase_gadget(validate):
@@ -216,4 +216,4 @@ def test_phase_gadget(validate):
         for i in range(n - 1):
             cx(qs[n - i - 1], qs[n - i - 2])
 
-    validate(paulig.compile())
+    validate(paulig.compile(entrypoint=False))

--- a/tests/integration/test_nested.py
+++ b/tests/integration/test_nested.py
@@ -208,7 +208,7 @@ def test_capture_recurse_nested(validate):
 
         return bar(x, 0)
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 def test_capture_while(validate):

--- a/tests/integration/test_nested.py
+++ b/tests/integration/test_nested.py
@@ -208,7 +208,7 @@ def test_capture_recurse_nested(validate):
 
         return bar(x, 0)
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 def test_capture_while(validate):

--- a/tests/integration/test_none.py
+++ b/tests/integration/test_none.py
@@ -14,5 +14,5 @@ def test_none(validate, run_int_fn):
     def main() -> int:
         return bar(foo(), 42)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
     run_int_fn(main, expected=42)

--- a/tests/integration/test_none.py
+++ b/tests/integration/test_none.py
@@ -14,5 +14,5 @@ def test_none(validate, run_int_fn):
     def main() -> int:
         return bar(foo(), 42)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
     run_int_fn(main, expected=42)

--- a/tests/integration/test_overload.py
+++ b/tests/integration/test_overload.py
@@ -24,7 +24,7 @@ def test_basic_overload(validate):
         combined(1, 2)
         combined(1, 2, 3)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_pick_first(validate):
@@ -46,7 +46,7 @@ def test_pick_first(validate):
         x = combined(42)
         return x
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_generic_overload(validate):
@@ -69,7 +69,7 @@ def test_generic_overload(validate):
         x = combined(1, 1.0)
         return x
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_pick_by_return_type1(validate):
@@ -86,7 +86,7 @@ def test_pick_by_return_type1(validate):
     def main() -> None:
         out: int = combined()
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_pick_by_return_type2(validate):
@@ -109,7 +109,7 @@ def test_pick_by_return_type2(validate):
         # the return type and infer that `variant2` is the only matching one.
         out: int = combined(42.0)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_comptime_overload_call(validate):
@@ -133,7 +133,7 @@ def test_comptime_overload_call(validate):
         combined(1, 2)
         combined(1, 2, 3)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_everything_can_be_overloaded(validate):
@@ -165,7 +165,7 @@ def test_everything_can_be_overloaded(validate):
         combined(1, 2, 3)
         combined(1, 2, 3, 4)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
     # If we have tket installed, we can even overload circuits
     try:
@@ -193,7 +193,7 @@ def test_everything_can_be_overloaded(validate):
             combined(q)
             combined(qs)
 
-        validate(main.compile())
+        validate(main.compile(entrypoint=False))
 
     except ImportError:
         pass

--- a/tests/integration/test_overload.py
+++ b/tests/integration/test_overload.py
@@ -24,7 +24,7 @@ def test_basic_overload(validate):
         combined(1, 2)
         combined(1, 2, 3)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_pick_first(validate):
@@ -46,7 +46,7 @@ def test_pick_first(validate):
         x = combined(42)
         return x
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_generic_overload(validate):
@@ -69,7 +69,7 @@ def test_generic_overload(validate):
         x = combined(1, 1.0)
         return x
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_pick_by_return_type1(validate):
@@ -86,7 +86,7 @@ def test_pick_by_return_type1(validate):
     def main() -> None:
         out: int = combined()
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_pick_by_return_type2(validate):
@@ -109,7 +109,7 @@ def test_pick_by_return_type2(validate):
         # the return type and infer that `variant2` is the only matching one.
         out: int = combined(42.0)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_comptime_overload_call(validate):
@@ -133,7 +133,7 @@ def test_comptime_overload_call(validate):
         combined(1, 2)
         combined(1, 2, 3)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_everything_can_be_overloaded(validate):
@@ -165,7 +165,7 @@ def test_everything_can_be_overloaded(validate):
         combined(1, 2, 3)
         combined(1, 2, 3, 4)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
     # If we have tket installed, we can even overload circuits
     try:
@@ -193,7 +193,7 @@ def test_everything_can_be_overloaded(validate):
             combined(q)
             combined(qs)
 
-        validate(main.compile(entrypoint=False))
+        validate(main.compile_function())
 
     except ImportError:
         pass

--- a/tests/integration/test_panic.py
+++ b/tests/integration/test_panic.py
@@ -35,9 +35,9 @@ def test_value(validate):
     def baz() -> None:
         return panic("I panicked!")
 
-    validate(foo.compile())
-    validate(bar.compile())
-    validate(baz.compile())
+    validate(foo.compile(entrypoint=False))
+    validate(bar.compile(entrypoint=False))
+    validate(baz.compile(entrypoint=False))
 
 
 def test_py_message(validate):
@@ -54,7 +54,7 @@ def test_comptime_panic(validate):
     def main() -> None:
         panic("foo")
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_comptime_exit(validate):
@@ -62,4 +62,4 @@ def test_comptime_exit(validate):
     def main() -> None:
         exit("foo", 1)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))

--- a/tests/integration/test_panic.py
+++ b/tests/integration/test_panic.py
@@ -35,9 +35,9 @@ def test_value(validate):
     def baz() -> None:
         return panic("I panicked!")
 
-    validate(foo.compile(entrypoint=False))
-    validate(bar.compile(entrypoint=False))
-    validate(baz.compile(entrypoint=False))
+    validate(foo.compile_function())
+    validate(bar.compile_function())
+    validate(baz.compile_function())
 
 
 def test_py_message(validate):
@@ -54,7 +54,7 @@ def test_comptime_panic(validate):
     def main() -> None:
         panic("foo")
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_comptime_exit(validate):
@@ -62,4 +62,4 @@ def test_comptime_exit(validate):
     def main() -> None:
         exit("foo", 1)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())

--- a/tests/integration/test_poly.py
+++ b/tests/integration/test_poly.py
@@ -24,7 +24,7 @@ def test_id(validate):
     def main(x: int) -> int:
         return foo(x)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_id_nested(validate):
@@ -37,7 +37,7 @@ def test_id_nested(validate):
     def main(x: int) -> int:
         return foo(foo(foo(x)))
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_use_twice(validate):
@@ -51,7 +51,7 @@ def test_use_twice(validate):
         foo(x)
         foo(y)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_define_twice(validate):
@@ -69,7 +69,7 @@ def test_define_twice(validate):
         foo(x)
         foo(y)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_return_tuple_implicit(validate):
@@ -82,7 +82,7 @@ def test_return_tuple_implicit(validate):
     def main(x: int) -> tuple[int, int]:
         return foo((x, 0))
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_same_args(validate):
@@ -95,7 +95,7 @@ def test_same_args(validate):
     def main(x: int) -> None:
         foo(x, 42)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_different_args(validate):
@@ -109,7 +109,7 @@ def test_different_args(validate):
     def main(x: int, y: float) -> float:
         return foo(x, y, (x, y)) + foo(y, 42.0, (0.0, y))
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_nat_args(validate):
@@ -122,7 +122,7 @@ def test_nat_args(validate):
     def main(x: array[int, 42]) -> array[int, 42]:
         return foo(x)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_infer_basic(validate):
@@ -135,7 +135,7 @@ def test_infer_basic(validate):
     def main() -> None:
         x: int = foo()
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_infer_list(validate):
@@ -149,7 +149,7 @@ def test_infer_list(validate):
         xs: list[int] = [foo()]
         ys = [1.0, foo()]
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_infer_nested(validate):
@@ -165,7 +165,7 @@ def test_infer_nested(validate):
     def main() -> None:
         x: int = bar(foo())
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_infer_left_to_right(validate):
@@ -182,7 +182,7 @@ def test_infer_left_to_right(validate):
     def main() -> None:
         bar(42, foo(), False, foo())
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_type_apply_basic(validate):
@@ -202,7 +202,7 @@ def test_type_apply_basic(validate):
         z = bar[float, int](y, x)
         return x, y, z
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_type_apply_higher_order(validate):
@@ -225,7 +225,7 @@ def test_type_apply_higher_order(validate):
         z = h(y, x)
         return x, y, z
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_type_apply_nat(validate):
@@ -238,7 +238,7 @@ def test_type_apply_nat(validate):
     def main() -> int:
         return foo[0](array()) + foo[2](array(1, 2))
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_type_apply_empty_tuple(validate):
@@ -252,7 +252,7 @@ def test_type_apply_empty_tuple(validate):
         # `()` is the type of an empty tuple (`tuple[]` is not syntactically valid)
         foo[()]
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_type_apply_method(validate):
@@ -268,7 +268,7 @@ def test_type_apply_method(validate):
     def main(s: MyStruct[int]) -> None:
         s.foo[int]()
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_pass_poly_basic(validate):
@@ -284,7 +284,7 @@ def test_pass_poly_basic(validate):
     def main() -> None:
         foo(bar)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_pass_poly_cross(validate):
@@ -301,7 +301,7 @@ def test_pass_poly_cross(validate):
     def main() -> None:
         foo(bar)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_linear(validate):
@@ -314,7 +314,7 @@ def test_linear(validate):
     def main(q: qubit) -> qubit:
         return foo(q)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_affine(validate):
@@ -327,7 +327,7 @@ def test_affine(validate):
     def main(a: array[int, 7]) -> None:
         foo(a)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_relevant(validate):
@@ -344,7 +344,7 @@ def test_relevant(validate):
         r_copy = r
         return foo(r_copy)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_pass_nonlinear(validate):
@@ -357,7 +357,7 @@ def test_pass_nonlinear(validate):
     def main(x: int) -> None:
         foo(x)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_pass_linear(validate):
@@ -373,7 +373,7 @@ def test_pass_linear(validate):
     def main() -> None:
         foo(bar)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_custom_higher_order():
@@ -407,4 +407,4 @@ def test_higher_order_value(validate):
         f = foo if b else bar
         return f(42)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())

--- a/tests/integration/test_poly.py
+++ b/tests/integration/test_poly.py
@@ -24,7 +24,7 @@ def test_id(validate):
     def main(x: int) -> int:
         return foo(x)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_id_nested(validate):
@@ -37,7 +37,7 @@ def test_id_nested(validate):
     def main(x: int) -> int:
         return foo(foo(foo(x)))
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_use_twice(validate):
@@ -51,7 +51,7 @@ def test_use_twice(validate):
         foo(x)
         foo(y)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_define_twice(validate):
@@ -69,7 +69,7 @@ def test_define_twice(validate):
         foo(x)
         foo(y)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_return_tuple_implicit(validate):
@@ -82,7 +82,7 @@ def test_return_tuple_implicit(validate):
     def main(x: int) -> tuple[int, int]:
         return foo((x, 0))
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_same_args(validate):
@@ -95,7 +95,7 @@ def test_same_args(validate):
     def main(x: int) -> None:
         foo(x, 42)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_different_args(validate):
@@ -109,7 +109,7 @@ def test_different_args(validate):
     def main(x: int, y: float) -> float:
         return foo(x, y, (x, y)) + foo(y, 42.0, (0.0, y))
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_nat_args(validate):
@@ -122,7 +122,7 @@ def test_nat_args(validate):
     def main(x: array[int, 42]) -> array[int, 42]:
         return foo(x)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_infer_basic(validate):
@@ -135,7 +135,7 @@ def test_infer_basic(validate):
     def main() -> None:
         x: int = foo()
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_infer_list(validate):
@@ -149,7 +149,7 @@ def test_infer_list(validate):
         xs: list[int] = [foo()]
         ys = [1.0, foo()]
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_infer_nested(validate):
@@ -165,7 +165,7 @@ def test_infer_nested(validate):
     def main() -> None:
         x: int = bar(foo())
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_infer_left_to_right(validate):
@@ -182,7 +182,7 @@ def test_infer_left_to_right(validate):
     def main() -> None:
         bar(42, foo(), False, foo())
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_type_apply_basic(validate):
@@ -202,7 +202,7 @@ def test_type_apply_basic(validate):
         z = bar[float, int](y, x)
         return x, y, z
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_type_apply_higher_order(validate):
@@ -225,7 +225,7 @@ def test_type_apply_higher_order(validate):
         z = h(y, x)
         return x, y, z
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_type_apply_nat(validate):
@@ -238,7 +238,7 @@ def test_type_apply_nat(validate):
     def main() -> int:
         return foo[0](array()) + foo[2](array(1, 2))
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_type_apply_empty_tuple(validate):
@@ -252,7 +252,7 @@ def test_type_apply_empty_tuple(validate):
         # `()` is the type of an empty tuple (`tuple[]` is not syntactically valid)
         foo[()]
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_type_apply_method(validate):
@@ -268,7 +268,7 @@ def test_type_apply_method(validate):
     def main(s: MyStruct[int]) -> None:
         s.foo[int]()
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_pass_poly_basic(validate):
@@ -284,7 +284,7 @@ def test_pass_poly_basic(validate):
     def main() -> None:
         foo(bar)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_pass_poly_cross(validate):
@@ -301,7 +301,7 @@ def test_pass_poly_cross(validate):
     def main() -> None:
         foo(bar)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_linear(validate):
@@ -314,7 +314,7 @@ def test_linear(validate):
     def main(q: qubit) -> qubit:
         return foo(q)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_affine(validate):
@@ -327,7 +327,7 @@ def test_affine(validate):
     def main(a: array[int, 7]) -> None:
         foo(a)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_relevant(validate):
@@ -344,7 +344,7 @@ def test_relevant(validate):
         r_copy = r
         return foo(r_copy)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_pass_nonlinear(validate):
@@ -357,7 +357,7 @@ def test_pass_nonlinear(validate):
     def main(x: int) -> None:
         foo(x)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_pass_linear(validate):
@@ -373,7 +373,7 @@ def test_pass_linear(validate):
     def main() -> None:
         foo(bar)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_custom_higher_order():
@@ -407,4 +407,4 @@ def test_higher_order_value(validate):
         f = foo if b else bar
         return f(42)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))

--- a/tests/integration/test_poly_const.py
+++ b/tests/integration/test_poly_const.py
@@ -40,7 +40,7 @@ def test_bool(validate, run_int_fn):
             s += 10000
         return s
 
-    compiled = main.compile()
+    compiled = main.compile(entrypoint=False)
     validate(compiled)
 
     # Check we have main, and 2 monomorphizations of foo (Dummy constructor is inlined)
@@ -76,7 +76,7 @@ def test_int(validate):
             + foo[1](Dummy())
         )
 
-    compiled = main.compile()
+    compiled = main.compile(entrypoint=False)
     validate(compiled)
 
     # Check we have main, and 4 monomorphizations of foo (Dummy constructor is inlined)
@@ -108,7 +108,7 @@ def test_float(validate, run_float_fn_approx):
             + foo[1.5](Dummy())
         )
 
-    compiled = main.compile()
+    compiled = main.compile(entrypoint=False)
     validate(compiled)
 
     # Check we have main, and 3 monomorphizations of foo (Dummy constructor is inlined)
@@ -143,7 +143,7 @@ def test_string(validate):
             foo["a"](Dummy()),
         )
 
-    compiled = main.compile()
+    compiled = main.compile(entrypoint=False)
     validate(compiled)
 
     # Check we have main, and 4 monomorphizations of foo (Dummy constructor is inlined)
@@ -185,7 +185,7 @@ def test_chain(validate, run_int_fn):
         d[True](Dummy())
         return 1 if x else 0
 
-    compiled = main.compile()
+    compiled = main.compile(entrypoint=False)
     validate(compiled)
 
     # Check we have main, and 4 monomorphizations (a, b, c, d)
@@ -221,7 +221,7 @@ def test_recursion(validate):
     def main() -> int:
         return baz[True](Dummy())
 
-    compiled = main.compile()
+    compiled = main.compile(entrypoint=False)
     validate(compiled)
 
     # Check we have main, and 5 monomorphizations of foo/bar/baz
@@ -281,7 +281,7 @@ def test_many(validate):
         bar(s3.x3s)
         foo(s3)
 
-    compiled = main.compile()
+    compiled = main.compile(entrypoint=False)
     validate(compiled)
 
     # Check we have main, and 2 monomorphizations of foo and baz each. Note that `s2`
@@ -307,7 +307,7 @@ def test_constructor(validate):
         f1()
         f2()
 
-    compiled = main.compile()
+    compiled = main.compile(entrypoint=False)
     validate(compiled)
 
     # Check we have main, and 2 monomorphizations of the MyStruct constructor
@@ -346,7 +346,7 @@ def test_higher_order(validate):
         foo(fun3[False])
         foo(fun3[True])
 
-    compiled = main.compile()
+    compiled = main.compile(entrypoint=False)
     validate(compiled)
 
     # Check we have main, fun2, and 2 monomorphizations of fun1, fun3, and foo each

--- a/tests/integration/test_poly_const.py
+++ b/tests/integration/test_poly_const.py
@@ -40,7 +40,7 @@ def test_bool(validate, run_int_fn):
             s += 10000
         return s
 
-    compiled = main.compile(entrypoint=False)
+    compiled = main.compile_function()
     validate(compiled)
 
     # Check we have main, and 2 monomorphizations of foo (Dummy constructor is inlined)
@@ -76,7 +76,7 @@ def test_int(validate):
             + foo[1](Dummy())
         )
 
-    compiled = main.compile(entrypoint=False)
+    compiled = main.compile_function()
     validate(compiled)
 
     # Check we have main, and 4 monomorphizations of foo (Dummy constructor is inlined)
@@ -108,7 +108,7 @@ def test_float(validate, run_float_fn_approx):
             + foo[1.5](Dummy())
         )
 
-    compiled = main.compile(entrypoint=False)
+    compiled = main.compile_function()
     validate(compiled)
 
     # Check we have main, and 3 monomorphizations of foo (Dummy constructor is inlined)
@@ -143,7 +143,7 @@ def test_string(validate):
             foo["a"](Dummy()),
         )
 
-    compiled = main.compile(entrypoint=False)
+    compiled = main.compile_function()
     validate(compiled)
 
     # Check we have main, and 4 monomorphizations of foo (Dummy constructor is inlined)
@@ -185,7 +185,7 @@ def test_chain(validate, run_int_fn):
         d[True](Dummy())
         return 1 if x else 0
 
-    compiled = main.compile(entrypoint=False)
+    compiled = main.compile_function()
     validate(compiled)
 
     # Check we have main, and 4 monomorphizations (a, b, c, d)
@@ -221,7 +221,7 @@ def test_recursion(validate):
     def main() -> int:
         return baz[True](Dummy())
 
-    compiled = main.compile(entrypoint=False)
+    compiled = main.compile_function()
     validate(compiled)
 
     # Check we have main, and 5 monomorphizations of foo/bar/baz
@@ -281,7 +281,7 @@ def test_many(validate):
         bar(s3.x3s)
         foo(s3)
 
-    compiled = main.compile(entrypoint=False)
+    compiled = main.compile_function()
     validate(compiled)
 
     # Check we have main, and 2 monomorphizations of foo and baz each. Note that `s2`
@@ -307,7 +307,7 @@ def test_constructor(validate):
         f1()
         f2()
 
-    compiled = main.compile(entrypoint=False)
+    compiled = main.compile_function()
     validate(compiled)
 
     # Check we have main, and 2 monomorphizations of the MyStruct constructor
@@ -346,7 +346,7 @@ def test_higher_order(validate):
         foo(fun3[False])
         foo(fun3[True])
 
-    compiled = main.compile(entrypoint=False)
+    compiled = main.compile_function()
     validate(compiled)
 
     # Check we have main, fun2, and 2 monomorphizations of fun1, fun3, and foo each

--- a/tests/integration/test_poly_def.py
+++ b/tests/integration/test_poly_def.py
@@ -12,7 +12,7 @@ def test_id(validate):
     def identity(x: T) -> T:
         return x
 
-    validate(identity.compile(entrypoint=False))
+    validate(identity.compile_function())
 
 
 def test_nonlinear(validate):
@@ -22,7 +22,7 @@ def test_nonlinear(validate):
     def copy(x: T) -> tuple[T, T]:
         return x, x
 
-    validate(copy.compile(entrypoint=False))
+    validate(copy.compile_function())
 
 
 def test_apply(validate):
@@ -33,7 +33,7 @@ def test_apply(validate):
     def apply(f: Callable[[S], T], x: S) -> T:
         return f(x)
 
-    validate(apply.compile(entrypoint=False))
+    validate(apply.compile_function())
 
 
 def test_annotate(validate):
@@ -44,7 +44,7 @@ def test_annotate(validate):
         y: T = x
         return y
 
-    validate(identity.compile(entrypoint=False))
+    validate(identity.compile_function())
 
 
 def test_recurse(validate):
@@ -54,7 +54,7 @@ def test_recurse(validate):
     def empty() -> T:
         return empty()
 
-    validate(empty.compile(entrypoint=False))
+    validate(empty.compile_function())
 
 
 def test_call(validate):
@@ -68,7 +68,7 @@ def test_call(validate):
     def main() -> float:
         return identity(5) + identity(42.0)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_nat(validate):
@@ -79,7 +79,7 @@ def test_nat(validate):
     def foo(xs: array[T, n] @ owned) -> array[T, n]:
         return xs
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 def test_nat_use(validate):
@@ -89,7 +89,7 @@ def test_nat_use(validate):
     def foo(xs: array[int, n]) -> int:
         return int(n)
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 def test_nat_call(validate):
@@ -104,7 +104,7 @@ def test_nat_call(validate):
     def main() -> tuple[array[int, 10], array[float, 20]]:
         return foo(), foo()
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_nat_recurse(validate):
@@ -114,7 +114,7 @@ def test_nat_recurse(validate):
     def empty() -> array[int, n]:
         return empty()
 
-    validate(empty.compile(entrypoint=False))
+    validate(empty.compile_function())
 
 
 def test_type_apply(validate):
@@ -128,7 +128,7 @@ def test_type_apply(validate):
     def identity(x: array[T, n]) -> array[T, n]:
         return foo[T, n](x)
 
-    validate(identity.compile(entrypoint=False))
+    validate(identity.compile_function())
 
 
 def test_custom_func_higher_order(validate):
@@ -140,4 +140,4 @@ def test_custom_func_higher_order(validate):
         f = nothing[T]
         return f()
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())

--- a/tests/integration/test_poly_def.py
+++ b/tests/integration/test_poly_def.py
@@ -12,7 +12,7 @@ def test_id(validate):
     def identity(x: T) -> T:
         return x
 
-    validate(identity.compile())
+    validate(identity.compile(entrypoint=False))
 
 
 def test_nonlinear(validate):
@@ -22,7 +22,7 @@ def test_nonlinear(validate):
     def copy(x: T) -> tuple[T, T]:
         return x, x
 
-    validate(copy.compile())
+    validate(copy.compile(entrypoint=False))
 
 
 def test_apply(validate):
@@ -33,7 +33,7 @@ def test_apply(validate):
     def apply(f: Callable[[S], T], x: S) -> T:
         return f(x)
 
-    validate(apply.compile())
+    validate(apply.compile(entrypoint=False))
 
 
 def test_annotate(validate):
@@ -44,7 +44,7 @@ def test_annotate(validate):
         y: T = x
         return y
 
-    validate(identity.compile())
+    validate(identity.compile(entrypoint=False))
 
 
 def test_recurse(validate):
@@ -54,7 +54,7 @@ def test_recurse(validate):
     def empty() -> T:
         return empty()
 
-    validate(empty.compile())
+    validate(empty.compile(entrypoint=False))
 
 
 def test_call(validate):
@@ -68,7 +68,7 @@ def test_call(validate):
     def main() -> float:
         return identity(5) + identity(42.0)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_nat(validate):
@@ -79,7 +79,7 @@ def test_nat(validate):
     def foo(xs: array[T, n] @ owned) -> array[T, n]:
         return xs
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 def test_nat_use(validate):
@@ -89,7 +89,7 @@ def test_nat_use(validate):
     def foo(xs: array[int, n]) -> int:
         return int(n)
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 def test_nat_call(validate):
@@ -104,7 +104,7 @@ def test_nat_call(validate):
     def main() -> tuple[array[int, 10], array[float, 20]]:
         return foo(), foo()
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_nat_recurse(validate):
@@ -114,7 +114,7 @@ def test_nat_recurse(validate):
     def empty() -> array[int, n]:
         return empty()
 
-    validate(empty.compile())
+    validate(empty.compile(entrypoint=False))
 
 
 def test_type_apply(validate):
@@ -128,7 +128,7 @@ def test_type_apply(validate):
     def identity(x: array[T, n]) -> array[T, n]:
         return foo[T, n](x)
 
-    validate(identity.compile())
+    validate(identity.compile(entrypoint=False))
 
 
 def test_custom_func_higher_order(validate):
@@ -140,4 +140,4 @@ def test_custom_func_higher_order(validate):
         f = nothing[T]
         return f()
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))

--- a/tests/integration/test_poly_py312.py
+++ b/tests/integration/test_poly_py312.py
@@ -12,7 +12,7 @@ def test_function(validate):
     def main[S, T](x: S @ owned, y: T @ owned) -> tuple[T, S]:
         return y, x
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_struct(validate):
@@ -25,7 +25,7 @@ def test_struct(validate):
     def main(s: MyStruct[int, float]) -> float:
         return s.x + s.y
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_inner_frame(validate):
@@ -56,7 +56,7 @@ def test_copy_bound(validate):
     def main[T: Copy](s: MyStruct[T]) -> tuple[T, T]:
         return s.x, s.x
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_drop_bound(validate):
@@ -68,7 +68,7 @@ def test_drop_bound(validate):
     def main[T: Drop](s: MyStruct[T] @ owned) -> None:
         pass
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_copy_and_drop_bound(validate):
@@ -80,7 +80,7 @@ def test_copy_and_drop_bound(validate):
     def main[T: (Copy, Drop)](s1: MyStruct[T], s2: MyStruct[T]) -> tuple[T, T]:
         return s1.x, s1.x
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_const_param(validate):
@@ -92,7 +92,7 @@ def test_const_param(validate):
     def main[T, n: nat](xs: array[T, n], s: MyStruct[T, n]) -> nat:
         return n
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_mixed_legacy_params(validate):
@@ -102,7 +102,7 @@ def test_mixed_legacy_params(validate):
     def main[S](x: S @ owned, y: T @ owned) -> tuple[T, S]:
         return y, x
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_reference_inside(validate):
@@ -111,4 +111,4 @@ def test_reference_inside(validate):
         x: Option[T] = nothing()
         nothing[T]()
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))

--- a/tests/integration/test_poly_py312.py
+++ b/tests/integration/test_poly_py312.py
@@ -12,7 +12,7 @@ def test_function(validate):
     def main[S, T](x: S @ owned, y: T @ owned) -> tuple[T, S]:
         return y, x
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_struct(validate):
@@ -25,7 +25,7 @@ def test_struct(validate):
     def main(s: MyStruct[int, float]) -> float:
         return s.x + s.y
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_inner_frame(validate):
@@ -56,7 +56,7 @@ def test_copy_bound(validate):
     def main[T: Copy](s: MyStruct[T]) -> tuple[T, T]:
         return s.x, s.x
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_drop_bound(validate):
@@ -68,7 +68,7 @@ def test_drop_bound(validate):
     def main[T: Drop](s: MyStruct[T] @ owned) -> None:
         pass
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_copy_and_drop_bound(validate):
@@ -80,7 +80,7 @@ def test_copy_and_drop_bound(validate):
     def main[T: (Copy, Drop)](s1: MyStruct[T], s2: MyStruct[T]) -> tuple[T, T]:
         return s1.x, s1.x
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_const_param(validate):
@@ -92,7 +92,7 @@ def test_const_param(validate):
     def main[T, n: nat](xs: array[T, n], s: MyStruct[T, n]) -> nat:
         return n
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_mixed_legacy_params(validate):
@@ -102,7 +102,7 @@ def test_mixed_legacy_params(validate):
     def main[S](x: S @ owned, y: T @ owned) -> tuple[T, S]:
         return y, x
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_reference_inside(validate):
@@ -111,4 +111,4 @@ def test_reference_inside(validate):
         x: Option[T] = nothing()
         nothing[T]()
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())

--- a/tests/integration/test_programs.py
+++ b/tests/integration/test_programs.py
@@ -22,9 +22,9 @@ def test_factorial(validate):
             return acc
         return factorial3(x - 1, acc * x)
 
-    validate(factorial1.compile(entrypoint=False), name="factorial1")
-    validate(factorial2.compile(entrypoint=False), name="factorial2")
-    validate(factorial3.compile(entrypoint=False), name="factorial3")
+    validate(factorial1.compile_function(), name="factorial1")
+    validate(factorial2.compile_function(), name="factorial2")
+    validate(factorial3.compile_function(), name="factorial3")
 
 
 def test_even_odd(validate):
@@ -40,5 +40,5 @@ def test_even_odd(validate):
             return False
         return is_even(x - 1)
 
-    validate(is_odd.compile(entrypoint=False))
-    validate(is_even.compile(entrypoint=False))
+    validate(is_odd.compile_function())
+    validate(is_even.compile_function())

--- a/tests/integration/test_programs.py
+++ b/tests/integration/test_programs.py
@@ -22,9 +22,9 @@ def test_factorial(validate):
             return acc
         return factorial3(x - 1, acc * x)
 
-    validate(factorial1.compile(), name="factorial1")
-    validate(factorial2.compile(), name="factorial2")
-    validate(factorial3.compile(), name="factorial3")
+    validate(factorial1.compile(entrypoint=False), name="factorial1")
+    validate(factorial2.compile(entrypoint=False), name="factorial2")
+    validate(factorial3.compile(entrypoint=False), name="factorial3")
 
 
 def test_even_odd(validate):
@@ -40,5 +40,5 @@ def test_even_odd(validate):
             return False
         return is_even(x - 1)
 
-    validate(is_odd.compile())
-    validate(is_even.compile())
+    validate(is_odd.compile(entrypoint=False))
+    validate(is_even.compile(entrypoint=False))

--- a/tests/integration/test_pytket_circuits.py
+++ b/tests/integration/test_pytket_circuits.py
@@ -26,7 +26,7 @@ def test_single_qubit_circuit(validate):
     def foo(q: qubit) -> None:
         guppy_circ(q)
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -44,7 +44,7 @@ def test_multi_qubit_circuit(validate):
     def foo(q1: qubit, q2: qubit) -> None:
         guppy_circ(q1, q2)
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -62,7 +62,7 @@ def test_measure(validate):
     def foo(q: qubit) -> bool:
         return guppy_circ(q)
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -80,7 +80,7 @@ def test_measure_multiple(validate):
     def foo(q1: qubit, q2: qubit) -> tuple[bool, bool]:
         return guppy_circ(q1, q2)
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -99,7 +99,7 @@ def test_measure_not_last(validate):
     def foo(q: qubit) -> bool:
         return guppy_circ(q)
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -115,7 +115,7 @@ def test_load_circuit(validate):
     def foo(q: qubit) -> None:
         guppy_circ(q)
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -137,7 +137,7 @@ def test_load_circuits(validate):
         guppy_circ1(q1)
         return guppy_circ2(q2, q3)
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -154,7 +154,7 @@ def test_measure_some(validate):
     def foo(q1: qubit, q2: qubit) -> bool:
         return guppy_circ(q1, q2)
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -169,7 +169,7 @@ def test_register_arrays_default(validate):
     def foo(default_reg: array[qubit, 2]) -> None:
         return guppy_circ(default_reg)
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -188,7 +188,7 @@ def test_register_arrays(validate):
         # lexicographically.
         return guppy_circ(extra_reg, default_reg)
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -214,7 +214,7 @@ def test_register_arrays_multiple_measure(validate):
         discard_array(extra_reg2)
         return result
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -234,7 +234,7 @@ def test_register_arrays_mixed(validate):
     ) -> tuple[array[bool, 1], array[bool, 3]]:
         return guppy_circ(q, q2)
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -247,7 +247,7 @@ def test_compile_sig(validate):
     @guppy.pytket(circ)
     def guppy_circ(q1: qubit) -> None: ...
 
-    validate(guppy_circ.compile())
+    validate(guppy_circ.compile(entrypoint=False))
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -259,7 +259,7 @@ def test_compile_load(validate):
 
     pytket_func = guppy.load_pytket("guppy_circ", circ, use_arrays=False)
 
-    validate(pytket_func.compile())
+    validate(pytket_func.compile(entrypoint=False))
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -286,7 +286,7 @@ def test_symbolic(validate):
         beta = angle(1.2)
         return guppy_circ(q1, q2, alpha, beta)
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -312,7 +312,7 @@ def test_symbolic_array(validate):
         params = array(angle(0.3), angle(1.2))
         return guppy_circ(reg, params)
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -338,7 +338,7 @@ def test_symbolic_exec(validate, run_int_fn):
         discard(q)
         return res
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
     run_int_fn(main, 1, num_qubits=2)
 
 
@@ -366,7 +366,7 @@ def test_exec(validate, run_int_fn):
         discard(q2)
         return int(res[0])
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
     run_int_fn(main, 1, num_qubits=2)
 
 
@@ -386,7 +386,7 @@ def test_qsystem_ops(validate):
     def foo(q1: qubit, q2: qubit) -> None:
         guppy_circ(q1, q2)
 
-    compiled = foo.compile()
+    compiled = foo.compile(entrypoint=False)
     validate(compiled)
 
     # Assert that we have no opaque (unrecognised) tket1 operations

--- a/tests/integration/test_pytket_circuits.py
+++ b/tests/integration/test_pytket_circuits.py
@@ -26,7 +26,7 @@ def test_single_qubit_circuit(validate):
     def foo(q: qubit) -> None:
         guppy_circ(q)
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -44,7 +44,7 @@ def test_multi_qubit_circuit(validate):
     def foo(q1: qubit, q2: qubit) -> None:
         guppy_circ(q1, q2)
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -62,7 +62,7 @@ def test_measure(validate):
     def foo(q: qubit) -> bool:
         return guppy_circ(q)
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -80,7 +80,7 @@ def test_measure_multiple(validate):
     def foo(q1: qubit, q2: qubit) -> tuple[bool, bool]:
         return guppy_circ(q1, q2)
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -99,7 +99,7 @@ def test_measure_not_last(validate):
     def foo(q: qubit) -> bool:
         return guppy_circ(q)
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -115,7 +115,7 @@ def test_load_circuit(validate):
     def foo(q: qubit) -> None:
         guppy_circ(q)
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -137,7 +137,7 @@ def test_load_circuits(validate):
         guppy_circ1(q1)
         return guppy_circ2(q2, q3)
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -154,7 +154,7 @@ def test_measure_some(validate):
     def foo(q1: qubit, q2: qubit) -> bool:
         return guppy_circ(q1, q2)
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -169,7 +169,7 @@ def test_register_arrays_default(validate):
     def foo(default_reg: array[qubit, 2]) -> None:
         return guppy_circ(default_reg)
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -188,7 +188,7 @@ def test_register_arrays(validate):
         # lexicographically.
         return guppy_circ(extra_reg, default_reg)
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -214,7 +214,7 @@ def test_register_arrays_multiple_measure(validate):
         discard_array(extra_reg2)
         return result
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -234,7 +234,7 @@ def test_register_arrays_mixed(validate):
     ) -> tuple[array[bool, 1], array[bool, 3]]:
         return guppy_circ(q, q2)
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -247,7 +247,7 @@ def test_compile_sig(validate):
     @guppy.pytket(circ)
     def guppy_circ(q1: qubit) -> None: ...
 
-    validate(guppy_circ.compile(entrypoint=False))
+    validate(guppy_circ.compile_function())
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -259,7 +259,7 @@ def test_compile_load(validate):
 
     pytket_func = guppy.load_pytket("guppy_circ", circ, use_arrays=False)
 
-    validate(pytket_func.compile(entrypoint=False))
+    validate(pytket_func.compile_function())
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -286,7 +286,7 @@ def test_symbolic(validate):
         beta = angle(1.2)
         return guppy_circ(q1, q2, alpha, beta)
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -312,7 +312,7 @@ def test_symbolic_array(validate):
         params = array(angle(0.3), angle(1.2))
         return guppy_circ(reg, params)
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 @pytest.mark.skipif(not tket_installed, reason="Tket is not installed")
@@ -338,7 +338,7 @@ def test_symbolic_exec(validate, run_int_fn):
         discard(q)
         return res
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
     run_int_fn(main, 1, num_qubits=2)
 
 
@@ -366,7 +366,7 @@ def test_exec(validate, run_int_fn):
         discard(q2)
         return int(res[0])
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
     run_int_fn(main, 1, num_qubits=2)
 
 
@@ -386,7 +386,7 @@ def test_qsystem_ops(validate):
     def foo(q1: qubit, q2: qubit) -> None:
         guppy_circ(q1, q2)
 
-    compiled = foo.compile(entrypoint=False)
+    compiled = foo.compile_function()
     validate(compiled)
 
     # Assert that we have no opaque (unrecognised) tket1 operations

--- a/tests/integration/test_qsystem.py
+++ b/tests/integration/test_qsystem.py
@@ -34,7 +34,7 @@ def test_qsystem(validate):  # type: ignore[no-untyped-def]
         qfree(q2)
         return b
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_qsystem_random(validate):  # type: ignore[no-untyped-def]
@@ -57,7 +57,7 @@ def test_qsystem_random(validate):  # type: ignore[no-untyped-def]
 
         return rint, rfloat, rint_bnd, rint_discrete, rangle, rcangle
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_measure_leaked(validate):  # type: ignore[no-untyped-def]
@@ -72,4 +72,4 @@ def test_measure_leaked(validate):  # type: ignore[no-untyped-def]
         b: bool = ml.to_result().unwrap()
         return b
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())

--- a/tests/integration/test_qsystem.py
+++ b/tests/integration/test_qsystem.py
@@ -34,7 +34,7 @@ def test_qsystem(validate):  # type: ignore[no-untyped-def]
         qfree(q2)
         return b
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_qsystem_random(validate):  # type: ignore[no-untyped-def]
@@ -57,7 +57,7 @@ def test_qsystem_random(validate):  # type: ignore[no-untyped-def]
 
         return rint, rfloat, rint_bnd, rint_discrete, rangle, rcangle
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_measure_leaked(validate):  # type: ignore[no-untyped-def]
@@ -72,4 +72,4 @@ def test_measure_leaked(validate):  # type: ignore[no-untyped-def]
         b: bool = ml.to_result().unwrap()
         return b
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))

--- a/tests/integration/test_quantum.py
+++ b/tests/integration/test_quantum.py
@@ -49,7 +49,7 @@ def test_alloc(validate):
         q1, q2 = cx(q1, q2)
         return (measure(q1), measure(q2))
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_1qb_op(validate):
@@ -67,7 +67,7 @@ def test_1qb_op(validate):
         q = vdg(q)
         return q
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_2qb_op(validate):
@@ -79,7 +79,7 @@ def test_2qb_op(validate):
         q1, q2 = ch(q1, q2)
         return (q1, q2)
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_3qb_op(validate):
@@ -90,7 +90,7 @@ def test_3qb_op(validate):
         q1, q2, q3 = toffoli(q1, q2, q3)
         return (q1, q2, q3)
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_measure_ops(validate):
@@ -104,7 +104,7 @@ def test_measure_ops(validate):
         b2 = measure(q2)
         return (b1, b2)
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_parametric(validate):
@@ -129,7 +129,7 @@ def test_measure_array(validate):
         qs = array(qubit() for _ in range(10))
         return measure_array(qs)
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_discard_array(validate):
@@ -140,7 +140,7 @@ def test_discard_array(validate):
         qs = array(qubit() for _ in range(10))
         discard_array(qs)
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_panic_discard(validate):
@@ -152,7 +152,7 @@ def test_panic_discard(validate):
         q = qubit()
         panic("I panicked!", q)
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_barrier(validate):
@@ -178,7 +178,7 @@ def test_barrier(validate):
         discard(q3)
         discard(q4)
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_barrier_array(validate):
@@ -200,7 +200,7 @@ def test_barrier_array(validate):
         barrier(qs)
         discard_array(qs)
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_barrier_struct(validate):
@@ -232,7 +232,7 @@ def test_barrier_struct(validate):
         discard(qs.q3)
         discard(qs.q4)
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_barrier_misc(validate):
@@ -249,4 +249,4 @@ def test_barrier_misc(validate):
         result("c", x)
         result("c2", measure(q1))
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())

--- a/tests/integration/test_quantum.py
+++ b/tests/integration/test_quantum.py
@@ -49,7 +49,7 @@ def test_alloc(validate):
         q1, q2 = cx(q1, q2)
         return (measure(q1), measure(q2))
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_1qb_op(validate):
@@ -67,7 +67,7 @@ def test_1qb_op(validate):
         q = vdg(q)
         return q
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_2qb_op(validate):
@@ -79,7 +79,7 @@ def test_2qb_op(validate):
         q1, q2 = ch(q1, q2)
         return (q1, q2)
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_3qb_op(validate):
@@ -90,7 +90,7 @@ def test_3qb_op(validate):
         q1, q2, q3 = toffoli(q1, q2, q3)
         return (q1, q2, q3)
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_measure_ops(validate):
@@ -104,7 +104,7 @@ def test_measure_ops(validate):
         b2 = measure(q2)
         return (b1, b2)
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_parametric(validate):
@@ -129,7 +129,7 @@ def test_measure_array(validate):
         qs = array(qubit() for _ in range(10))
         return measure_array(qs)
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_discard_array(validate):
@@ -140,7 +140,7 @@ def test_discard_array(validate):
         qs = array(qubit() for _ in range(10))
         discard_array(qs)
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_panic_discard(validate):
@@ -152,7 +152,7 @@ def test_panic_discard(validate):
         q = qubit()
         panic("I panicked!", q)
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_barrier(validate):
@@ -178,7 +178,7 @@ def test_barrier(validate):
         discard(q3)
         discard(q4)
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_barrier_array(validate):
@@ -200,7 +200,7 @@ def test_barrier_array(validate):
         barrier(qs)
         discard_array(qs)
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_barrier_struct(validate):
@@ -232,7 +232,7 @@ def test_barrier_struct(validate):
         discard(qs.q3)
         discard(qs.q4)
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_barrier_misc(validate):
@@ -249,4 +249,4 @@ def test_barrier_misc(validate):
         result("c", x)
         result("c2", measure(q1))
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))

--- a/tests/integration/test_range.py
+++ b/tests/integration/test_range.py
@@ -42,7 +42,7 @@ def test_static_size(validate):
     def negative() -> SizedIter[Range, 10]:
         return range(10)
 
-    validate(negative.compile(entrypoint=False))
+    validate(negative.compile_function())
 
 
 def test_py_size(validate):
@@ -52,7 +52,7 @@ def test_py_size(validate):
     def negative() -> SizedIter[Range, 10]:
         return range(py(n))
 
-    validate(negative.compile(entrypoint=False))
+    validate(negative.compile_function())
 
 
 def test_static_generic_size(validate):
@@ -62,4 +62,4 @@ def test_static_generic_size(validate):
     def negative() -> SizedIter[Range, n]:
         return range(n)
 
-    validate(negative.compile(entrypoint=False))
+    validate(negative.compile_function())

--- a/tests/integration/test_range.py
+++ b/tests/integration/test_range.py
@@ -42,7 +42,7 @@ def test_static_size(validate):
     def negative() -> SizedIter[Range, 10]:
         return range(10)
 
-    validate(negative.compile())
+    validate(negative.compile(entrypoint=False))
 
 
 def test_py_size(validate):
@@ -52,7 +52,7 @@ def test_py_size(validate):
     def negative() -> SizedIter[Range, 10]:
         return range(py(n))
 
-    validate(negative.compile())
+    validate(negative.compile(entrypoint=False))
 
 
 def test_static_generic_size(validate):
@@ -62,4 +62,4 @@ def test_static_generic_size(validate):
     def negative() -> SizedIter[Range, n]:
         return range(n)
 
-    validate(negative.compile())
+    validate(negative.compile(entrypoint=False))

--- a/tests/integration/test_redefinition.py
+++ b/tests/integration/test_redefinition.py
@@ -13,7 +13,7 @@ def test_func_redefinition(validate):
     def test() -> bool:  # noqa: F811
         return False
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_method_redefinition(validate):
@@ -33,7 +33,7 @@ def test_method_redefinition(validate):
     def main(t: Test) -> int:
         return t.foo()
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_redefine_after_error(validate):
@@ -46,7 +46,7 @@ def test_redefine_after_error(validate):
         return y  # noqa: F821
 
     with pytest.raises(GuppyError):
-        foo.compile(entrypoint=False)
+        foo.compile_function()
 
     @guppy.struct
     class Foo:  # noqa: F811
@@ -56,7 +56,7 @@ def test_redefine_after_error(validate):
     def foo(f: Foo) -> int:
         return f.x
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 @pytest.mark.skip("See https://github.com/CQCL/guppylang/issues/456")
@@ -73,7 +73,7 @@ def test_struct_redefinition(validate):
     def main(x: int) -> Test:
         return Test(x)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 @pytest.mark.skip("See https://github.com/CQCL/guppylang/issues/456")
@@ -98,4 +98,4 @@ def test_struct_method_redefinition(validate):
     def main(x: int) -> int:
         return Test(x).bar()
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())

--- a/tests/integration/test_redefinition.py
+++ b/tests/integration/test_redefinition.py
@@ -13,7 +13,7 @@ def test_func_redefinition(validate):
     def test() -> bool:  # noqa: F811
         return False
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_method_redefinition(validate):
@@ -33,7 +33,7 @@ def test_method_redefinition(validate):
     def main(t: Test) -> int:
         return t.foo()
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_redefine_after_error(validate):
@@ -46,7 +46,7 @@ def test_redefine_after_error(validate):
         return y  # noqa: F821
 
     with pytest.raises(GuppyError):
-        foo.compile()
+        foo.compile(entrypoint=False)
 
     @guppy.struct
     class Foo:  # noqa: F811
@@ -56,7 +56,7 @@ def test_redefine_after_error(validate):
     def foo(f: Foo) -> int:
         return f.x
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 @pytest.mark.skip("See https://github.com/CQCL/guppylang/issues/456")
@@ -73,7 +73,7 @@ def test_struct_redefinition(validate):
     def main(x: int) -> Test:
         return Test(x)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 @pytest.mark.skip("See https://github.com/CQCL/guppylang/issues/456")
@@ -98,4 +98,4 @@ def test_struct_method_redefinition(validate):
     def main(x: int) -> int:
         return Test(x).bar()
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))

--- a/tests/integration/test_result.py
+++ b/tests/integration/test_result.py
@@ -47,7 +47,7 @@ def test_array_generic(validate):
         result("c", y)
         result("d", z)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_array_drop_after_result(validate):
@@ -87,7 +87,7 @@ def test_comptime_tag_outside1(validate):
         for key, value in EXAMPLE_RESULTS:
             result(key, value)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_comptime_tag_outside2(validate):
@@ -97,4 +97,4 @@ def test_comptime_tag_outside2(validate):
     def main() -> None:
         result(EXAMPLE_RESULT[0], EXAMPLE_RESULT[1])
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())

--- a/tests/integration/test_result.py
+++ b/tests/integration/test_result.py
@@ -47,7 +47,7 @@ def test_array_generic(validate):
         result("c", y)
         result("d", z)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_array_drop_after_result(validate):
@@ -87,7 +87,7 @@ def test_comptime_tag_outside1(validate):
         for key, value in EXAMPLE_RESULTS:
             result(key, value)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_comptime_tag_outside2(validate):
@@ -97,4 +97,4 @@ def test_comptime_tag_outside2(validate):
     def main() -> None:
         result(EXAMPLE_RESULT[0], EXAMPLE_RESULT[1])
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))

--- a/tests/integration/test_self.py
+++ b/tests/integration/test_self.py
@@ -15,7 +15,7 @@ def test_implicit_self(validate):
     def main(s: MyStruct) -> None:
         s.foo()
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_implicit_self_generic(validate):
@@ -35,7 +35,7 @@ def test_implicit_self_generic(validate):
     def main(s: MyStruct[int, float]) -> int:
         return s.foo(1.5)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_explicit_self(validate):
@@ -49,7 +49,7 @@ def test_explicit_self(validate):
     def main(s: MyStruct) -> MyStruct:
         return s.foo(s).foo(s.foo(MyStruct()))
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_explicit_self_generic(validate):
@@ -67,7 +67,7 @@ def test_explicit_self_generic(validate):
     def main(s: MyStruct[int]) -> None:
         s.foo().foo()
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_more_generic(validate):
@@ -92,4 +92,4 @@ def test_more_generic(validate):
         a, b = s.foo(a, s.x)
         return a + b
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())

--- a/tests/integration/test_self.py
+++ b/tests/integration/test_self.py
@@ -15,7 +15,7 @@ def test_implicit_self(validate):
     def main(s: MyStruct) -> None:
         s.foo()
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_implicit_self_generic(validate):
@@ -35,7 +35,7 @@ def test_implicit_self_generic(validate):
     def main(s: MyStruct[int, float]) -> int:
         return s.foo(1.5)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_explicit_self(validate):
@@ -49,7 +49,7 @@ def test_explicit_self(validate):
     def main(s: MyStruct) -> MyStruct:
         return s.foo(s).foo(s.foo(MyStruct()))
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_explicit_self_generic(validate):
@@ -67,7 +67,7 @@ def test_explicit_self_generic(validate):
     def main(s: MyStruct[int]) -> None:
         s.foo().foo()
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_more_generic(validate):
@@ -92,4 +92,4 @@ def test_more_generic(validate):
         a, b = s.foo(a, s.x)
         return a + b
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))

--- a/tests/integration/test_side_effect_ordering.py
+++ b/tests/integration/test_side_effect_ordering.py
@@ -62,7 +62,7 @@ def test_result_panic(validate):
         exit("Foo!", 1)
         result("c", 10.5)
 
-    compiled = test.compile(entrypoint=False)
+    compiled = test.compile_function()
     validate(compiled)
 
     # Check that we have the expected order edges between the results
@@ -83,7 +83,7 @@ def test_qalloc_qfree(validate):
         q2 = qubit()
         measure(q2)
 
-    compiled = test.compile(entrypoint=False)
+    compiled = test.compile_function()
     validate(compiled)
 
     # Check that we have the expected order edges between the allocations and frees
@@ -109,7 +109,7 @@ def test_call(validate):
         f = my_discard
         f(q2)
 
-    compiled = test.compile(entrypoint=False)
+    compiled = test.compile_function()
     validate(compiled)
 
     # Check that we have the expected order edges between the allocations and calls
@@ -130,7 +130,7 @@ def test_nested(validate):
         qs2 = array(qubit() for _ in range(10))
         array(discard(q) for q in qs2)
 
-    compiled = test.compile(entrypoint=False)
+    compiled = test.compile_function()
     validate(compiled)
 
     # Check that we have the expected order edges between the comprehension tail loops

--- a/tests/integration/test_side_effect_ordering.py
+++ b/tests/integration/test_side_effect_ordering.py
@@ -62,7 +62,7 @@ def test_result_panic(validate):
         exit("Foo!", 1)
         result("c", 10.5)
 
-    compiled = test.compile()
+    compiled = test.compile(entrypoint=False)
     validate(compiled)
 
     # Check that we have the expected order edges between the results
@@ -83,7 +83,7 @@ def test_qalloc_qfree(validate):
         q2 = qubit()
         measure(q2)
 
-    compiled = test.compile()
+    compiled = test.compile(entrypoint=False)
     validate(compiled)
 
     # Check that we have the expected order edges between the allocations and frees
@@ -109,7 +109,7 @@ def test_call(validate):
         f = my_discard
         f(q2)
 
-    compiled = test.compile()
+    compiled = test.compile(entrypoint=False)
     validate(compiled)
 
     # Check that we have the expected order edges between the allocations and calls
@@ -130,7 +130,7 @@ def test_nested(validate):
         qs2 = array(qubit() for _ in range(10))
         array(discard(q) for q in qs2)
 
-    compiled = test.compile()
+    compiled = test.compile(entrypoint=False)
     validate(compiled)
 
     # Check that we have the expected order edges between the comprehension tail loops

--- a/tests/integration/test_state_result.py
+++ b/tests/integration/test_state_result.py
@@ -77,7 +77,7 @@ def test_struct_access(validate):
         discard(qs.q3)
         discard(qs.q4)
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_array(validate):
@@ -101,4 +101,4 @@ def test_generic_array(validate):
         cx(qs[0], qs[1])
         state_result("tag", qs)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))

--- a/tests/integration/test_state_result.py
+++ b/tests/integration/test_state_result.py
@@ -77,7 +77,7 @@ def test_struct_access(validate):
         discard(qs.q3)
         discard(qs.q4)
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_array(validate):
@@ -101,4 +101,4 @@ def test_generic_array(validate):
         cx(qs[0], qs[1])
         state_result("tag", qs)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())

--- a/tests/integration/test_strings.py
+++ b/tests/integration/test_strings.py
@@ -28,4 +28,4 @@ def test_struct(validate):
     def main(s: StringStruct) -> None:
         StringStruct("Lorem Ipsum")
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())

--- a/tests/integration/test_strings.py
+++ b/tests/integration/test_strings.py
@@ -28,4 +28,4 @@ def test_struct(validate):
     def main(s: StringStruct) -> None:
         StringStruct("Lorem Ipsum")
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))

--- a/tests/integration/test_struct.py
+++ b/tests/integration/test_struct.py
@@ -36,7 +36,7 @@ def test_basic_defs(validate):
         TwoMemberStruct((True, 0), 1.0)
         DocstringStruct(-1)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_backward_ref(validate):
@@ -52,7 +52,7 @@ def test_backward_ref(validate):
     def main(a: StructA, b: StructB) -> None:
         StructB(a)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_forward_ref(validate):
@@ -68,7 +68,7 @@ def test_forward_ref(validate):
     def main(a: StructA, b: StructB) -> None:
         StructA(b)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_generic(validate):
@@ -98,7 +98,7 @@ def test_generic(validate):
         StructB(x, a)
         StructC(y, StructA((0, [])), StructB(42.0, StructA((4, b))))
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_methods(validate):
@@ -123,7 +123,7 @@ def test_methods(validate):
     def main(a: StructA, b: StructB) -> tuple[int, float]:
         return a.foo(1), b.bar(a)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_higher_order(validate):
@@ -141,7 +141,7 @@ def test_higher_order(validate):
     def main() -> None:
         factory(Struct, 42)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_wiring(validate):
@@ -157,7 +157,7 @@ def test_wiring(validate):
         s = MyStruct(42)
         return s
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 def test_field_access_and_drop(validate):
@@ -173,7 +173,7 @@ def test_field_access_and_drop(validate):
         # dropping all the other fields
         return MyStruct(42, 3.14, (1, 2)).y
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 def test_redefine(validate):
@@ -191,4 +191,4 @@ def test_redefine(validate):
     def foo() -> MyStruct:
         return MyStruct()
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))

--- a/tests/integration/test_struct.py
+++ b/tests/integration/test_struct.py
@@ -36,7 +36,7 @@ def test_basic_defs(validate):
         TwoMemberStruct((True, 0), 1.0)
         DocstringStruct(-1)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_backward_ref(validate):
@@ -52,7 +52,7 @@ def test_backward_ref(validate):
     def main(a: StructA, b: StructB) -> None:
         StructB(a)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_forward_ref(validate):
@@ -68,7 +68,7 @@ def test_forward_ref(validate):
     def main(a: StructA, b: StructB) -> None:
         StructA(b)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_generic(validate):
@@ -98,7 +98,7 @@ def test_generic(validate):
         StructB(x, a)
         StructC(y, StructA((0, [])), StructB(42.0, StructA((4, b))))
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_methods(validate):
@@ -123,7 +123,7 @@ def test_methods(validate):
     def main(a: StructA, b: StructB) -> tuple[int, float]:
         return a.foo(1), b.bar(a)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_higher_order(validate):
@@ -141,7 +141,7 @@ def test_higher_order(validate):
     def main() -> None:
         factory(Struct, 42)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_wiring(validate):
@@ -157,7 +157,7 @@ def test_wiring(validate):
         s = MyStruct(42)
         return s
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 def test_field_access_and_drop(validate):
@@ -173,7 +173,7 @@ def test_field_access_and_drop(validate):
         # dropping all the other fields
         return MyStruct(42, 3.14, (1, 2)).y
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 def test_redefine(validate):
@@ -191,4 +191,4 @@ def test_redefine(validate):
     def foo() -> MyStruct:
         return MyStruct()
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())

--- a/tests/integration/test_tensor.py
+++ b/tests/integration/test_tensor.py
@@ -31,9 +31,9 @@ def test_check_callable(validate):
     def baz2(x: int) -> bool:
         return (foo,)(is_42)(x)
 
-    validate(baz.compile(entrypoint=False))
-    validate(baz1.compile(entrypoint=False))
-    validate(baz2.compile(entrypoint=False))
+    validate(baz.compile_function())
+    validate(baz1.compile_function())
+    validate(baz2.compile_function())
 
 
 def test_call(validate):
@@ -67,9 +67,9 @@ def test_call(validate):
         g = (foo, bar, f)
         return g()
 
-    validate(baz_ho_call.compile(entrypoint=False))
-    validate(baz.compile(entrypoint=False))
-    validate(call_var.compile(entrypoint=False))
+    validate(baz_ho_call.compile_function())
+    validate(baz.compile_function())
+    validate(call_var.compile_function())
 
 
 def test_call_inplace(validate):
@@ -77,7 +77,7 @@ def test_call_inplace(validate):
     def local(f: Callable[[int], bool], g: Callable[[bool], int]) -> tuple[bool, int]:
         return (f, g)(42, True)
 
-    validate(local.compile(entrypoint=False))
+    validate(local.compile_function())
 
 
 def test_singleton(validate):
@@ -89,7 +89,7 @@ def test_singleton(validate):
     def baz(x: int) -> tuple[int, int]:
         return (foo,)(x, x)
 
-    validate(baz.compile(entrypoint=False))
+    validate(baz.compile_function())
 
 
 def test_call_back(validate):
@@ -110,7 +110,7 @@ def test_call_back(validate):
         f = foo, baz
         return f(x, x, x)
 
-    validate(call_var.compile(entrypoint=False))
+    validate(call_var.compile_function())
 
 
 def test_normal(validate):
@@ -122,7 +122,7 @@ def test_normal(validate):
     def foo(x: int) -> int:
         return glo(x)
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 def test_higher_order(validate):
@@ -153,7 +153,7 @@ def test_higher_order(validate):
     #     def apply_call(args: tuple[int, float]) -> tuple[bool, int]:
     #         return apply(baz, args)
 
-    validate(baz.compile(entrypoint=False))
+    validate(baz.compile_function())
 
 
 def test_nesting(validate):
@@ -170,4 +170,4 @@ def test_nesting(validate):
         f = bar, (bar, foo)
         return f(x, x, x, x)
 
-    validate(call.compile(entrypoint=False))
+    validate(call.compile_function())

--- a/tests/integration/test_tensor.py
+++ b/tests/integration/test_tensor.py
@@ -31,9 +31,9 @@ def test_check_callable(validate):
     def baz2(x: int) -> bool:
         return (foo,)(is_42)(x)
 
-    validate(baz.compile())
-    validate(baz1.compile())
-    validate(baz2.compile())
+    validate(baz.compile(entrypoint=False))
+    validate(baz1.compile(entrypoint=False))
+    validate(baz2.compile(entrypoint=False))
 
 
 def test_call(validate):
@@ -67,9 +67,9 @@ def test_call(validate):
         g = (foo, bar, f)
         return g()
 
-    validate(baz_ho_call.compile())
-    validate(baz.compile())
-    validate(call_var.compile())
+    validate(baz_ho_call.compile(entrypoint=False))
+    validate(baz.compile(entrypoint=False))
+    validate(call_var.compile(entrypoint=False))
 
 
 def test_call_inplace(validate):
@@ -77,7 +77,7 @@ def test_call_inplace(validate):
     def local(f: Callable[[int], bool], g: Callable[[bool], int]) -> tuple[bool, int]:
         return (f, g)(42, True)
 
-    validate(local.compile())
+    validate(local.compile(entrypoint=False))
 
 
 def test_singleton(validate):
@@ -89,7 +89,7 @@ def test_singleton(validate):
     def baz(x: int) -> tuple[int, int]:
         return (foo,)(x, x)
 
-    validate(baz.compile())
+    validate(baz.compile(entrypoint=False))
 
 
 def test_call_back(validate):
@@ -110,7 +110,7 @@ def test_call_back(validate):
         f = foo, baz
         return f(x, x, x)
 
-    validate(call_var.compile())
+    validate(call_var.compile(entrypoint=False))
 
 
 def test_normal(validate):
@@ -122,7 +122,7 @@ def test_normal(validate):
     def foo(x: int) -> int:
         return glo(x)
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 def test_higher_order(validate):
@@ -153,7 +153,7 @@ def test_higher_order(validate):
     #     def apply_call(args: tuple[int, float]) -> tuple[bool, int]:
     #         return apply(baz, args)
 
-    validate(baz.compile())
+    validate(baz.compile(entrypoint=False))
 
 
 def test_nesting(validate):
@@ -170,4 +170,4 @@ def test_nesting(validate):
         f = bar, (bar, foo)
         return f(x, x, x, x)
 
-    validate(call.compile())
+    validate(call.compile(entrypoint=False))

--- a/tests/integration/test_tuples.py
+++ b/tests/integration/test_tuples.py
@@ -18,7 +18,7 @@ def test_indexing_input(validate):
     def main(t: tuple[int, float]) -> int:
         return t[0]
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_indexing_drop(run_int_fn):
@@ -34,7 +34,7 @@ def test_indexing_drop2(validate):
     def main() -> qubit:
         return (1, 2, qubit())[2]
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_indexing_nesting(run_int_fn):
@@ -69,7 +69,7 @@ def test_rest_after_use(validate):
         use(t[1])
         return t[0]
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_control_flow(validate):
@@ -83,7 +83,7 @@ def test_control_flow(validate):
         discard(t[0])
         discard(t[1])
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 def test_control_flow2(validate):
@@ -96,7 +96,7 @@ def test_control_flow2(validate):
             discard(q1)
             discard(q2)
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 def test_mem_swap(validate):
@@ -115,7 +115,7 @@ def test_mem_swap(validate):
         discard(t[0])
         discard(t[1])
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 def test_non_terminating(validate):
@@ -124,4 +124,4 @@ def test_non_terminating(validate):
         while True:
             x(t[0])
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))

--- a/tests/integration/test_tuples.py
+++ b/tests/integration/test_tuples.py
@@ -18,7 +18,7 @@ def test_indexing_input(validate):
     def main(t: tuple[int, float]) -> int:
         return t[0]
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_indexing_drop(run_int_fn):
@@ -34,7 +34,7 @@ def test_indexing_drop2(validate):
     def main() -> qubit:
         return (1, 2, qubit())[2]
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_indexing_nesting(run_int_fn):
@@ -69,7 +69,7 @@ def test_rest_after_use(validate):
         use(t[1])
         return t[0]
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_control_flow(validate):
@@ -83,7 +83,7 @@ def test_control_flow(validate):
         discard(t[0])
         discard(t[1])
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 def test_control_flow2(validate):
@@ -96,7 +96,7 @@ def test_control_flow2(validate):
             discard(q1)
             discard(q2)
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 def test_mem_swap(validate):
@@ -115,7 +115,7 @@ def test_mem_swap(validate):
         discard(t[0])
         discard(t[1])
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 def test_non_terminating(validate):
@@ -124,4 +124,4 @@ def test_non_terminating(validate):
         while True:
             x(t[0])
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())

--- a/tests/integration/test_unpack.py
+++ b/tests/integration/test_unpack.py
@@ -10,7 +10,7 @@ def test_unpack_array(validate):
         q1, q2, q3 = qs
         return q1, q2, q3
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_unpack_starred(validate):
@@ -24,7 +24,7 @@ def test_unpack_starred(validate):
         [*qs] = qs
         return q1, q2, q3, q4, q5, q6, qs
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_unpack_starred_empty(validate):
@@ -33,7 +33,7 @@ def test_unpack_starred_empty(validate):
         q1, *empty, q2 = qs
         return q1, empty, q2
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_unpack_big_iterable(validate):
@@ -44,7 +44,7 @@ def test_unpack_big_iterable(validate):
         q1, *qs, q2 = qs
         return q1, qs, q2
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_unpack_range(run_int_fn):
@@ -62,7 +62,7 @@ def test_unpack_tuple_starred(validate):
         x, *ys, z = 1, 2, 3, 4
         return ys
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_unpack_nested(validate):
@@ -80,7 +80,7 @@ def test_unpack_nested(validate):
         (x, [y, *z, _], *a), *b, c = xs
         return x, y, z, a, b, c
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_left_to_right(run_int_fn):

--- a/tests/integration/test_unpack.py
+++ b/tests/integration/test_unpack.py
@@ -10,7 +10,7 @@ def test_unpack_array(validate):
         q1, q2, q3 = qs
         return q1, q2, q3
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_unpack_starred(validate):
@@ -24,7 +24,7 @@ def test_unpack_starred(validate):
         [*qs] = qs
         return q1, q2, q3, q4, q5, q6, qs
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_unpack_starred_empty(validate):
@@ -33,7 +33,7 @@ def test_unpack_starred_empty(validate):
         q1, *empty, q2 = qs
         return q1, empty, q2
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_unpack_big_iterable(validate):
@@ -44,7 +44,7 @@ def test_unpack_big_iterable(validate):
         q1, *qs, q2 = qs
         return q1, qs, q2
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_unpack_range(run_int_fn):
@@ -62,7 +62,7 @@ def test_unpack_tuple_starred(validate):
         x, *ys, z = 1, 2, 3, 4
         return ys
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_unpack_nested(validate):
@@ -80,7 +80,7 @@ def test_unpack_nested(validate):
         (x, [y, *z, _], *a), *b, c = xs
         return x, y, z, a, b, c
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_left_to_right(run_int_fn):

--- a/tests/integration/test_unreachable.py
+++ b/tests/integration/test_unreachable.py
@@ -93,7 +93,7 @@ def test_unreachable_leak(validate):
         # This return would leak, but we don't complain since it's unreachable:
         return 0
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_unreachable_leak2(validate):
@@ -103,7 +103,7 @@ def test_unreachable_leak2(validate):
             # This would leak, but we don't complain since it's unreachable:
             q = qubit()
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_unreachable_copy(validate):
@@ -116,4 +116,4 @@ def test_unreachable_copy(validate):
             # unreachable:
             h(q)
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())

--- a/tests/integration/test_unreachable.py
+++ b/tests/integration/test_unreachable.py
@@ -93,7 +93,7 @@ def test_unreachable_leak(validate):
         # This return would leak, but we don't complain since it's unreachable:
         return 0
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_unreachable_leak2(validate):
@@ -103,7 +103,7 @@ def test_unreachable_leak2(validate):
             # This would leak, but we don't complain since it's unreachable:
             q = qubit()
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_unreachable_copy(validate):
@@ -116,4 +116,4 @@ def test_unreachable_copy(validate):
             # unreachable:
             h(q)
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))

--- a/tests/integration/test_wasm.py
+++ b/tests/integration/test_wasm.py
@@ -23,7 +23,7 @@ def test_wasm_functions(validate):
         return two + two2
         return 2
 
-    mod = main.compile()
+    mod = main.compile(entrypoint=False)
     validate(mod)
 
 
@@ -45,7 +45,7 @@ def test_wasm_methods(validate):
         mod.discard()
         return x
 
-    mod = main.compile()
+    mod = main.compile(entrypoint=False)
     validate(mod)
 
 
@@ -64,7 +64,7 @@ def test_wasm_types(validate):
         mod.discard()
         return
 
-    mod = main.compile()
+    mod = main.compile(entrypoint=False)
     validate(mod)
 
 
@@ -86,7 +86,7 @@ def test_wasm_guppy_module(validate):
         mod2.discard()
         return two + two2
 
-    mod = main.compile()
+    mod = main.compile(entrypoint=False)
     validate(mod)
 
 
@@ -105,7 +105,7 @@ def test_lookup_by_id(validate):
         c.discard()
         return x
 
-    mod = main.compile()
+    mod = main.compile(entrypoint=False)
     validate(mod)
 
     ops = set()
@@ -135,7 +135,7 @@ def test_lookup_by_name(validate):
         c.discard()
         return x
 
-    mod = main.compile()
+    mod = main.compile(entrypoint=False)
     validate(mod)
 
     ops = set()

--- a/tests/integration/test_wasm.py
+++ b/tests/integration/test_wasm.py
@@ -23,7 +23,7 @@ def test_wasm_functions(validate):
         return two + two2
         return 2
 
-    mod = main.compile(entrypoint=False)
+    mod = main.compile_function()
     validate(mod)
 
 
@@ -45,7 +45,7 @@ def test_wasm_methods(validate):
         mod.discard()
         return x
 
-    mod = main.compile(entrypoint=False)
+    mod = main.compile_function()
     validate(mod)
 
 
@@ -64,7 +64,7 @@ def test_wasm_types(validate):
         mod.discard()
         return
 
-    mod = main.compile(entrypoint=False)
+    mod = main.compile_function()
     validate(mod)
 
 
@@ -86,7 +86,7 @@ def test_wasm_guppy_module(validate):
         mod2.discard()
         return two + two2
 
-    mod = main.compile(entrypoint=False)
+    mod = main.compile_function()
     validate(mod)
 
 
@@ -105,7 +105,7 @@ def test_lookup_by_id(validate):
         c.discard()
         return x
 
-    mod = main.compile(entrypoint=False)
+    mod = main.compile_function()
     validate(mod)
 
     ops = set()
@@ -135,7 +135,7 @@ def test_lookup_by_name(validate):
         c.discard()
         return x
 
-    mod = main.compile(entrypoint=False)
+    mod = main.compile_function()
     validate(mod)
 
     ops = set()

--- a/tests/integration/tracing/test_arithmetic.py
+++ b/tests/integration/tracing/test_arithmetic.py
@@ -165,7 +165,7 @@ def test_angle(validate):
         """Dummy main function"""
         add, sub, mul, div
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def test_dunder_coercions(validate):
@@ -201,14 +201,14 @@ def test_dunder_coercions(validate):
     def test8(x: float, y: nat) -> float:
         return x + y
 
-    validate(test1.compile())
-    validate(test2.compile())
-    validate(test3.compile())
-    validate(test4.compile())
-    validate(test5.compile())
-    validate(test6.compile())
-    validate(test7.compile())
-    validate(test8.compile())
+    validate(test1.compile(entrypoint=False))
+    validate(test2.compile(entrypoint=False))
+    validate(test3.compile(entrypoint=False))
+    validate(test4.compile(entrypoint=False))
+    validate(test5.compile(entrypoint=False))
+    validate(test6.compile(entrypoint=False))
+    validate(test7.compile(entrypoint=False))
+    validate(test8.compile(entrypoint=False))
 
 
 def test_const(validate):
@@ -234,7 +234,7 @@ def test_const(validate):
     def test4() -> float:
         return x / 0.5
 
-    validate(test1.compile())
-    validate(test2.compile())
-    validate(test3.compile())
-    validate(test4.compile())
+    validate(test1.compile(entrypoint=False))
+    validate(test2.compile(entrypoint=False))
+    validate(test3.compile(entrypoint=False))
+    validate(test4.compile(entrypoint=False))

--- a/tests/integration/tracing/test_arithmetic.py
+++ b/tests/integration/tracing/test_arithmetic.py
@@ -165,7 +165,7 @@ def test_angle(validate):
         """Dummy main function"""
         add, sub, mul, div
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def test_dunder_coercions(validate):
@@ -201,14 +201,14 @@ def test_dunder_coercions(validate):
     def test8(x: float, y: nat) -> float:
         return x + y
 
-    validate(test1.compile(entrypoint=False))
-    validate(test2.compile(entrypoint=False))
-    validate(test3.compile(entrypoint=False))
-    validate(test4.compile(entrypoint=False))
-    validate(test5.compile(entrypoint=False))
-    validate(test6.compile(entrypoint=False))
-    validate(test7.compile(entrypoint=False))
-    validate(test8.compile(entrypoint=False))
+    validate(test1.compile_function())
+    validate(test2.compile_function())
+    validate(test3.compile_function())
+    validate(test4.compile_function())
+    validate(test5.compile_function())
+    validate(test6.compile_function())
+    validate(test7.compile_function())
+    validate(test8.compile_function())
 
 
 def test_const(validate):
@@ -234,7 +234,7 @@ def test_const(validate):
     def test4() -> float:
         return x / 0.5
 
-    validate(test1.compile(entrypoint=False))
-    validate(test2.compile(entrypoint=False))
-    validate(test3.compile(entrypoint=False))
-    validate(test4.compile(entrypoint=False))
+    validate(test1.compile_function())
+    validate(test2.compile_function())
+    validate(test3.compile_function())
+    validate(test4.compile_function())

--- a/tests/integration/tracing/test_array.py
+++ b/tests/integration/tracing/test_array.py
@@ -65,4 +65,4 @@ def test_comprehension(validate):
         assert xs == [0, 1, 2, 3, 4]
         return xs
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))

--- a/tests/integration/tracing/test_array.py
+++ b/tests/integration/tracing/test_array.py
@@ -65,4 +65,4 @@ def test_comprehension(validate):
         assert xs == [0, 1, 2, 3, 4]
         return xs
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())

--- a/tests/integration/tracing/test_basic.py
+++ b/tests/integration/tracing/test_basic.py
@@ -19,7 +19,7 @@ def test_flat(validate):
             x += i
         return x
 
-    hugr = foo.compile().modules[0]
+    hugr = foo.compile(entrypoint=False).modules[0]
     assert hugr.num_nodes() == 6
     [const] = [data.op for _, data in hugr.nodes() if isinstance(data.op, ops.Const)]
     assert isinstance(const.val, IntVal)
@@ -32,7 +32,7 @@ def test_inputs(validate):
     def foo(x: int, y: float) -> tuple[int, float]:
         return x, y
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 def test_recursion(validate):
@@ -41,7 +41,7 @@ def test_recursion(validate):
         # `foo` doesn't terminate but the compiler should!
         return foo(x)
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 def test_calls(validate):
@@ -61,7 +61,7 @@ def test_calls(validate):
     def regular2(x: int) -> int:
         return comptime1(x)
 
-    validate(regular2.compile())
+    validate(regular2.compile(entrypoint=False))
 
 
 def test_load_func(validate):
@@ -72,7 +72,7 @@ def test_load_func(validate):
     def test() -> Callable[[int], int]:
         return foo
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_inner_scope(validate):
@@ -91,8 +91,8 @@ def test_inner_scope(validate):
         return foo, bar
 
     foo, bar = make(42)
-    validate(foo.compile())
-    validate(bar.compile())
+    validate(foo.compile(entrypoint=False))
+    validate(bar.compile(entrypoint=False))
 
 
 def test_expr_id(run_int_fn):
@@ -123,7 +123,7 @@ def test_inout_type_infer(validate):
         assert all(isinstance(x, GuppyObject) for x in id)
         rng.discard()
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))
 
 
 def mem_swap_array(validate):
@@ -135,4 +135,4 @@ def mem_swap_array(validate):
         assert isinstance(xs[0], GuppyObject)
         assert isinstance(ys[0], GuppyObject)
 
-    validate(main.compile())
+    validate(main.compile(entrypoint=False))

--- a/tests/integration/tracing/test_basic.py
+++ b/tests/integration/tracing/test_basic.py
@@ -19,7 +19,7 @@ def test_flat(validate):
             x += i
         return x
 
-    hugr = foo.compile(entrypoint=False).modules[0]
+    hugr = foo.compile_function().modules[0]
     assert hugr.num_nodes() == 6
     [const] = [data.op for _, data in hugr.nodes() if isinstance(data.op, ops.Const)]
     assert isinstance(const.val, IntVal)
@@ -32,7 +32,7 @@ def test_inputs(validate):
     def foo(x: int, y: float) -> tuple[int, float]:
         return x, y
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 def test_recursion(validate):
@@ -41,7 +41,7 @@ def test_recursion(validate):
         # `foo` doesn't terminate but the compiler should!
         return foo(x)
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 def test_calls(validate):
@@ -61,7 +61,7 @@ def test_calls(validate):
     def regular2(x: int) -> int:
         return comptime1(x)
 
-    validate(regular2.compile(entrypoint=False))
+    validate(regular2.compile_function())
 
 
 def test_load_func(validate):
@@ -72,7 +72,7 @@ def test_load_func(validate):
     def test() -> Callable[[int], int]:
         return foo
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_inner_scope(validate):
@@ -91,8 +91,8 @@ def test_inner_scope(validate):
         return foo, bar
 
     foo, bar = make(42)
-    validate(foo.compile(entrypoint=False))
-    validate(bar.compile(entrypoint=False))
+    validate(foo.compile_function())
+    validate(bar.compile_function())
 
 
 def test_expr_id(run_int_fn):
@@ -123,7 +123,7 @@ def test_inout_type_infer(validate):
         assert all(isinstance(x, GuppyObject) for x in id)
         rng.discard()
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())
 
 
 def mem_swap_array(validate):
@@ -135,4 +135,4 @@ def mem_swap_array(validate):
         assert isinstance(xs[0], GuppyObject)
         assert isinstance(ys[0], GuppyObject)
 
-    validate(main.compile(entrypoint=False))
+    validate(main.compile_function())

--- a/tests/integration/tracing/test_mocked_builtins.py
+++ b/tests/integration/tracing/test_mocked_builtins.py
@@ -37,7 +37,7 @@ def test_float(validate):
             builtins.float(x)
         return float(x)
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
     # Outside the function, we have the regular builtin
     assert float is builtins.float
@@ -75,7 +75,7 @@ def test_int(validate):
             builtins.int(x)
         return int(x)
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
     # Outside the function, we have the regular builtin
     assert int is builtins.int
@@ -111,7 +111,7 @@ def test_len(validate):
             builtins.len(s)
         return len(s)
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
     # Outside the function, we have the regular builtin
     assert len is builtins.len

--- a/tests/integration/tracing/test_mocked_builtins.py
+++ b/tests/integration/tracing/test_mocked_builtins.py
@@ -37,7 +37,7 @@ def test_float(validate):
             builtins.float(x)
         return float(x)
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
     # Outside the function, we have the regular builtin
     assert float is builtins.float
@@ -75,7 +75,7 @@ def test_int(validate):
             builtins.int(x)
         return int(x)
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
     # Outside the function, we have the regular builtin
     assert int is builtins.int
@@ -111,7 +111,7 @@ def test_len(validate):
             builtins.len(s)
         return len(s)
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
     # Outside the function, we have the regular builtin
     assert len is builtins.len

--- a/tests/integration/tracing/test_quantum.py
+++ b/tests/integration/tracing/test_quantum.py
@@ -20,7 +20,7 @@ def test_basics(validate):
         cx(q1, q2)
         measure(q2)
 
-    validate(foo.compile(entrypoint=False))
+    validate(foo.compile_function())
 
 
 def test_ladder(validate):
@@ -29,7 +29,7 @@ def test_ladder(validate):
         for q1, q2 in itertools.pairwise(qs):
             cx(q1, q2)
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())
 
 
 def test_angles(validate):
@@ -39,4 +39,4 @@ def test_angles(validate):
             rz(q, theta)
             theta /= 2
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())

--- a/tests/integration/tracing/test_quantum.py
+++ b/tests/integration/tracing/test_quantum.py
@@ -20,7 +20,7 @@ def test_basics(validate):
         cx(q1, q2)
         measure(q2)
 
-    validate(foo.compile())
+    validate(foo.compile(entrypoint=False))
 
 
 def test_ladder(validate):
@@ -29,7 +29,7 @@ def test_ladder(validate):
         for q1, q2 in itertools.pairwise(qs):
             cx(q1, q2)
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))
 
 
 def test_angles(validate):
@@ -39,4 +39,4 @@ def test_angles(validate):
             rz(q, theta)
             theta /= 2
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))

--- a/tests/integration/tracing/test_struct.py
+++ b/tests/integration/tracing/test_struct.py
@@ -117,4 +117,4 @@ def test_load_constructor(validate):
     def test() -> Callable[[int], S]:
         return S
 
-    validate(test.compile())
+    validate(test.compile(entrypoint=False))

--- a/tests/integration/tracing/test_struct.py
+++ b/tests/integration/tracing/test_struct.py
@@ -117,4 +117,4 @@ def test_load_constructor(validate):
     def test() -> Callable[[int], S]:
         return S
 
-    validate(test.compile(entrypoint=False))
+    validate(test.compile_function())

--- a/tests/util.py
+++ b/tests/util.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 def compile_guppy(fn) -> Package:
     """A decorator that combines @guppy with HUGR compilation."""
     defn: GuppyFunctionDefinition = guppy(fn)
-    return defn.compile()
+    return defn.compile(entrypoint=False)
 
 
 def dump_llvm(package: PackagePointer):

--- a/tests/util.py
+++ b/tests/util.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 def compile_guppy(fn) -> Package:
     """A decorator that combines @guppy with HUGR compilation."""
     defn: GuppyFunctionDefinition = guppy(fn)
-    return defn.compile(entrypoint=False)
+    return defn.compile_function()
 
 
 def dump_llvm(package: PackagePointer):


### PR DESCRIPTION
Closes #1162

Introduces `GuppyFunctionDef` methods `compile_function` which behaves exactly like `compile` did before, and `compile_entrypoint` which checks the entrypoint function has no arguments. `compile` now is an alias for `compile_entrypoint`

This technically breaks existing behaviour even if API change is non-breaking. If `compile` was used to produce HUGR rather than executables, they would now need to call `compile_function` instead.
This is not deemed common enough to introduce a breaking version, but should still be made clear in the CHANGELOG.

Tests are updated to call the new function.
In tests of correct error paths, usually no change is required since this error is triggered after all other compilation is complete.
