### PR TITLE
test: Add test that made hugr-0.25.0 fail

### DIFF
--- a/tests/integration/test_constants.py
+++ b/tests/integration/test_constants.py
@@ -1,19 +1,7 @@
 """Constants are only loaded by execution compilers (not validation), test that."""
 
 from guppylang.decorator import guppy
-from guppylang.std.builtins import result, comptime, array
-
-
-# This caused problems with hugr (see https://github.com/Quantinuum/hugr/pull/2779),
-# as it makes the linearizer copy an array (indeed, two arrays of different lengths).
-def test_array_consts(run_int_fn):
-    @guppy
-    def main() -> int:
-        result("x", array(True, False))
-        result("y", array(False, True, False, False, True))
-        return 3
-
-    run_int_fn(main, 3)
+from guppylang.std.builtins import result, comptime
 
 
 def test_basic_type(run_int_fn):

--- a/tests/integration/test_result.py
+++ b/tests/integration/test_result.py
@@ -35,6 +35,18 @@ def test_array(validate):
     validate(main)
 
 
+# This caused problems with hugr (see https://github.com/Quantinuum/hugr/pull/2779),
+# as it makes the linearizer copy an array (indeed, two arrays of different lengths).
+def test_array_consts(run_int_fn):
+    @guppy
+    def main() -> int:
+        result("x", array(True, False))
+        result("y", array(False, True, False, False, True))
+        return 3
+
+    run_int_fn(main, 3)
+
+
 def test_array_generic(validate):
     n = guppy.nat_var("n")
 


### PR DESCRIPTION
This odd `guppy.comptime` + `result` combo seems to invoke the BorrowArray *copying* handler in a way that I haven't managed to otherwise.

The two calls with different-length arrays caused linking problems following https:://github.com/Quantinuum/hugr/pull/2749, fixed in https:://github.com/Quantinuum/hugr/pull/2779.

Note, all testing was based on guppylang 0.21.6, I realize there has been a 0.21.7 since but the testing was quite a faff so I will not repeat it unless you think there is reason guppy compilation may have changed....