### PR TITLE
docs: Improve docstrings for angles.py

### DIFF
--- a/guppylang/src/guppylang/std/angles.py
+++ b/guppylang/src/guppylang/std/angles.py
@@ -16,6 +16,17 @@ from guppylang.std.builtins import py
 class angle:
     """Not an angle in the truest sense but a rotation by a number of half-turns
     (does not wrap or identify with itself modulo any number of complete turns).
+
+    The ``halfturns`` field stores the number of half-turns, and ``float()`` converts
+    to radians by multiplying by π. The built-in constant ``pi`` equals ``angle(1)``.
+
+    For example, ``angle(1/2)`` is equivalent to ``pi / 2``:
+
+    .. code-block:: python
+
+        angle(1/2) == pi / 2   # True: both represent π/2 radians (90°)
+        angle(1)   == pi       # True: both represent π radians (180°)
+        angle(2)   == angle(0) # False: a full turn is not identified with zero
     """
 
     halfturns: float

--- a/uv.lock
+++ b/uv.lock
@@ -966,7 +966,7 @@ wheels = [
 
 [[package]]
 name = "guppylang"
-version = "0.21.9"
+version = "0.21.10"
 source = { editable = "guppylang" }
 dependencies = [
     { name = "guppylang-internals" },


### PR DESCRIPTION
## Motivation:
Closes #1188

## Summary:
The `angle `class docstring previously did not explain the half-turns convention, making it easy to misinterpret what values like `angle(1/2) `mean. This PR adds clarification directly to the docstring:

## Changes:
- States explicitly that 1 half-turn = `π `radians (180°)
- Shows that `angle(1/2) `is `π/2 `radians, equivalent to `pi / 2`
- Clarifies that `angle(2)` (a full turn) is not equal to `angle(0)` — angles do not wrap
