### PR TITLE
refactor(guppylang-internals)!: Substitute `Branch(Note)` class in `builder.py` with `MissingBranch(Note)` in `ExpectedError` class

### DIFF
--- a/guppylang-internals/src/guppylang_internals/cfg/builder.py
+++ b/guppylang-internals/src/guppylang_internals/cfg/builder.py
@@ -25,7 +25,7 @@ from guppylang_internals.checker.errors.generic import (
     UnsupportedError,
 )
 from guppylang_internals.checker.errors.type_errors import WrongNumberOfArgsError
-from guppylang_internals.diagnostic import Error, Note
+from guppylang_internals.diagnostic import Error
 from guppylang_internals.error import GuppyError, InternalGuppyError
 from guppylang_internals.experimental import (
     check_lists_enabled,
@@ -71,14 +71,6 @@ class Jumps(NamedTuple):
 class UnreachableError(Error):
     title: ClassVar[str] = "Unreachable"
     span_label: ClassVar[str] = "This code is not reachable"
-
-
-@dataclass(frozen=True)
-class Branch(Note):
-    span_label: ClassVar[str] = (
-        "Consider adding a return statement if this expression is `{truth_value}`"
-    )
-    truth_value: bool
 
 
 class CFGBuilder(AstVisitor[BB | None]):
@@ -137,7 +129,9 @@ class CFGBuilder(AstVisitor[BB | None]):
                         # for better error reporting
                         if branch_cond is not None:
                             expr, idx = branch_cond
-                            err.add_sub_diagnostic(Branch(expr, idx == 1))
+                            err.add_sub_diagnostic(
+                                ExpectedError.MissingBranch(expr, idx == 1)
+                            )
                     raise GuppyError(err)
             self.cfg.link(final_bb, self.cfg.exit_bb)
 

--- a/guppylang-internals/src/guppylang_internals/checker/errors/generic.py
+++ b/guppylang-internals/src/guppylang_internals/checker/errors/generic.py
@@ -52,6 +52,13 @@ class ExpectedError(Error):
             "method."
         )
 
+    @dataclass(frozen=True)
+    class MissingBranch(Note):
+        span_label: ClassVar[str] = (
+            "Consider adding a return statement if this expression is `{truth_value}`"
+        )
+        truth_value: bool
+
 
 @dataclass(frozen=True)
 class UnknownModifierError(Error):


### PR DESCRIPTION
To ensure coherence with other Error classes, the note error `Branch` in `builder.py` has been moved under `ExpectedError` as `MissingBranch`. The error semantics remain the same.

BREAKING CHANGE: deleted `Branch(Note)` class in `guppylang_internals/cfg/builder.py`.
