### PR TITLE
test: Enable pow arithmetic test

### DIFF
--- a/tests/integration/tracing/test_arithmetic.py
+++ b/tests/integration/tracing/test_arithmetic.py
@@ -111,15 +111,14 @@ def test_float(validate, run_float_fn_approx):
     def div(x: float, y: float) -> float:
         return 100 / (x / (y / 2))
 
-    # TODO: Requires lowering of `ffloor` op: https://github.com/quantinuum/hugr/issues/1905
+    @guppy.comptime
+    def pow(x: float, y: float) -> float:
+        return 4 ** (x ** (y**0.5))
+
+    # TODO: Requires lowering of `ffloor` op: https://github.com/Quantinuum/hugr/issues/1707
     # @guppy.comptime
     # def floordiv(x: float, y: float) -> float:
     #     return 100 // (x // (y // 2))
-
-    # TODO: Requires lowering of `fpow` op: https://github.com/quantinuum/hugr/issues/1905
-    # @guppy.comptime
-    # def pow(x: float, y: float) -> float:
-    #     return 4 ** (x ** (y ** 0.5))
 
     run_float_fn_approx(pos, 10.5, args=[10.5])
     run_float_fn_approx(neg, -10.5, args=[10.5])
@@ -127,12 +126,10 @@ def test_float(validate, run_float_fn_approx):
     run_float_fn_approx(sub, -8.5, args=[3, -4.5])
     run_float_fn_approx(mul, -27.0, args=[3, -4.5])
     run_float_fn_approx(div, 400.0, args=[0.5, 4])
+    run_float_fn_approx(pow, 262144, args=[3, 4])
 
-    # TODO: Requires lowering of `ffloor` op: https://github.com/quantinuum/hugr/issues/1905
+    # TODO: Requires lowering of `ffloor` op: https://github.com/Quantinuum/hugr/issues/1707
     # emulate_float_fn_approx(div, ..., [...])
-
-    # TODO: Requires lowering of `fpow` op: https://github.com/quantinuum/hugr/issues/1905
-    # emulate_float_fn_approx(pow, ..., [...])
 
 
 def test_angle(validate):


### PR DESCRIPTION
The `pow` llvm intrinsic has been generated since https://github.com/Quantinuum/hugr/commit/47349480b525e02ee4eb3721320df00d7f808f76 (released in `hugr-llvm` version `0.15.3`). It has been a while, and we are pulling in new enough versions of `selene-hugr-qis-compiler` from the `tket2` repo and thus transitively the `hugr-llvm` crate. Thus, we can safely use it in tests and resolve some todos.

As a driveby, I pointed the remaining todos in the file to the updated issue containing the intrinsics collection that still needs implementation.