### PR TITLE
chore(lint): mark hugr as third party to stabilise import sorting

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -82,6 +82,9 @@ ignore = [
 "tests/{hugr,integration}/*" = ["B", "FBT", "SIM", "I"]
 "__init__.py" = ["F401"]                                              # module imported but unused
 
+[lint.isort]
+known-third-party = ["hugr"]
+
 [per-file-target-version]
 "tests/*/*_py312.py" = "py312"
 


### PR DESCRIPTION
Locally `hugr` was being picked up as a local package for me (for reasons unknown) so just mark it as known third party to avoid future mess.