### PR TITLE
ci: revert wheel building to python 3.13

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -68,8 +68,8 @@ jobs:
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
-      - name: Install Python 3.14
-        run: uv python install 3.14
+      - name: Install Python 3.13
+        run: uv python install 3.13
         if: ${{ steps.check-tag.outputs.run == 'true' }}
 
       - name: Build sdist and wheels


### PR DESCRIPTION
There remain some issues, not worth the risk of a release failing.


failing: https://github.com/CQCL/guppylang/actions/runs/18912755383/job/53987785348