### PR TITLE
fix: Misleading error message for leaked qubits

### DIFF
--- a/tests/error/linear_errors/borrow_array_loop_leak.err
+++ b/tests/error/linear_errors/borrow_array_loop_leak.err
@@ -1,0 +1,11 @@
+Error: Drop violation (at $FILE:8:8)
+  | 
+6 |     @guppy
+7 |     def phase_gadget() -> None:
+8 |         qs = array(qubit() for _ in range(comptime(n_qb)))
+  |         ^^ Variable `qs` with non-droppable type `array[qubit, 5]` is
+  |            leaked
+
+Help: Make sure that `qs` is consumed or returned to avoid the leak
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/linear_errors/borrow_array_loop_leak.py
+++ b/tests/error/linear_errors/borrow_array_loop_leak.py
@@ -1,0 +1,17 @@
+from guppylang import guppy, array, comptime
+from guppylang.std.quantum import qubit, z
+
+
+def build_phase_gadget_prog(n_qb: int):
+    @guppy
+    def phase_gadget() -> None:
+        qs = array(qubit() for _ in range(comptime(n_qb)))
+        # Allocated array of qubits is not consumed.
+
+        for i in range(comptime(n_qb)):
+            z(qs[i])
+
+    return phase_gadget
+
+phase_gadget_1 = build_phase_gadget_prog(5)
+phase_gadget_1.check()

--- a/tests/error/linear_errors/borrow_both_branches_leak.err
+++ b/tests/error/linear_errors/borrow_both_branches_leak.err
@@ -1,0 +1,10 @@
+Error: Drop violation (at $FILE:8:4)
+  | 
+6 | @guppy
+7 | def foo(b: bool) -> None:
+8 |     q = qubit()
+  |     ^ Variable `q` with non-droppable type `qubit` is leaked
+
+Help: Make sure that `q` is consumed or returned to avoid the leak
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/linear_errors/borrow_both_branches_leak.py
+++ b/tests/error/linear_errors/borrow_both_branches_leak.py
@@ -1,0 +1,15 @@
+from guppylang.decorator import guppy
+from guppylang.std.builtins import owned
+from guppylang.std.quantum import qubit, h, t
+
+
+@guppy
+def foo(b: bool) -> None:
+    q = qubit()
+    if b:
+        h(q)
+    else:
+        t(q)
+
+
+foo.compile()

--- a/tests/error/linear_errors/borrow_branch_leak.err
+++ b/tests/error/linear_errors/borrow_branch_leak.err
@@ -1,0 +1,10 @@
+Error: Drop violation (at $FILE:8:4)
+  | 
+6 | @guppy
+7 | def foo(b: bool) -> None:
+8 |     q = qubit()
+  |     ^ Variable `q` with non-droppable type `qubit` is leaked
+
+Help: Make sure that `q` is consumed or returned to avoid the leak
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/linear_errors/borrow_branch_leak.py
+++ b/tests/error/linear_errors/borrow_branch_leak.py
@@ -1,0 +1,13 @@
+from guppylang.decorator import guppy
+from guppylang.std.builtins import owned
+from guppylang.std.quantum import qubit, h
+
+
+@guppy
+def foo(b: bool) -> None:
+    q = qubit()
+    if b:
+        h(q)
+
+
+foo.compile()

--- a/tests/error/linear_errors/consume_branch_leak.err
+++ b/tests/error/linear_errors/consume_branch_leak.err
@@ -1,0 +1,17 @@
+Error: Drop violation (at $FILE:8:4)
+  | 
+6 | @guppy
+7 | def foo(b: bool) -> None:
+8 |     q = qubit()
+  |     ^ Variable `q` with non-droppable type `qubit` may be leaked
+  |       ...
+
+Note:
+  | 
+8 |     q = qubit()
+9 |     if b:
+  |        - if this expression is `False`
+
+Help: Make sure that `q` is consumed or returned to avoid the leak
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/linear_errors/consume_branch_leak.py
+++ b/tests/error/linear_errors/consume_branch_leak.py
@@ -1,0 +1,13 @@
+from guppylang.decorator import guppy
+from guppylang.std.builtins import owned
+from guppylang.std.quantum import qubit, measure, h
+
+
+@guppy
+def foo(b: bool) -> None:
+    q = qubit()
+    if b:
+        _ = measure(q)
+
+
+foo.compile()


### PR DESCRIPTION
**Summary**
Resolves the misleading error message incorrectly blaming a branch condition when a non-droppable variable (e.g. a qubit) leaks unconditionally.

Fixes #909

**Root Cause**
The linearity checker uses liveness analysis to determine whether a variable is used on successor code paths. When a variable is live on some paths but not all, a `Branch `sub-diagnostic is attached pointing at the branch condition (e.g. `if this expression is 'False'`).

However, liveness analysis does not distinguish between borrowing and consuming a variable. A gate like `h(q)` borrows the qubit — only borrows the qubit, so it leaks on both paths. A borrow made the variable appear "used" on that path, so the checker assumed the leak was conditional.

**Fix:**

Before attaching the branch note, check the `UseKind `on each path. Only show the branch note when the variable is actually consumed (not just borrowed) on at least one path.


Before (misleading):


```
Variable `q` with non-droppable type `qubit` may be leaked ...
  if this expression is `False`
```
After (correct):


`Variable `q` with non-droppable type `qubit` is leaked`

When the variable is consumed on one path (e.g. via measure(q)), the Branch note still appears as before.

**Tests**
|Test | Scenario | Diagnostic|
| :--- | :---: | ---: |
|`borrow_branch_leak` | `h(q)` borrows in one branch |  `is leaked` — no Branch note |
|`borrow_both_branches_leak `| `h(q) `/` t(q)` borrow in both branches |  `is leaked` — no Branch note |
|`borrow_array_loop_leak `| From reproducer sample: borrow-only gates on array in a loop |  `is leaked` — no Branch note |
|`consume_branch_leak `| `measure(q) `consumes in one branch | `may be leaked ... if this expression is 'False'` — Branch note correctly shown |
