### PR TITLE
chore: sync lock file

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -977,7 +977,7 @@ requires-dist = [
     { name = "tket", specifier = ">=0.12.7" },
     { name = "tket-exts", specifier = "~=0.12.0" },
     { name = "typing-extensions", specifier = ">=4.9.0,<5" },
-    { name = "wasmtime", specifier = ">=38.0,<41.1" },
+    { name = "wasmtime", specifier = ">=38.0,<42.1" },
 ]
 provides-extras = ["pytket"]
 


### PR DESCRIPTION
It looks like the `uv.lock` file managed to be out of sync, despite tests in the corresponding PR #1543 passing (some were curiously cancelled in the merge queue).

Let's fix that