### PR TITLE
chore: add snapshot test for disallowed shadowing of extern variables

### DIFF
--- a/tests/error/errors_on_usage/shadow_extern.err
+++ b/tests/error/errors_on_usage/shadow_extern.err
@@ -1,0 +1,14 @@
+Error: Variable not defined (at $FILE:10:11)
+   | 
+ 8 |     if b:
+ 9 |         x = 4
+10 |     return x
+   |            ^ `x` might be undefined ...
+
+Note:
+   | 
+ 7 | def main(b: bool) -> int:
+ 8 |     if b:
+   |        - ... if this expression is `False`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/errors_on_usage/shadow_extern.py
+++ b/tests/error/errors_on_usage/shadow_extern.py
@@ -1,0 +1,13 @@
+from guppylang import guppy
+
+x = guppy._extern("x", ty="int")
+
+
+@guppy
+def main(b: bool) -> int:
+    if b:
+        x = 4
+    return x
+
+
+main.compile_function()

--- a/tests/integration/test_extern.py
+++ b/tests/integration/test_extern.py
@@ -1,10 +1,6 @@
-import pytest
-
 from hugr import ops, val
 
 from guppylang.decorator import guppy
-from guppylang_internals.error import GuppyError
-from guppylang_internals.checker.cfg_checker import VarMaybeNotDefinedError
 
 
 def test_extern_float(validate):
@@ -48,24 +44,3 @@ def test_extern_tuple(validate):
         return x + y
 
     validate(main.compile_function())
-
-
-# See https://github.com/quantinuum/guppylang/issues/827
-def test_extern_conditional_assign():
-    x = guppy._extern("x", ty="int")
-
-    @guppy
-    def main(b: bool) -> int:
-        if b:
-            x = 4
-        return x
-
-    with pytest.raises(
-        GuppyError,
-        check=lambda e: (
-            isinstance(e.error, VarMaybeNotDefinedError)
-            and "Variable not defined" in e.error.title
-            and "x" == e.error.var
-        ),
-    ):
-        main.compile_function()


### PR DESCRIPTION
The `tests/integration/test_extern.py::test_extern_conditional_assign` test case can now be enabled and is expected to fail.