### PR TITLE
fix: Correctly store stack frames for nested function definitions

### DIFF
--- a/guppylang-internals/src/guppylang_internals/checker/core.py
+++ b/guppylang-internals/src/guppylang_internals/checker/core.py
@@ -328,8 +328,10 @@ class Globals:
     f_locals: dict[str, Any]
     f_globals: dict[str, Any]
     f_builtins: dict[str, Any]
+    frame: FrameType | None
 
     def __init__(self, frame: FrameType | None) -> None:
+        self.frame = frame
         if frame is not None:
             self.f_locals = frame.f_locals
             self.f_globals = frame.f_globals

--- a/guppylang-internals/src/guppylang_internals/checker/func_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/func_checker.py
@@ -207,6 +207,10 @@ def check_nested_func_def(
     def_id = DefId.fresh()
     globals = ctx.globals
 
+    # Even though global, this function will be private to the built hugr,
+    # so the link name does not really matter.
+    link_name = func_def.name
+
     # Check if the body contains a free (recursive) occurrence of the function name.
     # By checking if the name is free at the entry BB, we avoid false positives when
     # a user shadows the name with a local variable
@@ -217,17 +221,16 @@ def check_nested_func_def(
 
             from guppylang_internals.definition.function import ParsedFunctionDef
 
+            parent_frame = ctx.globals.frame
             func = ParsedFunctionDef(
                 def_id,
                 func_def.name,
                 func_def,
                 func_ty,
                 None,
-                # Even though global, this function will be private to the built hugr,
-                # so the link name does not really matter.
-                link_name=func_def.name,
+                link_name,
             )
-            DEF_STORE.register_def(func, None)
+            DEF_STORE.register_def(func, parent_frame)
             ENGINE.parsed[def_id] = func
             globals.f_locals[func_def.name] = GuppyDefinition(func)
         else:
@@ -246,6 +249,18 @@ def check_nested_func_def(
         decorator_list=func_def.decorator_list,
         returns=func_def.returns,
         type_comment=func_def.type_comment,
+    )
+
+    from guppylang_internals.definition.function import CheckedFunctionDef
+
+    ENGINE.checked[def_id] = CheckedFunctionDef(
+        def_id,
+        func_def.name,
+        func_def,
+        func_ty,
+        func_def.docstring,
+        link_name,
+        checked_cfg,
     )
     return with_loc(func_def, checked_def)
 

--- a/guppylang-internals/src/guppylang_internals/compiler/core.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/core.py
@@ -182,16 +182,6 @@ class CompilerContext(ToHugrContext):
 
         Might mutate the current Hugr if this definition has never been compiled before.
         """
-        # TODO: The check below is a hack to support nested function definitions. We
-        #  forgot to insert frames for nested functions into the DEF_STORE, which would
-        #  make the call to `ENGINE.get_checked` below fail. For now, let's just short-
-        #  cut if the function doesn't take any generic params (as is the case for all
-        #  nested functions).
-        #  See https://github.com/quantinuum/guppylang/issues/1032
-        if (def_id, ()) in self.compiled:
-            assert type_args == []
-            return self.compiled[def_id, ()], type_args
-
         mono_args: PartiallyMonomorphizedArgs | None = None
         rem_args = type_args
         compile_outer: Callable[[], CompiledDef]


### PR DESCRIPTION
Fixes #1032

Gets rid of the previous hack in `CompilerContext.build_compiled_def`, by assigning a stack frame for nested function definitions and storing the checked function in the engine.

Pulled out from #1441