### PR TITLE
fix: Fix rendering of `compile_entrypoint` diagnostics

### DIFF
--- a/guppylang/src/guppylang/defs.py
+++ b/guppylang/src/guppylang/defs.py
@@ -13,7 +13,7 @@ import guppylang_internals
 from guppylang_internals.definition.value import CompiledCallableDef
 from guppylang_internals.diagnostic import Error, Note
 from guppylang_internals.engine import ENGINE, CoreMetadataKeys
-from guppylang_internals.error import GuppyError
+from guppylang_internals.error import GuppyError, pretty_errors
 from guppylang_internals.span import Span, to_span
 from guppylang_internals.tracing.object import TracingDefMixin
 from guppylang_internals.tracing.util import hide_trace
@@ -126,6 +126,7 @@ class GuppyFunctionDefinition(GuppyDefinition, Generic[P, Out]):
 
         return self.compile_entrypoint()
 
+    @pretty_errors
     def compile_entrypoint(self) -> Package:
         """
         Compiles an execution entrypoint function definition to a HUGR package

--- a/tests/error/misc_errors/entrypoint_with_args2.err
+++ b/tests/error/misc_errors/entrypoint_with_args2.err
@@ -1,0 +1,12 @@
+Error: Entrypoint function has arguments (at $FILE:4:8)
+  | 
+2 | 
+3 | @guppy
+4 | def foo(x: bool) -> bool:
+  |         ^^^^^^^ Entrypoint function must have no input parameters, found
+  |                 (`x`).
+
+Note: If the function is not an execution entrypoint, consider using
+`foo.compile_function()`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/misc_errors/entrypoint_with_args2.py
+++ b/tests/error/misc_errors/entrypoint_with_args2.py
@@ -1,0 +1,8 @@
+from guppylang.decorator import guppy
+
+@guppy
+def foo(x: bool) -> bool:
+    return x
+
+
+foo.compile_entrypoint()


### PR DESCRIPTION
Fixes #1340