### PR TITLE
docs: Change return value in enum decorator doc string

### DIFF
--- a/guppylang/src/guppylang/decorator.py
+++ b/guppylang/src/guppylang/decorator.py
@@ -263,7 +263,7 @@ class _Guppy:
                 Variant2 = {"a": int}
 
                 @guppy
-                def method_on_enum(e: MyEnum) -> int:
+                def method_on_enum(self: MyEnum) -> int:
                     return 1
         ..
         """


### PR DESCRIPTION
There was an error in the doc string since field access is not allowed on enums