### PR TITLE
fix: Misleading error message when trying to load a list of numpy integers using comptime

### DIFF
--- a/guppylang-internals/src/guppylang_internals/checker/errors/comptime_errors.py
+++ b/guppylang-internals/src/guppylang_internals/checker/errors/comptime_errors.py
@@ -12,6 +12,13 @@ class IllegalComptimeExpressionError(Error):
     span_label: ClassVar[str] = "Expression of type `{python_ty}` is not supported"
     python_ty: type
 
+    @dataclass(frozen=True)
+    class InContainer(Note):
+        message: ClassVar[str] = (
+            "Unsupported value was found inside a `{container_ty.__name__}`"
+        )
+        container_ty: type
+
 
 @dataclass(frozen=True)
 class ComptimeExprNotCPythonError(Error):

--- a/tests/error/comptime_expr_errors/unsupported_in_list.err
+++ b/tests/error/comptime_expr_errors/unsupported_in_list.err
@@ -1,0 +1,10 @@
+Error: Unsupported Python expression (at $FILE:13:14)
+   | 
+11 | def main() -> None:
+12 |     q = qubit()
+13 |     randval = comptime(randints)[get_current_shot()]
+   |               ^^^^^^^^^^^^^^^^^^ Expression of type `<class 'numpy.int64'>` is not supported
+
+Note: Unsupported value was found inside a `list`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/comptime_expr_errors/unsupported_in_list.py
+++ b/tests/error/comptime_expr_errors/unsupported_in_list.py
@@ -1,0 +1,16 @@
+import random
+import numpy as np
+from guppylang import guppy
+from guppylang.std.builtins import comptime
+from guppylang.std.qsystem.utils import get_current_shot
+from guppylang.std.quantum import qubit, discard
+
+randints = list(np.random.choice(3, 50, p = [0.1, 0.5, 0.4]))
+
+@guppy
+def main() -> None:
+    q = qubit()
+    randval = comptime(randints)[get_current_shot()]
+    discard(q)
+
+main.compile()


### PR DESCRIPTION
**Summary**

- Fixes #1262: 
- When a `list `or `tuple `containing unsupported element types (e.g., `np.int64`) is passed to `comptime()`, the error now correctly identifies the unsupported element type instead of blaming the container type
- Before: `Expression of type <class 'list'> is not supported`
- After:` Expression of type <class 'numpy.int64'> is not supported + Note: Unsupported value was found inside a list`

**Changes**

- Added `InContainer `Note sub-diagnostic to `IllegalComptimeExpressionError `in `comptime_errors.py`
- Modified _`python_list_to_guppy_type` and the tuple branch in `python_value_to_guppy_type` in `[expr_checker.py`] to raise eagerly with the element's type when conversion fails, instead of returning `None `and letting the caller blame the container
- Added error snapshot test [`unsupported_in_list.py`] reproducing the exact scenario from the issue (numpy integers in a list)

**Test plan**

-  Existing comptime error tests pass (`test_comptime_expr_errors, test_comptime_arg_errors`)
-  New snapshot test `unsupported_in_list` verifies the improved error message with `np.int64`