### PR TITLE
refactor: Clarify indexing of RHS elements while checking unpacking assignments

### DIFF
--- a/guppylang-internals/src/guppylang_internals/checker/stmt_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/stmt_checker.py
@@ -282,7 +282,9 @@ class StmtChecker(AstVisitor[BBStatement]):
             assert isinstance(starred, ast.Name), "Python grammar"
             # We can use any value for `rhs` as it is ignored for variable assignments.
             unpack.pattern.starred = self._check_variable_assign(
-                starred, rhs_elts[0], array_ty
+                starred,
+                rhs_elts[0],  # ignored
+                array_ty,
             )
 
         return with_type(rhs_ty, with_loc(lhs, unpack))


### PR DESCRIPTION
This is indeed not a bug since `starred` is always an `ast.Name` when this code is encountered, and the dynamic dispatch method for `ast.Name` (`_check_variable_assign`) does not use its RHS element. I have clarified this in the code and used the dispatch method directly to make this clearer.

Closes #780