### PR TITLE
fix!: Allow comptime string arguments as result tags

### DIFF
--- a/guppylang-internals/src/guppylang_internals/nodes.py
+++ b/guppylang-internals/src/guppylang_internals/nodes.py
@@ -263,9 +263,10 @@ class ResultExpr(ast.expr):
     base_ty: Type
     #: Array length in case this is an array result, otherwise `None`
     array_len: Const | None
-    tag: str
+    tag_value: Const
+    tag_expr: ast.expr
 
-    _fields = ("value", "base_ty", "array_len", "tag")
+    _fields = ("value", "base_ty", "array_len", "tag_value", "tag_expr")
 
     @property
     def args(self) -> list[ast.expr]:
@@ -299,12 +300,13 @@ class BarrierExpr(ast.expr):
 class StateResultExpr(ast.expr):
     """A `state_result(tag, *args)` expression."""
 
-    tag: str
+    tag_value: Const
+    tag_expr: ast.expr
     args: list[ast.expr]
     func_ty: FunctionType
     #: Array length in case this is an array result, otherwise `None`
     array_len: Const | None
-    _fields = ("tag", "args", "func_ty", "has_array_input")
+    _fields = ("tag_value", "tag_expr", "args", "func_ty", "has_array_input")
 
 
 AnyCall = (

--- a/guppylang-internals/src/guppylang_internals/std/_internal/debug.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/debug.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import ClassVar, cast
 
 from guppylang_internals.ast_util import with_loc
+from guppylang_internals.checker.core import ComptimeVariable
 from guppylang_internals.checker.errors.generic import ExpectedError
 from guppylang_internals.checker.errors.type_errors import WrongNumberOfArgsError
 from guppylang_internals.checker.expr_checker import (
@@ -14,14 +15,14 @@ from guppylang_internals.definition.custom import CustomCallChecker
 from guppylang_internals.definition.ty import TypeDef
 from guppylang_internals.diagnostic import Error
 from guppylang_internals.error import GuppyTypeError
-from guppylang_internals.nodes import StateResultExpr
-from guppylang_internals.std._internal.checker import TAG_MAX_LEN, TooLongError
+from guppylang_internals.nodes import GenericParamValue, PlaceNode, StateResultExpr
 from guppylang_internals.tys.builtin import (
     get_array_length,
     get_element_type,
     is_array_type,
     string_type,
 )
+from guppylang_internals.tys.const import Const, ConstValue
 from guppylang_internals.tys.ty import (
     FuncInput,
     FunctionType,
@@ -43,12 +44,16 @@ class StateResultChecker(CustomCallChecker):
 
     def synthesize(self, args: list[ast.expr]) -> tuple[ast.expr, Type]:
         tag, _ = ExprChecker(self.ctx).check(args[0], string_type())
-        if not isinstance(tag, ast.Constant) or not isinstance(tag.value, str):
-            raise GuppyTypeError(ExpectedError(tag, "a string literal"))
-        if len(tag.value.encode("utf-8")) > TAG_MAX_LEN:
-            err: Error = TooLongError(tag)
-            err.add_sub_diagnostic(TooLongError.Hint(None))
-            raise GuppyTypeError(err)
+        tag_value: Const
+        match tag:
+            case ast.Constant(value=str(v)):
+                tag_value = ConstValue(string_type(), v)
+            case PlaceNode(place=ComptimeVariable(static_value=str(v))):
+                tag_value = ConstValue(string_type(), v)
+            case GenericParamValue() as param_value:
+                tag_value = param_value.param.to_bound().const
+            case _:
+                raise GuppyTypeError(ExpectedError(tag, "a string literal"))
         syn_args: list[ast.expr] = [tag]
 
         if len(args) < 2:
@@ -90,6 +95,10 @@ class StateResultChecker(CustomCallChecker):
         args, ret_ty, inst = synthesize_call(func_ty, syn_args, self.node, self.ctx)
         assert len(inst) == 0, "func_ty is not generic"
         node = StateResultExpr(
-            tag=tag.value, args=args, func_ty=func_ty, array_len=array_len
+            tag_value=tag_value,
+            tag_expr=tag,
+            args=args,
+            func_ty=func_ty,
+            array_len=array_len,
         )
         return with_loc(self.node, node), ret_ty

--- a/tests/error/result_errors/result_tag_too_big_generic.err
+++ b/tests/error/result_errors/result_tag_too_big_generic.err
@@ -1,0 +1,13 @@
+Error: Tag too long (at $FILE:7:11)
+  | 
+5 | @guppy
+6 | def foo(tag: str @ comptime, y: bool) -> None:
+7 |     result(tag, y)
+  |            ^^^ Result tag is too long
+
+Note: Result tags are limited to 200 bytes
+
+Note: Parameter `tag` was instantiated to
+`✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅❌`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/result_errors/result_tag_too_big_generic.py
+++ b/tests/error/result_errors/result_tag_too_big_generic.py
@@ -1,0 +1,16 @@
+from guppylang import guppy, comptime
+from guppylang.std.builtins import result
+
+
+@guppy
+def foo(tag: str @ comptime, y: bool) -> None:
+    result(tag, y)
+
+
+@guppy
+def main() -> None:
+    # each tick or cross is 3 bytes. The cross sends the tag over the limit.
+    foo("✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅❌", True)
+
+
+main.compile()

--- a/tests/error/result_errors/state_result_tag_too_long_generic.err
+++ b/tests/error/result_errors/state_result_tag_too_long_generic.err
@@ -1,0 +1,15 @@
+Error: Tag too long (at $FILE:11:17)
+   | 
+ 9 | def foo(tag: str @ comptime) -> None:
+10 |     q1 = qubit()
+11 |     state_result(tag, q1)
+   |                  ^^^ Result tag is too long
+
+Note: Result tags are limited to 200 bytes
+
+Note: Parameter `tag` was instantiated to `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaa`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/result_errors/state_result_tag_too_long_generic.py
+++ b/tests/error/result_errors/state_result_tag_too_long_generic.py
@@ -1,0 +1,20 @@
+from guppylang import guppy
+from guppylang.std.builtins import comptime
+from guppylang.std.debug import state_result
+from guppylang.std.quantum import discard, qubit
+
+TAG_MAX_LEN = 200
+
+@guppy
+def foo(tag: str @ comptime) -> None:
+    q1 = qubit()
+    state_result(tag, q1)
+    discard(q1)
+
+
+@guppy
+def main() -> None:
+    foo(comptime("a" * (TAG_MAX_LEN + 1)))
+
+
+main.compile()


### PR DESCRIPTION
Closes #1353

This required moving the tag length check from type checking into Hugr compilation since we need to wait until monomorphisation is resolved. This can be undone once we have #1299.

BREAKING CHANGE:  The `tag` field of `guppylang_internals.nodes.{ResultExpr, StateResultExpr}` has been replaced with a const `tag_value` and a `tag_expr` expression