### PR TITLE
feat: Add array helpers for qubit measurements for qsystem measurement variants

### DIFF
--- a/guppylang/src/guppylang/std/qsystem/__init__.py
+++ b/guppylang/src/guppylang/std/qsystem/__init__.py
@@ -216,6 +216,13 @@ N = guppy.nat_var("N")
 
 @guppy
 @no_type_check
+def measure_and_reset_array(qubits: array[qubit, N]) -> array[bool, N]:
+    """Measure and reset an array of qubits, returning an array of bools."""
+    return array(measure_and_reset(qubits[i]) for i in range(N))
+
+
+@guppy
+@no_type_check
 def lazy_measure_array(qubits: array[qubit, N] @ owned) -> array["Measurement", N]:
     """Request a destructive lazy measurement of an array of qubits, returning an array
     of `Measurement` values. Call `.read()` on each value to block until results are

--- a/guppylang/src/guppylang/std/qsystem/__init__.py
+++ b/guppylang/src/guppylang/std/qsystem/__init__.py
@@ -216,6 +216,13 @@ N = guppy.nat_var("N")
 
 @guppy
 @no_type_check
+def measure_array(qubits: array[qubit, N] @ owned) -> array[bool, N]:
+    """Measure an array of qubits, returning an array of bools."""
+    return array(measure(q) for q in qubits)
+
+
+@guppy
+@no_type_check
 def measure_and_reset_array(qubits: array[qubit, N]) -> array[bool, N]:
     """Measure and reset an array of qubits, returning an array of bools."""
     return array(measure_and_reset(qubits[i]) for i in range(N))
@@ -229,6 +236,15 @@ def lazy_measure_array(qubits: array[qubit, N] @ owned) -> array["Measurement", 
     available.
     """
     return array(lazy_measure(q) for q in qubits)
+
+
+@guppy
+@no_type_check
+def lazy_measure_and_reset_array(
+    qubits: array[qubit, N],
+) -> array["Measurement", N]:
+    """Like `lazy_measure_array`, but also resets each qubit after measurement."""
+    return array(lazy_measure_and_reset(qubits[i]) for i in range(N))
 
 
 @custom_type(

--- a/guppylang/src/guppylang/std/qsystem/functional.py
+++ b/guppylang/src/guppylang/std/qsystem/functional.py
@@ -11,6 +11,7 @@ from guppylang.std import qsystem
 from guppylang.std.angles import angle
 from guppylang.std.array import array
 from guppylang.std.builtins import owned
+from guppylang.std.qsystem import Measurement
 from guppylang.std.quantum import qubit
 
 N = guppy.nat_var("N")
@@ -42,12 +43,37 @@ def measure_and_reset(q: qubit @ owned) -> tuple[qubit, bool]:
 
 @guppy
 @no_type_check
+def lazy_measure_and_reset(q: qubit @ owned) -> tuple[qubit, Measurement]:
+    """Functional lazy_measure_and_reset command."""
+    measurement = qsystem.lazy_measure_and_reset(q)
+    return q, measurement
+
+
+@guppy
+@no_type_check
+def measure_array(qubits: array[qubit, N] @ owned) -> array[bool, N]:
+    """Functional measure_array command."""
+    return qsystem.measure_array(qubits)
+
+
+@guppy
+@no_type_check
 def measure_and_reset_array(
     qubits: array[qubit, N] @ owned,
 ) -> tuple[array[qubit, N], array[bool, N]]:
     """Functional measure_and_reset_array command."""
     bs = qsystem.measure_and_reset_array(qubits)
     return qubits, bs
+
+
+@guppy
+@no_type_check
+def lazy_measure_and_reset_array(
+    qubits: array[qubit, N] @ owned,
+) -> tuple[array[qubit, N], array[Measurement, N]]:
+    """Functional lazy_measure_and_reset_array command."""
+    measurements = qsystem.lazy_measure_and_reset_array(qubits)
+    return qubits, measurements
 
 
 @guppy

--- a/guppylang/src/guppylang/std/qsystem/functional.py
+++ b/guppylang/src/guppylang/std/qsystem/functional.py
@@ -9,8 +9,11 @@ from typing import no_type_check
 from guppylang.decorator import guppy
 from guppylang.std import qsystem
 from guppylang.std.angles import angle
+from guppylang.std.array import array
 from guppylang.std.builtins import owned
 from guppylang.std.quantum import qubit
+
+N = guppy.nat_var("N")
 
 
 @guppy
@@ -35,6 +38,16 @@ def measure_and_reset(q: qubit @ owned) -> tuple[qubit, bool]:
     """Functional measure_and_reset command."""
     b = qsystem.measure_and_reset(q)
     return q, b
+
+
+@guppy
+@no_type_check
+def measure_and_reset_array(
+    qubits: array[qubit, N] @ owned,
+) -> tuple[array[qubit, N], array[bool, N]]:
+    """Functional measure_and_reset_array command."""
+    bs = qsystem.measure_and_reset_array(qubits)
+    return qubits, bs
 
 
 @guppy

--- a/tests/integration/test_qsystem.py
+++ b/tests/integration/test_qsystem.py
@@ -17,6 +17,7 @@ from guppylang.std.quantum import qubit, measure_array, x
 from guppylang.std.qsystem.functional import (
     phased_x,
     zz_phase,
+    measure_and_reset_array as measure_and_reset_array_fn,
     measure_and_reset,
     zz_max,
     reset,
@@ -170,6 +171,29 @@ def test_measure_and_reset_array(validate, run_int_fn):  # type: ignore[no-untyp
                 x(qubits[i])
 
         first = measure_and_reset_array(qubits)
+        second = measure_array(qubits)
+
+        for i in range(len(first)):
+            if int(first[i]) != pattern[i] or second[i]:
+                return 0
+        return 1
+
+    validate(test.compile_function())
+    run_int_fn(test, 1, num_qubits=NUM_QUBITS)
+
+
+def test_measure_and_reset_array_functional(validate, run_int_fn):  # type: ignore[no-untyped-def]
+    NUM_QUBITS = 5
+
+    @guppy
+    def test() -> int:
+        qubits = array(qubit() for _ in range(comptime(NUM_QUBITS)))
+        pattern = array(1, 0, 1, 1, 0)
+        for i in range(len(qubits)):
+            if pattern[i]:
+                x(qubits[i])
+
+        qubits, first = measure_and_reset_array_fn(qubits)
         second = measure_array(qubits)
 
         for i in range(len(first)):

--- a/tests/integration/test_qsystem.py
+++ b/tests/integration/test_qsystem.py
@@ -9,6 +9,7 @@ from guppylang.std.qsystem import (
     lazy_measure,
     lazy_measure_array,
     lazy_measure_and_reset,
+    measure_and_reset_array,
     measure_leaked,
 )
 from guppylang.std.qsystem.utils import get_current_shot
@@ -155,3 +156,26 @@ def test_lazy_measure_and_reset(validate, run_int_fn):  # type: ignore[no-untype
 
     validate(test.compile_function())
     run_int_fn(test, 1, num_qubits=1)
+
+
+def test_measure_and_reset_array(validate, run_int_fn):  # type: ignore[no-untyped-def]
+    NUM_QUBITS = 5
+
+    @guppy
+    def test() -> int:
+        qubits = array(qubit() for _ in range(comptime(NUM_QUBITS)))
+        pattern = array(1, 0, 1, 1, 0)
+        for i in range(len(qubits)):
+            if pattern[i]:
+                x(qubits[i])
+
+        first = measure_and_reset_array(qubits)
+        second = measure_array(qubits)
+
+        for i in range(len(first)):
+            if int(first[i]) != pattern[i] or second[i]:
+                return 0
+        return 1
+
+    validate(test.compile_function())
+    run_int_fn(test, 1, num_qubits=NUM_QUBITS)

--- a/tests/integration/test_qsystem.py
+++ b/tests/integration/test_qsystem.py
@@ -10,6 +10,7 @@ from guppylang.std.qsystem import (
     lazy_measure_array,
     lazy_measure_and_reset,
     measure_and_reset_array,
+    measure_array as qsystem_measure_array,
     measure_leaked,
 )
 from guppylang.std.qsystem.utils import get_current_shot
@@ -17,7 +18,10 @@ from guppylang.std.quantum import qubit, measure_array, x
 from guppylang.std.qsystem.functional import (
     phased_x,
     zz_phase,
+    measure_array as measure_array_fn,
     measure_and_reset_array as measure_and_reset_array_fn,
+    lazy_measure_and_reset as lazy_measure_and_reset_fn,
+    lazy_measure_and_reset_array as lazy_measure_and_reset_array_fn,
     measure_and_reset,
     zz_max,
     reset,
@@ -159,6 +163,21 @@ def test_lazy_measure_and_reset(validate, run_int_fn):  # type: ignore[no-untype
     run_int_fn(test, 1, num_qubits=1)
 
 
+def test_lazy_measure_and_reset_functional(validate, run_int_fn):  # type: ignore[no-untyped-def]
+    @guppy
+    def test() -> int:
+        q = qubit()
+        x(q)
+        q, first_result = lazy_measure_and_reset_fn(q)
+        second_result = measure(q)
+        if first_result.read() and not second_result:
+            return 1
+        return 0
+
+    validate(test.compile_function())
+    run_int_fn(test, 1, num_qubits=1)
+
+
 def test_measure_and_reset_array(validate, run_int_fn):  # type: ignore[no-untyped-def]
     NUM_QUBITS = 5
 
@@ -171,10 +190,32 @@ def test_measure_and_reset_array(validate, run_int_fn):  # type: ignore[no-untyp
                 x(qubits[i])
 
         first = measure_and_reset_array(qubits)
-        second = measure_array(qubits)
+        second = qsystem_measure_array(qubits)
 
         for i in range(len(first)):
             if int(first[i]) != pattern[i] or second[i]:
+                return 0
+        return 1
+
+    validate(test.compile_function())
+    run_int_fn(test, 1, num_qubits=NUM_QUBITS)
+
+
+def test_measure_array_functional(validate, run_int_fn):  # type: ignore[no-untyped-def]
+    NUM_QUBITS = 5
+
+    @guppy
+    def test() -> int:
+        qubits = array(qubit() for _ in range(comptime(NUM_QUBITS)))
+        pattern = array(1, 0, 1, 1, 0)
+        for i in range(len(qubits)):
+            if pattern[i]:
+                x(qubits[i])
+
+        bits = measure_array_fn(qubits)
+
+        for i in range(len(bits)):
+            if int(bits[i]) != pattern[i]:
                 return 0
         return 1
 
@@ -198,6 +239,30 @@ def test_measure_and_reset_array_functional(validate, run_int_fn):  # type: igno
 
         for i in range(len(first)):
             if int(first[i]) != pattern[i] or second[i]:
+                return 0
+        return 1
+
+    validate(test.compile_function())
+    run_int_fn(test, 1, num_qubits=NUM_QUBITS)
+
+
+def test_lazy_measure_and_reset_array_functional(validate, run_int_fn):  # type: ignore[no-untyped-def]
+    NUM_QUBITS = 5
+
+    @guppy
+    def test() -> int:
+        qubits = array(qubit() for _ in range(comptime(NUM_QUBITS)))
+        pattern = array(1, 0, 1, 1, 0)
+        for i in range(len(qubits)):
+            if pattern[i]:
+                x(qubits[i])
+
+        qubits, measurements = lazy_measure_and_reset_array_fn(qubits)
+        results = collect_measurements(measurements)
+        second = qsystem_measure_array(qubits)
+
+        for i in range(len(results)):
+            if int(results[i]) != pattern[i] or second[i]:
                 return 0
         return 1
 


### PR DESCRIPTION
Hi all, 

This PR adds measure_and_reset_array, an array helper built on top of the existing qsystem measure_and_reset operation. It mirrors measure_array, but preserves the reset semantics for each qubit.

A test prepares a non-symmetric bitstring in a register, verifies the measured bits match the pattern, and then checks that the same register reads back as all zeros afterwards.

I’ve placed this in std.qsystem to keep the qsystem-specific measurement/reset operations together, but I’d like feedback on whether this should instead live in std.quantum.




