### PR TITLE
refactor!: Make frames mandatory and reduce usage of Globals

### DIFF
--- a/guppylang-internals/src/guppylang_internals/checker/core.py
+++ b/guppylang-internals/src/guppylang_internals/checker/core.py
@@ -12,7 +12,6 @@ from typing import (
     NamedTuple,
     TypeAlias,
     TypeVar,
-    cast,
     overload,
 )
 
@@ -25,30 +24,12 @@ from guppylang_internals.definition.common import (
     Definition,
     ParsedDef,
 )
-from guppylang_internals.definition.ty import TypeDef
-from guppylang_internals.definition.value import CallableDef
 from guppylang_internals.engine import BUILTIN_DEFS, DEF_STORE, ENGINE
 from guppylang_internals.error import InternalGuppyError
-from guppylang_internals.tys.builtin import (
-    callable_type_def,
-    float_type_def,
-    int_type_def,
-    nat_type_def,
-    none_type_def,
-    tuple_type_def,
-)
 from guppylang_internals.tys.param import Parameter
 from guppylang_internals.tys.ty import (
-    BoundTypeVar,
-    EnumType,
-    ExistentialTypeVar,
-    FunctionType,
     InputFlags,
-    NoneType,
-    NumericType,
-    OpaqueType,
     StructType,
-    TupleType,
     Type,
 )
 
@@ -319,18 +300,17 @@ class PythonObject:
 
 
 class Globals:
-    """Wrapper around the `DEF_STORE` that allows looking-up of definitions by name
-    based on which objects are in scope in a stack frame.
+    """Wrapper around a stack frame in which a Guppy definition was defined.
 
-    Additionally, keeps track of which definitions in the store have been used.
+    Gives access to the other globals that are in scope for that definition.
     """
 
     f_locals: dict[str, Any]
     f_globals: dict[str, Any]
     f_builtins: dict[str, Any]
-    frame: FrameType | None
+    frame: FrameType
 
-    def __init__(self, frame: FrameType | None) -> None:
+    def __init__(self, frame: FrameType) -> None:
         self.frame = frame
         if frame is not None:
             self.f_locals = frame.f_locals
@@ -352,50 +332,6 @@ class Globals:
             for name, val in guppylang.std.builtins.__dict__.items()
             if isinstance(val, GuppyDefinition)
         }
-
-    def get_instance_func(self, ty: Type | TypeDef, name: str) -> CallableDef | None:
-        """Looks up an instance function with a given name for a type.
-
-        Returns `None` if the name doesn't exist or isn't a function.
-        """
-        type_defn: TypeDef
-        match ty:
-            case TypeDef() as type_defn:
-                pass
-            case BoundTypeVar() | ExistentialTypeVar():
-                return None
-            case NumericType(kind):
-                match kind:
-                    case NumericType.Kind.Nat:
-                        type_defn = nat_type_def
-                    case NumericType.Kind.Int:
-                        type_defn = int_type_def
-                    case NumericType.Kind.Float:
-                        type_defn = float_type_def
-                    case kind:
-                        return assert_never(kind)
-            case FunctionType():
-                type_defn = callable_type_def
-            case OpaqueType() as ty:
-                type_defn = ty.defn
-            case StructType() as ty:
-                type_defn = ty.defn
-            case TupleType():
-                type_defn = tuple_type_def
-            case NoneType():
-                type_defn = none_type_def
-            case EnumType():
-                type_defn = ty.defn
-            case _:
-                return assert_never(ty)
-
-        type_defn = cast("TypeDef", ENGINE.get_checked(type_defn.id))
-        if type_defn.id in DEF_STORE.impls and name in DEF_STORE.impls[type_defn.id]:
-            def_id = DEF_STORE.impls[type_defn.id][name]
-            defn = ENGINE.get_parsed(def_id)
-            if isinstance(defn, CallableDef):
-                return defn
-        return None
 
     def __contains__(self, item: DefId | str) -> bool:
         match item:

--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -48,7 +48,6 @@ from guppylang_internals.checker.core import (
     Context,
     DummyEvalDict,
     FieldAccess,
-    Globals,
     Locals,
     Place,
     PythonObject,
@@ -94,6 +93,7 @@ from guppylang_internals.definition.common import Definition
 from guppylang_internals.definition.parameter import ParamDef
 from guppylang_internals.definition.ty import TypeDef
 from guppylang_internals.definition.value import CallableDef, ValueDef
+from guppylang_internals.engine import ENGINE
 from guppylang_internals.error import (
     GuppyComptimeError,
     GuppyError,
@@ -266,7 +266,7 @@ class ExprChecker(AstVisitor[tuple[ast.expr, Subst]]):
         return ExprSynthesizer(self.ctx).synthesize(node, allow_free_vars)
 
     def visit_Constant(self, node: ast.Constant, ty: Type) -> tuple[ast.expr, Subst]:
-        act = python_value_to_guppy_type(node.value, node, self.ctx.globals, ty)
+        act = python_value_to_guppy_type(node.value, node, ty)
         if act is None:
             raise GuppyError(IllegalConstant(node, type(node.value)))
         node, subst, inst = check_type_against(act, ty, node, self.ctx, self._kind)
@@ -352,7 +352,7 @@ class ExprChecker(AstVisitor[tuple[ast.expr, Subst]]):
                 TensorCall(func=node.func, args=processed_args, tensor_ty=tensor_ty),
             ), subst
 
-        elif callee := self.ctx.globals.get_instance_func(func_ty, "__call__"):
+        elif callee := ENGINE.get_instance_func(func_ty, "__call__"):
             return callee.check_call(node.args, ty, node, self.ctx)
         else:
             raise GuppyTypeError(NotCallableError(node.func, func_ty))
@@ -361,9 +361,7 @@ class ExprChecker(AstVisitor[tuple[ast.expr, Subst]]):
         self, node: ComptimeExpr, ty: Type
     ) -> tuple[ast.expr, Subst]:
         python_val = eval_comptime_expr(node, self.ctx)
-        if act := python_value_to_guppy_type(
-            python_val, node.value, self.ctx.globals, ty
-        ):
+        if act := python_value_to_guppy_type(python_val, node.value, ty):
             subst = unify(ty, act, {})
             if subst is None:
                 self._fail(ty, act, node)
@@ -412,7 +410,7 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
         return ExprChecker(self.ctx).check(expr, ty, kind)
 
     def visit_Constant(self, node: ast.Constant) -> tuple[ast.expr, Type]:
-        ty = python_value_to_guppy_type(node.value, node, self.ctx.globals)
+        ty = python_value_to_guppy_type(node.value, node)
         if ty is None:
             raise GuppyError(IllegalConstant(node, type(node.value)))
         return node, ty
@@ -500,7 +498,7 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
             case ParsedEnumDef() as defn:
                 if len(defn.variants) == 0:
                     raise GuppyError(UnexpectedError(node, "empty enum initialization"))
-                constr = self.ctx.globals.get_instance_func(
+                constr = ENGINE.get_instance_func(
                     defn, next(iter(defn.variants.keys()))
                 )
                 if constr is None:
@@ -512,7 +510,7 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
                 ), constr.ty.output
             # For types, we return their `__new__` constructor
             case TypeDef() as defn:
-                if constr := self.ctx.globals.get_instance_func(defn, "__new__"):
+                if constr := ENGINE.get_instance_func(defn, "__new__"):
                     return with_loc(
                         node, GlobalName(id=name, def_id=constr.id)
                     ), constr.ty
@@ -600,7 +598,7 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
                 # If we are accessing to a variant, we need to check that node.value is
                 # a GlobalName corresponding to the enum class definition.
                 if isinstance(node.value, GlobalName):
-                    variant_constr = self.ctx.globals.get_instance_func(ty, node.attr)
+                    variant_constr = ENGINE.get_instance_func(ty, node.attr)
                     assert variant_constr is not None, (
                         "Valid variants should be available in `ctx.globals`"
                     )
@@ -634,7 +632,7 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
         self, ty: Type, node: ast.Attribute
     ) -> tuple[PartialApply, FunctionType] | None:
         """Helper method to check if an attribute access corresponds to a method call"""
-        if func := self.ctx.globals.get_instance_func(ty, node.attr):
+        if func := ENGINE.get_instance_func(ty, node.attr):
             name = with_type(
                 func.ty, with_loc(node, GlobalName(id=func.name, def_id=func.id))
             )
@@ -703,7 +701,7 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
 
         # Check all other unary expressions by calling out to instance dunder methods
         op, display_name = unary_table[node.op.__class__]
-        func = self.ctx.globals.get_instance_func(op_ty, op)
+        func = ENGINE.get_instance_func(op_ty, op)
         if func is None:
             raise GuppyTypeError(
                 UnaryOperatorNotDefinedError(node.operand, op_ty, display_name)
@@ -724,11 +722,11 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
         left_expr, left_ty = self.synthesize(left_expr)
         right_expr, right_ty = self.synthesize(right_expr)
 
-        if func := self.ctx.globals.get_instance_func(left_ty, lop):
+        if func := ENGINE.get_instance_func(left_ty, lop):
             with suppress(GuppyError):
                 return func.synthesize_call([left_expr, right_expr], node, self.ctx)
 
-        if func := self.ctx.globals.get_instance_func(right_ty, rop):
+        if func := ENGINE.get_instance_func(right_ty, rop):
             with suppress(GuppyError):
                 return func.synthesize_call([right_expr, left_expr], node, self.ctx)
 
@@ -756,7 +754,7 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
         given expected signature.
         """
         node, ty = self.synthesize(node)
-        func = self.ctx.globals.get_instance_func(ty, func_name)
+        func = ENGINE.get_instance_func(ty, func_name)
         if func is None:
             err = BadProtocolError(node, ty, description)
             if give_reason and exp_sig is not None:
@@ -892,7 +890,7 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
                 node, TensorCall(func=node.func, args=args, tensor_ty=tensor_ty)
             ), return_ty
 
-        elif f := self.ctx.globals.get_instance_func(ty, "__call__"):
+        elif f := ENGINE.get_instance_func(ty, "__call__"):
             return f.synthesize_call(node.args, node, self.ctx)
         else:
             raise GuppyTypeError(NotCallableError(node.func, ty))
@@ -945,7 +943,7 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
 
     def visit_ComptimeExpr(self, node: ComptimeExpr) -> tuple[ast.expr, Type]:
         python_val = eval_comptime_expr(node, self.ctx)
-        if ty := python_value_to_guppy_type(python_val, node, self.ctx.globals):
+        if ty := python_value_to_guppy_type(python_val, node):
             return with_loc(node, ast.Constant(value=python_val)), ty
 
         raise GuppyError(IllegalComptimeExpressionError(node.value, type(python_val)))
@@ -1037,7 +1035,7 @@ def try_coerce_to(
         return None
     # Ordering on `NumericType.Kind` defines the coercion relation
     if act.kind < exp.kind:
-        f = ctx.globals.get_instance_func(act, f"__{exp.kind.name.lower()}__")
+        f = ENGINE.get_instance_func(act, f"__{exp.kind.name.lower()}__")
         assert f is not None
         node, subst = f.check_call([node], exp, node, ctx)
         assert len(subst) == 0, "Coercion methods are not generic"
@@ -1517,7 +1515,7 @@ def eval_comptime_expr(node: ComptimeExpr, ctx: Context) -> Any:
 
 
 def python_value_to_guppy_type(
-    v: Any, node: ast.AST, globals: Globals, type_hint: Type | None = None
+    v: Any, node: ast.AST, type_hint: Type | None = None
 ) -> Type | None:
     """Turns a primitive Python value into a Guppy type.
 
@@ -1550,7 +1548,7 @@ def python_value_to_guppy_type(
             )
             tys: list[Type] = []
             for elt, hint in zip(elts, hints, strict=False):
-                ty = python_value_to_guppy_type(elt, node, globals, hint)
+                ty = python_value_to_guppy_type(elt, node, hint)
                 if ty is None:
                     err = IllegalComptimeExpressionError(node, type(elt))
                     err.add_sub_diagnostic(
@@ -1560,7 +1558,7 @@ def python_value_to_guppy_type(
                 tys.append(ty)
             return TupleType(tys)
         case list():
-            return _python_list_to_guppy_type(v, node, globals, type_hint)
+            return _python_list_to_guppy_type(v, node, type_hint)
         case None:
             return NoneType()
         case _:
@@ -1581,7 +1579,7 @@ def _int_bounds_check(value: int, node: AstNode, signed: bool) -> None:
 
 
 def _python_list_to_guppy_type(
-    vs: list[Any], node: ast.AST, globals: Globals, type_hint: Type | None
+    vs: list[Any], node: ast.AST, type_hint: Type | None
 ) -> OpaqueType | None:
     """Turns a Python list into a Guppy type.
 
@@ -1598,13 +1596,13 @@ def _python_list_to_guppy_type(
         if type_hint and is_frozenarray_type(type_hint)
         else None
     )
-    el_ty = python_value_to_guppy_type(v, node, globals, elt_hint)
+    el_ty = python_value_to_guppy_type(v, node, elt_hint)
     if el_ty is None:
         err = IllegalComptimeExpressionError(node, type(v))
         err.add_sub_diagnostic(IllegalComptimeExpressionError.InContainer(None, list))
         raise GuppyError(err)
     for v in rest:
-        ty = python_value_to_guppy_type(v, node, globals, elt_hint)
+        ty = python_value_to_guppy_type(v, node, elt_hint)
         if ty is None:
             err = IllegalComptimeExpressionError(node, type(v))
             err.add_sub_diagnostic(

--- a/guppylang-internals/src/guppylang_internals/checker/stmt_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/stmt_checker.py
@@ -53,6 +53,7 @@ from guppylang_internals.checker.expr_checker import (
     check_place_assignable,
     synthesize_comprehension,
 )
+from guppylang_internals.engine import ENGINE
 from guppylang_internals.error import GuppyError, GuppyTypeError, InternalGuppyError
 from guppylang_internals.nodes import (
     AnyUnpack,
@@ -326,7 +327,7 @@ class StmtChecker(AstVisitor[BBStatement]):
                     )
                     raise GuppyError(err)
 
-        elif self.ctx.globals.get_instance_func(ty, "__iter__"):
+        elif ENGINE.get_instance_func(ty, "__iter__"):
             size = check_iter_unpack_has_static_size(expr, self.ctx)
             # Create a dummy variable and assign the expression to it. This helps us to
             # wire it up correctly during Hugr generation.

--- a/guppylang-internals/src/guppylang_internals/compiler/core.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/core.py
@@ -20,7 +20,6 @@ from typing_extensions import assert_never
 
 from guppylang_internals.checker.core import (
     FieldAccess,
-    Globals,
     Place,
     PlaceId,
     TupleAccess,
@@ -149,8 +148,6 @@ class CompilerContext(ToHugrContext):
     #: the purpose of monomorphization
     current_mono_args: PartiallyMonomorphizedArgs | None
 
-    checked_globals: Globals
-
     def __init__(
         self,
         module: DefinitionBuilder[ops.Module],
@@ -159,7 +156,6 @@ class CompilerContext(ToHugrContext):
         self.worklist = {}
         self.compiled = {}
         self.global_funcs = {}
-        self.checked_globals = Globals(None)
         self.current_mono_args = None
 
     @contextmanager
@@ -258,7 +254,7 @@ class CompilerContext(ToHugrContext):
         """
         from guppylang_internals.engine import ENGINE
 
-        parsed_func = self.checked_globals.get_instance_func(ty, name)
+        parsed_func = ENGINE.get_instance_func(ty, name)
         if parsed_func is None:
             return None
         checked_func = ENGINE.get_checked(parsed_func.id)

--- a/guppylang-internals/src/guppylang_internals/engine.py
+++ b/guppylang-internals/src/guppylang_internals/engine.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from types import FrameType
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import hugr
 import hugr.build.function as hf
@@ -10,7 +10,7 @@ from hugr.ext import Extension, ExtensionRegistry
 from hugr.metadata import HugrGenerator, HugrUsedExtensions
 from hugr.package import ModulePointer, Package
 from semver import Version
-from typing_extensions import deprecated
+from typing_extensions import assert_never, deprecated
 
 import guppylang_internals
 from guppylang_internals.definition.common import (
@@ -24,6 +24,7 @@ from guppylang_internals.definition.common import (
 )
 from guppylang_internals.definition.ty import TypeDef
 from guppylang_internals.definition.value import (
+    CallableDef,
     CompiledCallableDef,
     CompiledHugrNodeDef,
 )
@@ -45,7 +46,18 @@ from guppylang_internals.tys.builtin import (
     string_type_def,
     tuple_type_def,
 )
-from guppylang_internals.tys.ty import FunctionType
+from guppylang_internals.tys.ty import (
+    BoundTypeVar,
+    EnumType,
+    ExistentialTypeVar,
+    FunctionType,
+    NoneType,
+    NumericType,
+    OpaqueType,
+    StructType,
+    TupleType,
+    Type,
+)
 
 if TYPE_CHECKING:
     from guppylang_internals.compiler.core import MonoDefId
@@ -92,10 +104,9 @@ class DefinitionStore:
         self.sources = SourceMap()
         self.wasm_functions = {}
 
-    def register_def(self, defn: RawDef, frame: FrameType | None) -> None:
+    def register_def(self, defn: RawDef, frame: FrameType) -> None:
         self.raw_defs[defn.id] = defn
-        if frame:
-            self.frames[defn.id] = frame
+        self.frames[defn.id] = frame
 
     def register_impl(self, ty_id: DefId, name: str, impl_id: DefId) -> None:
         assert impl_id not in self.impl_parents, "Already an impl"
@@ -232,10 +243,54 @@ class CompilationEngine:
 
         if isinstance(defn, CheckedStructDef | CheckedEnumDef):
             for method_def in defn.generated_methods():
-                DEF_STORE.register_def(method_def, None)
+                DEF_STORE.register_def(method_def, DEF_STORE.frames[id])
                 DEF_STORE.register_impl(defn.id, method_def.name, method_def.id)
 
         return defn
+
+    def get_instance_func(self, ty: Type | TypeDef, name: str) -> CallableDef | None:
+        """Looks up an instance function with a given name for a type.
+
+        Returns `None` if the name doesn't exist or isn't a function.
+        """
+        type_defn: TypeDef
+        match ty:
+            case TypeDef() as type_defn:
+                pass
+            case BoundTypeVar() | ExistentialTypeVar():
+                return None
+            case NumericType(kind):
+                match kind:
+                    case NumericType.Kind.Nat:
+                        type_defn = nat_type_def
+                    case NumericType.Kind.Int:
+                        type_defn = int_type_def
+                    case NumericType.Kind.Float:
+                        type_defn = float_type_def
+                    case kind:
+                        return assert_never(kind)
+            case FunctionType():
+                type_defn = callable_type_def
+            case OpaqueType() as ty:
+                type_defn = ty.defn
+            case StructType() as ty:
+                type_defn = ty.defn
+            case TupleType():
+                type_defn = tuple_type_def
+            case NoneType():
+                type_defn = none_type_def
+            case EnumType():
+                type_defn = ty.defn
+            case _:
+                return assert_never(ty)
+
+        type_defn = cast("TypeDef", ENGINE.get_checked(type_defn.id))
+        if type_defn.id in DEF_STORE.impls and name in DEF_STORE.impls[type_defn.id]:
+            def_id = DEF_STORE.impls[type_defn.id][name]
+            defn = ENGINE.get_parsed(def_id)
+            if isinstance(defn, CallableDef):
+                return defn
+        return None
 
     @pretty_errors
     def check(self, id: DefId) -> None:

--- a/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
@@ -25,6 +25,7 @@ from guppylang_internals.definition.custom import (
 )
 from guppylang_internals.definition.overloaded import InternalExpectOverloadError
 from guppylang_internals.diagnostic import Error, Note
+from guppylang_internals.engine import ENGINE
 from guppylang_internals.error import GuppyError, GuppyTypeError, InternalGuppyError
 from guppylang_internals.nodes import (
     AbortExpr,
@@ -81,7 +82,7 @@ class ReversingChecker(CustomCallChecker):
     def synthesize(self, args: list[ast.expr]) -> tuple[ast.expr, Type]:
         [self_arg, other_arg] = args
         self_arg, self_ty = ExprSynthesizer(self.ctx).synthesize(self_arg)
-        f = self.ctx.globals.get_instance_func(self_ty, self.parse_name())
+        f = ENGINE.get_instance_func(self_ty, self.parse_name())
         assert f is not None
         return f.synthesize_call([other_arg, self_arg], self.node, self.ctx)
 
@@ -137,7 +138,7 @@ class CallableChecker(CustomCallChecker):
         arg, ty = ExprSynthesizer(self.ctx).synthesize(arg)
         is_callable = (
             isinstance(ty, FunctionType)
-            or self.ctx.globals.get_instance_func(ty, "__call__") is not None
+            or ENGINE.get_instance_func(ty, "__call__") is not None
         )
         const = with_loc(self.node, ast.Constant(value=is_callable))
         return const, bool_type()
@@ -453,7 +454,7 @@ def to_sized_iter(
 ) -> tuple[ast.expr, Type]:
     """Adds a static size annotation to an iterator."""
     sized_iter_ty = sized_iter_type(range_ty, size)
-    make_sized_iter = ctx.globals.get_instance_func(sized_iter_ty, "__new__")
+    make_sized_iter = ENGINE.get_instance_func(sized_iter_ty, "__new__")
     assert make_sized_iter is not None
     sized_iter, _ = make_sized_iter.check_call([iterator], sized_iter_ty, iterator, ctx)
     return sized_iter, sized_iter_ty

--- a/guppylang-internals/src/guppylang_internals/tracing/function.py
+++ b/guppylang-internals/src/guppylang_internals/tracing/function.py
@@ -7,12 +7,19 @@ from hugr.build.dfg import DfBase
 
 from guppylang_internals.ast_util import AstNode, with_loc, with_type
 from guppylang_internals.cfg.builder import tmp_vars
-from guppylang_internals.checker.core import ComptimeVariable, Context, Locals, Variable
+from guppylang_internals.checker.core import (
+    ComptimeVariable,
+    Context,
+    Globals,
+    Locals,
+    Variable,
+)
 from guppylang_internals.checker.errors.type_errors import TypeMismatchError
 from guppylang_internals.compiler.core import CompilerContext, DFContainer
 from guppylang_internals.compiler.expr_compiler import ExprCompiler
 from guppylang_internals.definition.value import CallableDef
 from guppylang_internals.diagnostic import Error
+from guppylang_internals.engine import DEF_STORE
 from guppylang_internals.error import GuppyComptimeError, GuppyError, exception_hook
 from guppylang_internals.nodes import PlaceNode
 from guppylang_internals.tracing.builtins_mock import mock_builtins
@@ -163,9 +170,8 @@ def trace_call(func: CallableDef, *args: Any) -> Any:
     arg_exprs: list[ast.expr] = [
         with_loc(state.node, with_type(var.ty, PlaceNode(var))) for var in arg_vars
     ]
-    call_node, ret_ty = func.synthesize_call(
-        arg_exprs, state.node, Context(state.globals, locals, {})
-    )
+    ctx = Context(Globals(DEF_STORE.frames[func.id]), locals, {})
+    call_node, ret_ty = func.synthesize_call(arg_exprs, state.node, ctx)
 
     # Compile call
     ret_wire = ExprCompiler(state.ctx).compile(call_node, state.dfg)

--- a/guppylang-internals/src/guppylang_internals/tracing/object.py
+++ b/guppylang-internals/src/guppylang_internals/tracing/object.py
@@ -350,7 +350,7 @@ class GuppyObject(DunderMixin):
     def __getattr__(self, key: str) -> Any:
         # Guppy objects don't have fields (structs are treated separately below), so the
         # only attributes we have to worry about are methods.
-        func = get_tracing_state().globals.get_instance_func(self._ty, key)
+        func = ENGINE.get_instance_func(self._ty, key)
         if func is None:
             raise GuppyComptimeError(
                 f"Expression of type `{self._ty}` has no attribute `{key}`"
@@ -459,7 +459,7 @@ class GuppyStructObject(DunderMixin):
         if key in self._field_values:
             return self._field_values[key]
         # Or a method
-        func = get_tracing_state().globals.get_instance_func(self._ty, key)
+        func = ENGINE.get_instance_func(self._ty, key)
         if func is None:
             err = f"Expression of struct type `{self._ty}` has no attribute `{key}`"
             raise AttributeError(err)
@@ -511,7 +511,7 @@ class GuppyEnumObject(DunderMixin):
     @hide_trace
     def __getattr__(self, key: str) -> Any:
         # We can only access methods
-        func = get_tracing_state().globals.get_instance_func(self._ty, key)
+        func = ENGINE.get_instance_func(self._ty, key)
         if func is None:
             raise GuppyComptimeError(
                 f" Expression of enum type `{self._ty}` has no method `{key}`. "
@@ -575,8 +575,7 @@ class TracingDefMixin(DunderMixin):
         # TODO: Alternatively, it could be a type application on a generic function.
         #  Supporting those requires a comptime representation of types as values
         if tracing_active():
-            state = get_tracing_state()
-            defn = state.globals[self.wrapped.id]
+            defn = ENGINE.get_checked(self.wrapped.id)
             if isinstance(defn, CallableDef) and defn.ty.parametrized:
                 raise GuppyComptimeError(
                     "Explicitly specifying type arguments of generic functions in a "

--- a/guppylang-internals/src/guppylang_internals/tracing/state.py
+++ b/guppylang-internals/src/guppylang_internals/tracing/state.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from guppylang_internals.ast_util import AstNode
-from guppylang_internals.checker.core import Globals
 from guppylang_internals.compiler.core import CompilerContext, DFContainer
 from guppylang_internals.error import InternalGuppyError
 
@@ -31,10 +30,6 @@ class TracingState:
     unused_undroppable_objs: "dict[GuppyObjectId, GuppyObject]" = field(
         default_factory=dict
     )
-
-    @property
-    def globals(self) -> Globals:
-        return self.ctx.checked_globals
 
 
 _STATE: ContextVar[TracingState | None] = ContextVar("_STATE", default=None)

--- a/guppylang-internals/src/guppylang_internals/tracing/unpacking.py
+++ b/guppylang-internals/src/guppylang_internals/tracing/unpacking.py
@@ -140,7 +140,7 @@ def guppy_object_from_py(
             # TODO: Propagate type information?
             raise GuppyComptimeError("Cannot infer the type of empty list")
         case v:
-            ty = python_value_to_guppy_type(v, node, get_tracing_state().globals)
+            ty = python_value_to_guppy_type(v, node)
             if ty is None:
                 raise GuppyError(IllegalComptimeExpressionError(node, type(v)))
             hugr_val = python_value_to_hugr(v, ty, ctx)


### PR DESCRIPTION
Some refactors around the usage of `Globals` instances, pulled out from #1441:
* Reduces uses of the `Globals` object: `get_instance_func` moved into the engine and `python_value_to_guppy_type` no longer requires globals
* Also ensures that all definition now have a corresponding frame in the `DEF_STORE`

BREAKING CHANGE: Removed `Globals.get_instance_func`. Use `ENGINE.get_instance_func` instead.
BREAKING CHANGE: Removed `TracingState.globals`
BREAKING CHANGE: Removed `CompilerContext.checked_globals`
BREAKING CHANGE: `DEF_STORE.register_def` now requires a mandatory stack frame
BREAKING CHANGE: Removed `globals` argument from `python_value_to_guppy_type`
