### PR TITLE
fix!: Revert experimental features break

### DIFF
--- a/guppylang-internals/src/guppylang_internals/experimental.py
+++ b/guppylang-internals/src/guppylang_internals/experimental.py
@@ -1,5 +1,6 @@
 from ast import expr
 from dataclasses import dataclass
+from types import TracebackType
 from typing import ClassVar
 
 from guppylang_internals.ast_util import AstNode
@@ -10,25 +11,52 @@ from guppylang_internals.error import GuppyError
 EXPERIMENTAL_FEATURES_ENABLED = False
 
 
-def are_experimental_features_enabled() -> bool:
-    """Whether experimental Guppy features are enabled."""
-    return EXPERIMENTAL_FEATURES_ENABLED
+class enable_experimental_features:
+    """Enables experimental Guppy features.
+
+    Can be used as a context manager to enable experimental features in a `with` block.
+    """
+
+    def __init__(self) -> None:
+        global EXPERIMENTAL_FEATURES_ENABLED
+        self.original = EXPERIMENTAL_FEATURES_ENABLED
+        EXPERIMENTAL_FEATURES_ENABLED = True
+
+    def __enter__(self) -> None:
+        pass
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        global EXPERIMENTAL_FEATURES_ENABLED
+        EXPERIMENTAL_FEATURES_ENABLED = self.original
 
 
-def enable_experimental_features() -> None:
-    """Enables experimental Guppy features."""
-    set_experimental_features_enabled(True)
+class disable_experimental_features:
+    """Disables experimental Guppy features.
 
+    Can be used as a context manager to enable experimental features in a `with` block.
+    """
 
-def disable_experimental_features() -> None:
-    """Disables experimental Guppy features."""
-    set_experimental_features_enabled(False)
+    def __init__(self) -> None:
+        global EXPERIMENTAL_FEATURES_ENABLED
+        self.original = EXPERIMENTAL_FEATURES_ENABLED
+        EXPERIMENTAL_FEATURES_ENABLED = False
 
+    def __enter__(self) -> None:
+        pass
 
-def set_experimental_features_enabled(enabled: bool) -> None:
-    """Sets whether experimental Guppy features are enabled."""
-    global EXPERIMENTAL_FEATURES_ENABLED
-    EXPERIMENTAL_FEATURES_ENABLED = enabled
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        global EXPERIMENTAL_FEATURES_ENABLED
+        EXPERIMENTAL_FEATURES_ENABLED = self.original
 
 
 @dataclass(frozen=True)

--- a/guppylang/src/guppylang/experimental.py
+++ b/guppylang/src/guppylang/experimental.py
@@ -1,13 +1,6 @@
 from guppylang_internals.experimental import (
-    are_experimental_features_enabled,
     disable_experimental_features,
     enable_experimental_features,
-    set_experimental_features_enabled,
 )
 
-__all__ = (
-    "are_experimental_features_enabled",
-    "disable_experimental_features",
-    "enable_experimental_features",
-    "set_experimental_features_enabled",
-)
+__all__ = ("disable_experimental_features", "enable_experimental_features")

--- a/tests/error/test_experimental_errors.py
+++ b/tests/error/test_experimental_errors.py
@@ -1,7 +1,7 @@
 import pathlib
 import pytest
 
-from guppylang.experimental import are_experimental_features_enabled, set_experimental_features_enabled
+from guppylang.experimental import disable_experimental_features
 from tests.error.util import run_error_test
 
 path = pathlib.Path(__file__).parent.resolve() / "experimental_errors"
@@ -17,9 +17,5 @@ files = [str(f) for f in files]
 
 @pytest.mark.parametrize("file", files)
 def test_experimental_errors(file, capsys, snapshot):
-    original = are_experimental_features_enabled()
-    set_experimental_features_enabled(False)
-
-    run_error_test(file, capsys, snapshot)
-
-    set_experimental_features_enabled(original)
+    with disable_experimental_features():
+        run_error_test(file, capsys, snapshot)


### PR DESCRIPTION
This reverts commit de0a3188653ca47c74301bfdfd8f623137ac43b2, to allow a way easier patch release of `guppylang`.

An issue will be created to reapply this update once we want to include a breaking change for `guppylang`.

BREAKING CHANGE: Revert the experimental features breaking change from the previous release.

BEGIN_COMMIT_OVERRIDE
""
END_COMMIT_OVERRIDE