### PR TITLE
chore(lint): Revert mark hugr as third party to stabilise import sorting

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -82,9 +82,6 @@ ignore = [
 "tests/{hugr,integration}/*" = ["B", "FBT", "SIM", "I"]
 "__init__.py" = ["F401"]                                              # module imported but unused
 
-[lint.isort]
-known-third-party = ["hugr"]
-
 [per-file-target-version]
 "tests/*/*_py312.py" = "py312"
 


### PR DESCRIPTION
This reverts commit 931c12bb9a2a84f89648ecb872ff22c335b52a86.

Solved locally by deleting vestigial `tests/hugr` directory