### PR TITLE
refactor!: Experimental features should only be set globally

### DIFF
--- a/guppylang-internals/src/guppylang_internals/experimental.py
+++ b/guppylang-internals/src/guppylang_internals/experimental.py
@@ -1,6 +1,5 @@
 from ast import expr
 from dataclasses import dataclass
-from types import TracebackType
 from typing import ClassVar
 
 from guppylang_internals.ast_util import AstNode
@@ -11,52 +10,25 @@ from guppylang_internals.error import GuppyError
 EXPERIMENTAL_FEATURES_ENABLED = False
 
 
-class enable_experimental_features:
-    """Enables experimental Guppy features.
-
-    Can be used as a context manager to enable experimental features in a `with` block.
-    """
-
-    def __init__(self) -> None:
-        global EXPERIMENTAL_FEATURES_ENABLED
-        self.original = EXPERIMENTAL_FEATURES_ENABLED
-        EXPERIMENTAL_FEATURES_ENABLED = True
-
-    def __enter__(self) -> None:
-        pass
-
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> None:
-        global EXPERIMENTAL_FEATURES_ENABLED
-        EXPERIMENTAL_FEATURES_ENABLED = self.original
+def are_experimental_features_enabled() -> bool:
+    """Whether experimental Guppy features are enabled."""
+    return EXPERIMENTAL_FEATURES_ENABLED
 
 
-class disable_experimental_features:
-    """Disables experimental Guppy features.
+def enable_experimental_features() -> None:
+    """Enables experimental Guppy features."""
+    set_experimental_features_enabled(True)
 
-    Can be used as a context manager to enable experimental features in a `with` block.
-    """
 
-    def __init__(self) -> None:
-        global EXPERIMENTAL_FEATURES_ENABLED
-        self.original = EXPERIMENTAL_FEATURES_ENABLED
-        EXPERIMENTAL_FEATURES_ENABLED = False
+def disable_experimental_features() -> None:
+    """Disables experimental Guppy features."""
+    set_experimental_features_enabled(False)
 
-    def __enter__(self) -> None:
-        pass
 
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> None:
-        global EXPERIMENTAL_FEATURES_ENABLED
-        EXPERIMENTAL_FEATURES_ENABLED = self.original
+def set_experimental_features_enabled(enabled: bool) -> None:
+    """Sets whether experimental Guppy features are enabled."""
+    global EXPERIMENTAL_FEATURES_ENABLED
+    EXPERIMENTAL_FEATURES_ENABLED = enabled
 
 
 @dataclass(frozen=True)

--- a/guppylang/src/guppylang/experimental.py
+++ b/guppylang/src/guppylang/experimental.py
@@ -1,6 +1,13 @@
 from guppylang_internals.experimental import (
+    are_experimental_features_enabled,
     disable_experimental_features,
     enable_experimental_features,
+    set_experimental_features_enabled,
 )
 
-__all__ = ("disable_experimental_features", "enable_experimental_features")
+__all__ = (
+    "are_experimental_features_enabled",
+    "disable_experimental_features",
+    "enable_experimental_features",
+    "set_experimental_features_enabled",
+)

--- a/tests/error/test_experimental_errors.py
+++ b/tests/error/test_experimental_errors.py
@@ -1,7 +1,7 @@
 import pathlib
 import pytest
 
-from guppylang.experimental import disable_experimental_features
+from guppylang.experimental import are_experimental_features_enabled, set_experimental_features_enabled
 from tests.error.util import run_error_test
 
 path = pathlib.Path(__file__).parent.resolve() / "experimental_errors"
@@ -17,5 +17,9 @@ files = [str(f) for f in files]
 
 @pytest.mark.parametrize("file", files)
 def test_experimental_errors(file, capsys, snapshot):
-    with disable_experimental_features():
-        run_error_test(file, capsys, snapshot)
+    original = are_experimental_features_enabled()
+    set_experimental_features_enabled(False)
+
+    run_error_test(file, capsys, snapshot)
+
+    set_experimental_features_enabled(original)


### PR DESCRIPTION
Currently, experimental features are enabled and disabled via classes that simultaneously act as a function to enable/disable experimental features globally, or as a context manager that may enable experimental features within a given code range. This double usage, although with a somewhat clean usage API, already was a source of confusion / missing clarity in the code / suspected bugs (see #1321).

Depending on the range of experimental features added to Guppy, parts of code compiled against experimental APIs may break with parts of code compiled against non-experimental API. A context-manager API promotes usage of experimental features in the above way.

This PR changes the API of experimental features such that they are only usable as a function to globally set / unset experimental features. A context-manager-like behaviour can still be mimicked using `is_` and `set_` functions, but that is not considered intended usage anymore and to be used at own risk.

BREAKING CHANGE: Enabling / disabling experimental features is no longer possible via context managers. Features should either be enabled or disabled globally.

BEGIN_COMMIT_OVERRIDE
""
END_COMMIT_OVERRIDE