### PR TITLE
chore: Run PR title workflow on 0.21.x series

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -3,6 +3,10 @@ on:
   pull_request_target:
     branches:
       - main
+      # Also run on the 0.21.x series. This has to be configured on the main
+      # branch since we are using `pull_request_target`, which runs in that
+      # context.
+      - guppylang-0.21
     types:
       - opened
       - edited


### PR DESCRIPTION
`pull_request_target` necessitates that changes to the workflow are made on the default branch.