### PR TITLE
chore: Bump `guppylang-internals` to 0.28.0 in `guppylang`

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -171,6 +171,10 @@ To override the version getting released, you must merge a PR to `main` containi
 `Release-As: 0.1.0` in the description.
 Python pre-release versions should be formatted as `0.1.0a1` (or `b1`, `rc1`).
 
+Before merging a release PR, make sure to update the uv lock file by running `uv
+lock` and pushing to the release branch.
+When releasing `guppylang-internals`, also update the dependency version in `guppylang/pyproject.toml`.
+
 ### Patch releases
 
 Sometimes we need to release a patch version to fix a critical bug, but we don't want

--- a/guppylang/pyproject.toml
+++ b/guppylang/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "guppylang-internals ~= 0.27.0",
+    "guppylang-internals ~= 0.28.0",
     "numpy~=2.0",
     "selene-hugr-qis-compiler~=0.2.9",
     "selene-sim~=0.2.7",


### PR DESCRIPTION
We should have done this bump in `guppy-internals`' release PR.

I added a notice in DEVELOPMENT.md about it.

This will fix the current wheel building error on `main`: https://github.com/Quantinuum/guppylang/actions/runs/21716665138/job/62634456250