### PR TITLE
test: Fix WASM error test runner for replacing WASM paths containing newlines

### DIFF
--- a/tests/error/util.py
+++ b/tests/error/util.py
@@ -9,6 +9,7 @@ from hugr import tys
 from hugr.tys import TypeBound
 
 from guppylang_internals.decorator import custom_type
+from guppylang_internals.diagnostic import DiagnosticsRenderer, wrap
 from tests.util import get_wasm_file
 
 # Regular expression to match the `~~~~~^^^~~~` highlights that are printed in
@@ -36,7 +37,6 @@ def filter_traceback_not_containing(s: str, disallowed_regex: re.Pattern[str]) -
 
     return "\n".join(result)
 
-
 def run_error_test(file, capsys, snapshot):
     file = pathlib.Path(file)
 
@@ -53,8 +53,12 @@ def run_error_test(file, capsys, snapshot):
     sys.excepthook(exc_info.type, exc_info.value.with_traceback(tb), tb)
 
     err = capsys.readouterr().err
+    err = err.replace(str(file), "$FILE")
+    # The WASM file descriptor can stretch across multiple lines in a longer message,
+    # so we try to predict the wrapping points to be able to build a replacement regex.
     wasm_module = get_wasm_file()
-    err = err.replace(str(file), "$FILE").replace(wasm_module, "$WASM")
+    wrapped_wasm = wrap(f"`{wasm_module}`", DiagnosticsRenderer.MAX_MESSAGE_LINE_LEN)
+    err = re.sub("\n".join(wrapped_wasm), "`$WASM`", err)
     # Strip the bootstrap included in the traceback by Python 3.13+ for parallel tests
     err = filter_traceback_not_containing(err, EXECNET_BOOTSTRAP)
     # Strip the error markers that are only present for Python 3.11+


### PR DESCRIPTION
In short, local wasm file descriptors in error messages that contain too many path elements (or are just too long in general) get wrapped and thus not picked up by the replacer in the error test runner.

This is a bandaid to try and predict the wrapping of the WASM file descriptors, as I found no good way of enabling a "ignore all newlines for the sake of this" (and it might be computationally expensive to search for anyway).