### PR TITLE
feat: Add missing bool methods (__rxor__, __rand__, __ror__)

### DIFF
--- a/guppylang/src/guppylang/std/bool.py
+++ b/guppylang/src/guppylang/std/bool.py
@@ -8,7 +8,7 @@ from typing import no_type_check
 
 from guppylang_internals.decorator import custom_function, extend_type, hugr_op
 from guppylang_internals.definition.custom import NoopCompiler
-from guppylang_internals.std._internal.checker import DunderChecker
+from guppylang_internals.std._internal.checker import DunderChecker, ReversingChecker
 from guppylang_internals.std._internal.util import bool_logic_op
 from guppylang_internals.tys.builtin import bool_type_def
 
@@ -61,3 +61,12 @@ class bool:
 
     @hugr_op(bool_logic_op("xor"))
     def __xor__(self: bool, other: bool) -> bool: ...
+
+    @custom_function(checker=ReversingChecker())
+    def __rand__(self: bool, other: bool) -> bool: ...
+
+    @custom_function(checker=ReversingChecker())
+    def __ror__(self: bool, other: bool) -> bool: ...
+
+    @custom_function(checker=ReversingChecker())
+    def __rxor__(self: bool, other: bool) -> bool: ...

--- a/tests/integration/test_arithmetic.py
+++ b/tests/integration/test_arithmetic.py
@@ -284,6 +284,54 @@ def test_xor(run_int_fn):
     run_int_fn(main2, 0)
 
 
+def test_bool_rand(run_int_fn):
+    @guppy
+    def main1() -> int:
+        x: bool = True
+        return int(x.__rand__(False))
+
+    run_int_fn(main1, 0)
+
+    @guppy
+    def main2() -> int:
+        x: bool = True
+        return int(x.__rand__(True))
+
+    run_int_fn(main2, 1)
+
+
+def test_bool_ror(run_int_fn):
+    @guppy
+    def main1() -> int:
+        x: bool = False
+        return int(x.__ror__(True))
+
+    run_int_fn(main1, 1)
+
+    @guppy
+    def main2() -> int:
+        x: bool = False
+        return int(x.__ror__(False))
+
+    run_int_fn(main2, 0)
+
+
+def test_bool_rxor(run_int_fn):
+    @guppy
+    def main1() -> int:
+        x: bool = True
+        return int(x.__rxor__(True))
+
+    run_int_fn(main1, 0)
+
+    @guppy
+    def main2() -> int:
+        x: bool = True
+        return int(x.__rxor__(False))
+
+    run_int_fn(main2, 1)
+
+
 def test_pow(run_int_fn) -> None:
     @guppy
     def main() -> int:


### PR DESCRIPTION
Closes #274 

- Adds reverse boolean operator methods (`__rand__`, `__ror__`, `__rxor__`) to the bool type using ReversingChecker, matching the pattern used by int and nat types
- Adds integration tests for each new method in `test_arithmetic.py`