### PR TITLE
docs: fix typo in API docs for CH gate definition

### DIFF
--- a/guppylang/src/guppylang/std/quantum/__init__.py
+++ b/guppylang/src/guppylang/std/quantum/__init__.py
@@ -402,7 +402,7 @@ def ch(control: qubit, target: qubit) -> None:
 
     Qubit ordering: [control, target]
 
-     .. math::
+    .. math::
         \mathrm{CH} =
           \begin{pmatrix}
             1 & 0 & 0 & 0 \\


### PR DESCRIPTION
Pointed out by an external user.

The definition is

$$
CH = |0\rangle\langle 0| \otimes I + |1 \rangle\langle 1| \otimes H
$$

as a matrix

This means that the $1/\sqrt{2}$ factor should multiply the 3rd and 4th rows rather than the entire matrix.

As a matrix

$$
          \begin{pmatrix}
            1 & 0 & 0 & 0 \\
            0 & 1 & 0 & 0 \\
            0 & 0 &  \frac{1}{\sqrt{2}} &  \frac{1}{\sqrt{2}} \\
            0 & 0 &  \frac{1}{\sqrt{2}} & -\frac{1}{\sqrt{2}}
        \end{pmatrix}
$$

See the matlab docs https://www.mathworks.com/help/matlab/ref/chgate.html