### PR TITLE
fix: Fix another wasm diagnostics rendering issue

### DIFF
--- a/guppylang-internals/src/guppylang_internals/decorator.py
+++ b/guppylang-internals/src/guppylang_internals/decorator.py
@@ -253,6 +253,7 @@ def ext_module_decorator(
     def fun(
         filename: str, module: str | None
     ) -> Callable[[builtins.type[T]], GuppyDefinition]:
+        @pretty_errors
         def dec(cls: builtins.type[T]) -> GuppyDefinition:
             # N.B. Only one module per file and vice-versa
             ext_module = type_def(


### PR DESCRIPTION
Missed one previously in #1398 

As a side note, I think it would be better if those errors were only triggered when we call `check` instead of when the decorator is called, but that's a separate issue