### PR TITLE
chore: Add env var for enabling debug info

### DIFF
--- a/guppylang-internals/src/guppylang_internals/debug_mode.py
+++ b/guppylang-internals/src/guppylang_internals/debug_mode.py
@@ -1,7 +1,9 @@
 """Global state for determining whether to attach debug information to Hugr nodes
 during compilation."""
 
-_DEBUG_MODE_ENABLED = False
+import os
+
+_DEBUG_MODE_ENABLED = os.getenv("GUPPYLANG_FORCE_DEBUGINFO") == "1"
 
 
 def turn_on_debug_mode() -> None:


### PR DESCRIPTION
When testing debug info generation in hugr-llvm, it is useful to be able to take an arbitrary Guppy source file and compile it with debug info without modifying the file. This is somewhat difficult because typical Guppy programs drive compilation from their own source code.

I have tried to figure something out with importlib and/or runpy, but I haven't found an approach that works for all the Guppy programs I want to compile. I don't love config via env var but I think this is the cleanest way to do it.