### PR TITLE
chore: fix exporting integration tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,7 +20,7 @@ def export_test_cases_dir(request):
     return r
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def validate(request, export_test_cases_dir: Path):
     def validate_impl(package: Package | PackagePointer | Hugr, name=None):
         if isinstance(package, PackagePointer):


### PR DESCRIPTION
There's an issue with the exporting of hugrs generated while running integration tests. We just need to change the `validate` fixture to have `scope="function"`  (the default one), otherwise the hugr files are overwritten as the `request.node_name` is always None.