### PR TITLE
chore(ci): Fix smoketest of building wheels

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -14,9 +14,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types:
-      - synchronize
   release:
     types:
       - published


### PR DESCRIPTION
The existing CI job failed every time there were breaking changes between `guppylang-internals` and `guppylang`, since their wheels were built independently, and subsequently the `guppylang` wheel was smoke-tested without using the `guppylang-internals` wheel. Thus, the latest release was fetched from pypi, which may not feature the latest requirements from the `guppylang` wheel. See e.g. https://github.com/Quantinuum/guppylang/actions/runs/21624672648/job/62321750068.

This PR changes the workflow such that
1. Both wheels are built and smoke tested together
2. The wheels are uploaded independently, and in a separate job

I am unsure how to test the release workflow itself pre-merge, but given that it follows [the recommendation from packaging.python.org](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#checking-out-the-project-and-building-distributions) rather closely, I think it should be fine.

> [!IMPORTANT]
> See https://github.com/Quantinuum/guppylang/actions/runs/21668492823?pr=1466 for a successful run of this