### PR TITLE
fix: improve docstring formatting array methods

### DIFF
--- a/guppylang/src/guppylang/std/array.py
+++ b/guppylang/src/guppylang/std/array.py
@@ -94,9 +94,6 @@ class array(builtins.list[_T], Generic[_T, _n]):
         This is the case whenever a non-copyable element is borrowed, or when an element
         is manually taken out of the array via the `take` method.
 
-        Example
-        -------
-
         .. code-block:: python
 
             qs = array(qubit() for _ in range(10))
@@ -126,9 +123,6 @@ class array(builtins.list[_T], Generic[_T, _n]):
         Also see `array.try_take` for a version of this function that does not panic if
         the element has already been taken out.
 
-        Example
-        -------
-
         .. code-block:: python
 
             qs = array(qubit() for _ in range(10))
@@ -155,9 +149,6 @@ class array(builtins.list[_T], Generic[_T, _n]):
 
         Returns the extracted element or `nothing` if the element has already been taken
         out. Panics if the provided index is negative or out of bounds.
-
-        Example
-        -------
 
         .. code-block:: python
 
@@ -188,9 +179,6 @@ class array(builtins.list[_T], Generic[_T, _n]):
         Also see `array.try_put` for a version of this function that does not panic if
         if there is already an element at the given index.
 
-        Example
-        -------
-
         .. code-block:: python
 
             qs = array(qubit() for _ in range(10))
@@ -213,9 +201,6 @@ class array(builtins.list[_T], Generic[_T, _n]):
         If there is already an element at the given index, then the array will not be
         mutated and the passed replacement element will be returned back in an `err`
         variant. Panics if the provided index is negative or out of bounds.
-
-        Example
-        -------
 
         .. code-block:: python
 
@@ -278,9 +263,6 @@ def array_swap(arr: array[L, n], idx: int, idx2: int) -> None:
         arr: The array to modify
         idx: Index of first element to swap
         idx2: Index of second element to swap
-
-    Example
-    -------
 
     .. code-block:: python
 


### PR DESCRIPTION
Previously this file used "```" instead of the `.. code-block::` sphinx directive meaning the code snippet did not render properly in the docstrings

Before 
<img width="719" height="345" alt="Screenshot 2026-02-16 at 10 49 00" src="https://github.com/user-attachments/assets/e3248f28-8a9b-495a-878b-b85d867d516f" />


After

<img width="725" height="424" alt="Screenshot 2026-02-16 at 10 46 49" src="https://github.com/user-attachments/assets/a1876ce8-fcae-46de-9cdc-1da0e36b31ae" />
