### PR TITLE
fix: contextmanager experimental features and docstring disable_experimental_features

### DIFF
--- a/guppylang-internals/src/guppylang_internals/experimental.py
+++ b/guppylang-internals/src/guppylang_internals/experimental.py
@@ -17,13 +17,10 @@ class enable_experimental_features:
     Can be used as a context manager to enable experimental features in a `with` block.
     """
 
-    def __init__(self) -> None:
+    def __enter__(self) -> None:
         global EXPERIMENTAL_FEATURES_ENABLED
         self.original = EXPERIMENTAL_FEATURES_ENABLED
         EXPERIMENTAL_FEATURES_ENABLED = True
-
-    def __enter__(self) -> None:
-        pass
 
     def __exit__(
         self,
@@ -38,16 +35,13 @@ class enable_experimental_features:
 class disable_experimental_features:
     """Disables experimental Guppy features.
 
-    Can be used as a context manager to enable experimental features in a `with` block.
+    Can be used as a context manager to disable experimental features in a `with` block.
     """
 
-    def __init__(self) -> None:
+    def __enter__(self) -> None:
         global EXPERIMENTAL_FEATURES_ENABLED
         self.original = EXPERIMENTAL_FEATURES_ENABLED
         EXPERIMENTAL_FEATURES_ENABLED = False
-
-    def __enter__(self) -> None:
-        pass
 
     def __exit__(
         self,


### PR DESCRIPTION
Unless I misunderstand the usage of a Python context manager, there seems to be a bug in the current code, in that the value is set in the init instead of the enter.