### PR TITLE
chore: Add enum definition to exported symbols

### DIFF
--- a/guppylang/src/guppylang/defs.py
+++ b/guppylang/src/guppylang/defs.py
@@ -33,7 +33,12 @@ from guppylang.emulator.exceptions import EmulatorBuildError
 if TYPE_CHECKING:
     import ast
 
-__all__ = ("GuppyDefinition", "GuppyFunctionDefinition", "GuppyTypeVarDefinition")
+__all__ = (
+    "GuppyDefinition",
+    "GuppyEnumDefinition",
+    "GuppyFunctionDefinition",
+    "GuppyTypeVarDefinition",
+)
 
 
 P = ParamSpec("P")


### PR DESCRIPTION
Adds enum definition to the exported symbols, relieving an IDE warning about a missing public export from that module.

Is a chore, because the corresponding feature that introduced it is not released yet and thus already in the changelog.