### PR TITLE
fix!: Add a line break for printing WASM files

### DIFF
--- a/guppylang-internals/src/guppylang_internals/wasm_util.py
+++ b/guppylang-internals/src/guppylang_internals/wasm_util.py
@@ -27,7 +27,7 @@ class ConcreteWasmModule:
 class WasmSignatureError(Error):
     title: ClassVar[str] = (
         "Invalid signature for @wasm function `{fn_name}`\n"
-        "in wasm file: `{filename}`"
+        "in wasm file:\n`{filename}`"
     )
     fn_name: str
     filename: str
@@ -53,7 +53,7 @@ class WasmFunctionNotInFile(Error):
 
     @dataclass(frozen=True)
     class WasmFileNote(Note):
-        message: ClassVar[str] = "Wasm file: {filename}"
+        message: ClassVar[str] = "Wasm file:\n`{filename}`"
         filename: str
 
 

--- a/tests/error/wasm_errors/wasm_bad_input.err
+++ b/tests/error/wasm_errors/wasm_bad_input.err
@@ -1,5 +1,6 @@
 Error: Invalid signature for @wasm function `bad_input_type`
-in wasm file: `$WASM`
+in wasm file:
+`$WASM`
 
 Note: Unsupported input type: i32
 

--- a/tests/error/wasm_errors/wasm_bad_output.err
+++ b/tests/error/wasm_errors/wasm_bad_output.err
@@ -1,5 +1,6 @@
 Error: Invalid signature for @wasm function `bad_output_type`
-in wasm file: `$WASM`
+in wasm file:
+`$WASM`
 
 Note: Unsupported output type: f32
 

--- a/tests/error/wasm_errors/wasm_multi_output.err
+++ b/tests/error/wasm_errors/wasm_multi_output.err
@@ -1,5 +1,6 @@
 Error: Invalid signature for @wasm function `multiple_outputs`
-in wasm file: `$WASM`
+in wasm file:
+`$WASM`
 
 Note: Multiple output types unsupported in function `multiple_outputs`
 

--- a/tests/error/wasm_errors/wasm_no_func.err
+++ b/tests/error/wasm_errors/wasm_no_func.err
@@ -1,5 +1,6 @@
 Error: Declared wasm function `foo` isn't exported by wasm file
 
-Note: Wasm file: $WASM
+Note: Wasm file:
+`$WASM`
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/wasm_errors/wasm_non_function.err
+++ b/tests/error/wasm_errors/wasm_non_function.err
@@ -1,5 +1,6 @@
 Error: Invalid signature for @wasm function `non_fn`
-in wasm file: `$WASM`
+in wasm file:
+`$WASM`
 
 Note: `non_fn` is not exported as a function
 


### PR DESCRIPTION
This way, a long path to the wasm file on a developer's machine can't induce a line break which isn't present in CI, causing a mismatch between local golden values and those on CI

BREAKING CHANGE: (guppylang-internals): update a class var on the error